### PR TITLE
ignore io.EOF error if data was fully read

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -65,6 +65,9 @@ func (b *buffer) readNext(need int) (p []byte, err error) {
 	if b.length < need {
 		// refill
 		err = b.fill(need) // err deferred
+		if err == io.EOF && b.length >= need {
+			err = nil
+		}
 	}
 
 	p = b.buf[b.idx : b.idx+need]


### PR DESCRIPTION
This should fix [Issue 108](https://github.com/go-sql-driver/mysql/issues/108).
In buffer, we pass io.EOF to the caller where it's always checked for nil.
This can cause false positive errors when the data was fully read.
[io.Reader](http://golang.org/pkg/io/#Reader) is allowed to return the number of bytes read AND io.EOF, which is not an error in our case.

I'd love to add a test for this (and for closed issues for bugs in the code in general), but I don't know how to do it without a fake packet, which seems to be a little over the top. Any ideas?
