### PR TITLE
ensure cipher memory safety

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -188,9 +188,13 @@ func (mc *mysqlConn) readInitPacket() ([]byte, error) {
 		//	return
 		//}
 		//return errMalformPkt
+		return cipher, nil
 	}
 
-	return cipher, nil
+	// make a memory safe copy of the cipher slice
+	var b [8]byte
+	copy(b[:], cipher)
+	return b[:], nil
 }
 
 // Client Authentication Packet


### PR DESCRIPTION
If no second cipher part is received, the cipher can be overwritten since it is just a slice from the net buffer
