### PR TITLE
Replace recursive approach with iterative approach for readPacket()

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -61,9 +61,16 @@ func (mc *mysqlConn) readPacket() ([]byte, error) {
 			return nil, driver.ErrBadConn
 		}
 
+		isLastPacket := (pktLen < maxPacketSize)
+
+		// Zero allocations for non-splitting packets
+		if isLastPacket && payload == nil {
+			return data, nil
+		}
+
 		payload = append(payload, data...)
 
-		if pktLen < maxPacketSize {
+		if isLastPacket {
 			return payload, nil
 		}
 	}


### PR DESCRIPTION
Possible benefits:
- Less expensive function calls and stack space.
- Probably make it easier for compression implementation since the loop gonna work on the same buffer (uncompressed payload).
