### PR TITLE
Add Google Cloud SQL support for App Engine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,11 @@ TCP on a remote host, e.g. Amazon RDS:
 id:password@tcp(your-amazonaws-uri.com:3306)/dbname
 ```
 
+Google Cloud SQL on App Engine:
+```
+user@cloudsql(project-id:instance-name)/dbname
+```
+
 TCP using default port (3306) on localhost:
 ```
 user:password@tcp/dbname&charset=utf8mb4,utf8&sys_var=esc%40ped

--- a/appengine.go
+++ b/appengine.go
@@ -1,0 +1,25 @@
+// Go MySQL Driver - A MySQL-Driver for Go's database/sql package
+//
+// Copyright 2013 The Go-MySQL-Driver Authors. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build appengine
+
+package mysql
+
+import (
+	"appengine/cloudsql"
+	"net"
+)
+
+func init() {
+	if dials == nil {
+		dials = make(map[string]dialFunc)
+	}
+	dials["cloudsql"] = func(cfg *config) (net.Conn, error) {
+		return cloudsql.Dial(cfg.addr)
+	}
+}


### PR DESCRIPTION
It uses Cloud SQL as a database if it runs on Google App Engine with using cloudsql DSN.

`appengine.go` includes a [build constraint for GAE](http://blog.golang.org/the-app-engine-sdk-and-workspaces-gopath) to avoid an error outside App Engine.
