### PR TITLE
document how notes can be ignored + test

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ Valid Values:   true, false
 Default:        false
 ```
 
-`strict=true` enables strict mode. MySQL warnings are treated as errors.
+`strict=true` enables the strict mode in which MySQL warnings are treated as errors.
+
+By default MySQL also treats notes as warnings. Use [`sql_notes=false`](http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_sql_notes) to ignore notes. See the [examples](#examples) for an DSN example.
 
 
 ##### `timeout`
@@ -232,6 +234,11 @@ root:pw@unix(/tmp/mysql.sock)/myDatabase?loc=Local
 
 ```
 user:password@tcp(localhost:5555)/dbname?tls=skip-verify&autocommit=true
+```
+
+Use the [strict mode](#strict) but ignore notes:
+```
+user:password@/dbname?strict=true&sql_notes=false
 ```
 
 TCP via IPv6:

--- a/errors_test.go
+++ b/errors_test.go
@@ -28,3 +28,9 @@ func TestSetLogger(t *testing.T) {
 		t.Errorf("expected %q, got %q", expected, actual)
 	}
 }
+
+func TestErrorsStrictIgnoreNotes(t *testing.T) {
+	runTests(t, dsn+"&sql_notes=false", func(dbt *DBTest) {
+		dbt.mustExec("DROP TABLE IF EXISTS does_not_exist")
+	})
+}


### PR DESCRIPTION
I currently don't see an efficient way how notes could be ignored by the driver in strict mode. For now configuring the server to ignore notes is the best option IMO.

fixes #235 
