### PR TITLE
add support for fallback charsets, closes #27

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -56,7 +57,13 @@ func (mc *mysqlConn) handleParams() (e error) {
 		switch param {
 		// Charset
 		case "charset":
-			e = mc.exec("SET NAMES " + val)
+			charsets := strings.Split(val, ",")
+			for _, charset := range charsets {
+				e = mc.exec("SET NAMES " + charset)
+				if e == nil {
+					break
+				}
+			}
 			if e != nil {
 				return
 			}

--- a/utils_test.go
+++ b/utils_test.go
@@ -21,6 +21,7 @@ var testDSNs = []struct {
 	{"username:password@protocol(address)/dbname?param=value", "&{user:username passwd:password net:protocol addr:address dbname:dbname params:map[param:value]}"},
 	{"user@unix(/path/to/socket)/dbname?charset=utf8", "&{user:user passwd: net:unix addr:/path/to/socket dbname:dbname params:map[charset:utf8]}"},
 	{"user:password@tcp(localhost:5555)/dbname?charset=utf8", "&{user:user passwd:password net:tcp addr:localhost:5555 dbname:dbname params:map[charset:utf8]}"},
+	{"user:password@tcp(localhost:5555)/dbname?charset=utf8mb4,utf8", "&{user:user passwd:password net:tcp addr:localhost:5555 dbname:dbname params:map[charset:utf8mb4,utf8]}"},
 	{"user:password@/dbname", "&{user:user passwd:password net:tcp addr:127.0.0.1:3306 dbname:dbname params:map[]}"},
 	{"user:p@ss(word)@tcp([de:ad:be:ef::ca:fe]:80)/dbname", "&{user:user passwd:p@ss(word) net:tcp addr:[de:ad:be:ef::ca:fe]:80 dbname:dbname params:map[]}"},
 	{"/dbname", "&{user: passwd: net:tcp addr:127.0.0.1:3306 dbname:dbname params:map[]}"},


### PR DESCRIPTION
Fallback charsets are supported in the DSN like this:

`user:password@tcp(localhost:5555)/dbname?charset=utf8mb4,utf8`

this first attempts to set the charset to `utf8mb4` and sets it to `utf8` when it fails.
