### PR TITLE
old_passwords support

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -46,6 +46,7 @@ type config struct {
 	tls             *tls.Config
 	allowAllFiles   bool
 	clientFoundRows bool
+	oldPasswords    bool
 }
 
 // Handles parameters set in DSN

--- a/crypt323.go
+++ b/crypt323.go
@@ -1,0 +1,102 @@
+/*
+ * crypt323.go
+ *
+ * Implementation of the MySQL 323 encryption algorithm
+ *
+ * 27.08.2013, Klaus Hennemann
+ */
+
+package mysql
+
+import (
+	"math"
+)
+
+/*--------------------------------------------------------------------------*/
+/*	MySQL < 4.1 pseudo random number generator			    */
+/*--------------------------------------------------------------------------*/
+
+const seed_max = 0x3FFFFFFF
+
+type rand struct {
+	seed1 uint32
+	seed2 uint32
+}
+
+/*!
+ * Initialize the random number generator
+ */
+func newRand(seed1, seed2 uint32) *rand {
+	r := new(rand)
+	r.seed1 = seed1 % seed_max
+	r.seed2 = seed2 % seed_max
+
+	return r
+}
+
+/*!
+ * Generate one random float64 number.
+ */
+func (r *rand) Float64() float64 {
+	r.seed1 = (3*r.seed1 + r.seed2) % seed_max
+	r.seed2 = (r.seed1 + r.seed2 + 33) % seed_max
+
+	return float64(r.seed1) / float64(seed_max)
+}
+
+/*--------------------------------------------------------------------------*/
+/*	Message encryption functions					    */
+/*--------------------------------------------------------------------------*/
+
+func hash(buf []byte) (value [2]uint32) {
+	var add uint32 = 7
+
+	value[0] = 1345345333
+	value[1] = 0x12345671
+
+	for _, b := range buf {
+		/* skip spaces and tabs in password */
+		if b == ' ' || b == '\t' {
+			continue
+		}
+
+		tmp := uint32(b)
+		value[0] ^= (((value[0] & 63) + add) * tmp) + (value[0] << 8)
+		value[1] += (value[1] << 8) ^ value[0]
+		add += tmp
+	}
+
+	value[0] &= 0x7FFFFFFF
+	value[1] &= 0x7FFFFFFF
+	return
+}
+
+/*!
+ * Scramble \a message with \a password. Only the first 8
+ * bytes of \a message are scrambled.
+ */
+func Crypt323(message []byte, password []byte) []byte {
+	if len(password) <= 0 {
+		return nil
+	}
+
+	hash_msg := hash(message[:8])
+	hash_pwd := hash(password)
+
+	rand := newRand(hash_pwd[0]^hash_msg[0],
+		hash_pwd[1]^hash_msg[1])
+
+	var out [8]byte
+
+	for n := range out {
+		out[n] = byte(math.Floor(31*rand.Float64()) + 64)
+	}
+
+	mask := byte(math.Floor(31 * rand.Float64()))
+
+	for n := range out {
+		out[n] ^= mask
+	}
+
+	return out[:]
+}

--- a/driver.go
+++ b/driver.go
@@ -66,7 +66,22 @@ func (d *MySQLDriver) Open(dsn string) (driver.Conn, error) {
 	// Read Result Packet
 	err = mc.readResultOK()
 	if err != nil {
-		return nil, err
+		if !mc.cfg.oldPasswords {
+			return nil, err
+		}
+
+		// try old password method
+		err = mc.writeOldPasswordPacket()
+
+		if err != nil {
+			return nil, err
+		}
+
+		err = mc.readResultOK()
+
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Get max allowed packet size

--- a/errors.go
+++ b/errors.go
@@ -20,7 +20,7 @@ var (
 	errInvalidConn = errors.New("Invalid Connection")
 	errMalformPkt  = errors.New("Malformed Packet")
 	errNoTLS       = errors.New("TLS encryption requested but server does not support TLS")
-	errOldPassword = errors.New("It seems like you are using old_passwords, which is unsupported. See https://github.com/go-sql-driver/mysql/wiki/old_passwords")
+	errOldPassword = errors.New("It seems like you are using old_passwords. To fix this, enable parameter 'oldPasswords'.")
 	errOldProtocol = errors.New("MySQL-Server does not support required Protocol 41+")
 	errPktSync     = errors.New("Commands out of sync. You can't run this command now")
 	errPktSyncMul  = errors.New("Commands out of sync. Did you run multiple statements at once?")

--- a/utils.go
+++ b/utils.go
@@ -157,6 +157,15 @@ func parseDSN(dsn string) (cfg *config, err error) {
 						}
 					}
 
+				// Old passwords (pre MySQL 4.1)
+				case "oldPasswords":
+					var isBool bool
+					cfg.oldPasswords, isBool = readBool(value)
+					if !isBool {
+						err = fmt.Errorf("Invalid Bool value: %s", value)
+						return
+					}
+
 				default:
 					cfg.params[param[0]] = value
 				}


### PR DESCRIPTION
I received a patch by Klaus Hennemann of CBC Cologne Broadcasting Center GmbH (Mediengruppe RTL) to add support for the old (pre MySQL 4.1.1) password mechanism, which unfortunately is still used sometimes.

The initial commit is just the applied (and gofmt'ed) patch, as received.
