### PR TITLE
Fewer memory allocations

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -194,13 +194,14 @@ func (mc *mysqlConn) Query(query string, args []driver.Value) (driver.Rows, erro
 			var resLen int
 			resLen, err = mc.readResultSetHeaderPacket()
 			if err == nil {
-				rows := &mysqlRows{mc, false, nil, false}
+				rows := newMysqlRows()
+				rows.mc = mc
 
 				if resLen > 0 {
 					// Columns
 					rows.columns, err = mc.readColumns(resLen)
 				}
-				return rows, err
+				return &mysqlRowsI{rows}, err
 			}
 		}
 
@@ -221,7 +222,8 @@ func (mc *mysqlConn) getSystemVar(name string) (val []byte, err error) {
 		var resLen int
 		resLen, err = mc.readResultSetHeaderPacket()
 		if err == nil {
-			rows := &mysqlRows{mc, false, nil, false}
+			rows := newMysqlRows()
+			rows.mc = mc
 
 			if resLen > 0 {
 				// Columns

--- a/statement.go
+++ b/statement.go
@@ -79,7 +79,9 @@ func (stmt *mysqlStmt) Query(args []driver.Value) (driver.Rows, error) {
 		return nil, err
 	}
 
-	rows := &mysqlRows{stmt.mc, true, nil, false}
+	rows := newMysqlRows()
+	rows.mc = stmt.mc
+	rows.binary = true
 
 	if resLen > 0 {
 		// Columns
@@ -89,5 +91,5 @@ func (stmt *mysqlStmt) Query(args []driver.Value) (driver.Rows, error) {
 		}
 	}
 
-	return rows, err
+	return &mysqlRowsI{rows}, err
 }

--- a/utils.go
+++ b/utils.go
@@ -300,19 +300,6 @@ func readBool(value string) bool {
 *                       Convert from and to bytes                             *
 ******************************************************************************/
 
-func uint64ToBytes(n uint64) []byte {
-	return []byte{
-		byte(n),
-		byte(n >> 8),
-		byte(n >> 16),
-		byte(n >> 24),
-		byte(n >> 32),
-		byte(n >> 40),
-		byte(n >> 48),
-		byte(n >> 56),
-	}
-}
-
 func uint64ToString(n uint64) []byte {
 	var a [20]byte
 	i := 20


### PR DESCRIPTION
Feel free to take all or part of this.  I'll be away until Monday, at which time I can resume working on memory/CPU/contention in the MySQL driver and database/sql code.

Before: 603 B/op          24 allocs/op
After: 344 B/op       15 allocs/op

Fewer garbage collection events, since we're allocating less.

From:

``` go
package main

import (
        "database/sql"
        "sync"
        "sync/atomic"
        "testing"

        _ "github.com/go-sql-driver/mysql"
)

const concurrencyLevel = 10

type TB interface {
        Fatal(...interface{})
}

func check(tb TB, err error) {
        if err != nil {
                tb.Fatal(err)
        }
}

func initDB(tb TB) *sql.DB {
        checkRes := func(res sql.Result, err error) {
                check(tb, err)
        }
        db, err := sql.Open("mysql", "root:r@/test?charset=utf8")
        check(tb, err)
        db.SetMaxIdleConns(concurrencyLevel)
        checkRes(db.Exec("DROP TABLE IF EXISTS foo"))
        checkRes(db.Exec("CREATE TABLE foo (id INT PRIMARY KEY, val CHAR(50))"))
        checkRes(db.Exec(`INSERT INTO foo VALUES (1, "one")`))
        checkRes(db.Exec(`INSERT INTO foo VALUES (2, "two")`))
        return db
}

func BenchmarkQuery(b *testing.B) {
        b.StopTimer()
        b.ReportAllocs()
        db := initDB(b)
        defer db.Close()

        stmt, err := db.Prepare("SELECT val FROM foo WHERE id=?")
        check(b, err)
        defer stmt.Close()
        b.StartTimer()

        remain := int64(b.N)
        var wg sync.WaitGroup
        wg.Add(concurrencyLevel)
        defer wg.Wait()
        for i := 0; i < concurrencyLevel; i ++ {
                go func() {
                        defer wg.Done()
                        for {
                                if atomic.AddInt64(&remain, -1) < 0 {
                                        return
                                }
                                var got string
                                check(b, stmt.QueryRow(1).Scan(&got))
                                if got != "one" {
                                        b.Errorf("query = %q; want one", got)
                                        return
                                }
                        }
                }()
        }
}
```
