### PR TITLE
Don't try old auth method on closed conn

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -84,7 +84,7 @@ func (d *MySQLDriver) Open(dsn string) (driver.Conn, error) {
 	err = mc.readResultOK()
 	if err != nil {
 		// Retry with old authentication method, if allowed
-		if mc.cfg.allowOldPasswords && err == errOldPassword {
+		if mc.cfg != nil && mc.cfg.allowOldPasswords && err == errOldPassword {
 			if err = mc.writeOldAuthPacket(cipher); err != nil {
 				mc.Close()
 				return nil, err


### PR DESCRIPTION
If `mc.readResultOK()` on line 84 fails because of an EOF, it closes the connection and sets `mc.cfg` to nil and then line 87 panics.
