### PR TITLE
remove deprecated long password flag

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -203,7 +203,6 @@ func (mc *mysqlConn) writeAuthPacket(cipher []byte) error {
 	// Adjust client flags based on server support
 	clientFlags := clientProtocol41 |
 		clientSecureConn |
-		clientLongPassword |
 		clientTransactions |
 		clientLocalFiles |
 		mc.flags&clientLongFlag


### PR DESCRIPTION
I compared a package capture from our driver and mymysql, this flag and multi result / multi statment were the only differences apart from the password salt.

http://dev.mysql.com/doc/internals/en/capability-flags.html says the flag is deprecated and assumed to be set since MySQL 4.1.1.

Probably fixes #184 - I asked @dsparling to try it.
