### PR TITLE
Add support for microseconds, DATETIME(6)

### DIFF
--- a/const.go
+++ b/const.go
@@ -11,7 +11,7 @@ package mysql
 const (
 	minProtocolVersion byte = 10
 	maxPacketSize           = 1<<24 - 1
-	timeFormat              = "2006-01-02 15:04:05"
+	timeFormat              = "2006-01-02 15:04:05.000000"
 )
 
 // MySQL constants documentation:


### PR DESCRIPTION
MySQL 5.6.4 and up expands fractional seconds support for TIME, DATETIME, and TIMESTAMP values, with up to microseconds (6 digits) precision.
