### PR TITLE
return first err in mysqlConn.Close

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -113,8 +113,12 @@ func (mc *mysqlConn) Begin() (driver.Tx, error) {
 func (mc *mysqlConn) Close() (err error) {
 	// Makes Close idempotent
 	if mc.netConn != nil {
-		mc.writeCommandPacket(comQuit)
-		mc.netConn.Close()
+		err = mc.writeCommandPacket(comQuit)
+		if err == nil {
+			err = mc.netConn.Close()
+		} else {
+			mc.netConn.Close()
+		}
 		mc.netConn = nil
 	}
 


### PR DESCRIPTION
fixes #218

Usually, `Close()` is not a problem. Recovering from it is next to impossible anyway.
Every returned error in the driver itself is replaced with `driver.ErrBadConn`, so the error is not even used in the driver (I only checked packets.go and connection.go, but still...).
In `database/sql`, the error is ignored everywhere except in a call to `finalClose`, which apparently is _never_ called.

Please check this, it's pretty weird and should probably be a golang issue:
- open [`database/sql/sql.go`](http://golang.org/src/pkg/database/sql/sql.go) (the other file, `convert.go`, is irrelevant in this regard)
- search for `driver.Conn` - it's only used in `driverConn`, field name `ci`
- search for `ci.Close()` - three usages, only one in `finalClose()` stores the error
- search for `finalClose(` - it's not exported and never called?!?

Back to the issue: `Close` isn't that important and the result is apparently never used in `database/sql`, but we export the driver which exposes the possibility to call `Close()` directly and it should still be preserved.
