### PR TITLE
Default TLS ServerName to the host in the DSN.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,3 +34,4 @@ Xiuming Chen <cc at cxm.cc>
 
 Barracuda Networks, Inc.
 Google Inc.
+Stripe Inc.

--- a/utils.go
+++ b/utils.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/url"
 	"strings"
 	"time"
@@ -244,6 +245,13 @@ func parseDSNParams(cfg *config, params string) (err error) {
 				if strings.ToLower(value) == "skip-verify" {
 					cfg.tls = &tls.Config{InsecureSkipVerify: true}
 				} else if tlsConfig, ok := tlsConfigRegister[value]; ok {
+					if len(tlsConfig.ServerName) == 0 && !tlsConfig.InsecureSkipVerify {
+						host, _, err := net.SplitHostPort(cfg.addr)
+						if err == nil {
+							tlsConfig.ServerName = host
+						}
+					}
+
 					cfg.tls = tlsConfig
 				} else {
 					return fmt.Errorf("Invalid value / unknown config name: %s", value)


### PR DESCRIPTION
A TLS configuration must either have a ServerName or specify InsecureSkipVerify. In most cases, the ServerName value will match the host part of the address in the DSN. This change updates the DSN parser to default the ServerName to the host value provided unless InsecureSkipVerify is specified.
