### PR TITLE
update to make Travis-CI use Go 1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
-
+go:
+  - 1.1
 before_script:
   - mysql -e 'create database gotest;'


### PR DESCRIPTION
I'm not 100% sure if I got the syntax right, but here we are...
[Tavis-CI supports Go 1.1](http://about.travis-ci.org/docs/user/languages/go/).
