### PR TITLE
stmt: Cache Columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes:
   - Changed the copyright header to include all contributors
   - Optimized the buffer for reading
   - Use the buffer also for writing. This results in zero allocations (by the driver) for most queries
+  - stmt.Query now caches column metadata
   - Improved the LOAD INFILE documentation
   - The driver struct is now exported to make the driver directly accessible
   - Refactored the driver tests

--- a/connection.go
+++ b/connection.go
@@ -136,8 +136,7 @@ func (mc *mysqlConn) Prepare(query string) (driver.Stmt, error) {
 	columnCount, err := stmt.readPrepareResultPacket()
 	if err == nil {
 		if stmt.paramCount > 0 {
-			stmt.params, err = mc.readColumns(stmt.paramCount)
-			if err != nil {
+			if err = mc.readUntilEOF(); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
Saves a few allocations if a stmt is queried multiple times and therefore lowers the memory footprint
