### PR TITLE
Added execution of multiple statement at once with two tests

### DIFF
--- a/tests/complex_statement.sql
+++ b/tests/complex_statement.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS `test` (
+	  `id` int(11),
+	  `value` int(11),
+	  PRIMARY KEY (`id`)
+	) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+
+INSERT INTO test VALUES(1,1);
+INSERT INTO test VALUES(2,1);


### PR DESCRIPTION
Hi,

I'm pretty new to Go and I've tried to do something here, please give me advice if I did something wrong. I'm also new to the GitHub workflow so if you have any advice I'll gladly take them.

I'm using a tool called migrate (https://github.com/mattes/migrate). The tools allows for database refactoring. The tool currently support MySQL in an experimental matter. One of the problem is that the migration are done reading files and as you probably know, SQL file can contains multiple statement to be executed one after the other.

There is currently no support for this feature in any MySQL (afaik) driver. I've tried something with this. It works, but I think it is far from optimal. I currently split the input on ";" and then run each query individually. I also add any affectedRows and return it with the result.

I can think of many problem with this, on the top of my head : 
- If the ";" character anywhere in a comment , or something it will break
- If an error occur with one of the statement, what happens?

I didn't spent too much time here because I want to know your opinion before going any further. I have also seen https://github.com/go-sql-driver/mysql/issues/258 but maybe we can work something out here ?

Thanks a lot, David
