### PR TITLE
Fix panic when failed to SetKeepAlive().

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,6 +19,7 @@ Frederick Mayle <frederickmayle at gmail.com>
 Gustavo Kristic <gkristic at gmail.com>
 Hanno Braun <mail at hannobraun.com>
 Henri Yandell <flamefew at gmail.com>
+INADA Naoki <songofacandy at gmail.com>
 James Harr <james.harr at gmail.com>
 Jian Zhen <zhenjl at gmail.com>
 Julien Schmidt <go-sql-driver at julienschmidt.com>

--- a/driver.go
+++ b/driver.go
@@ -72,7 +72,9 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 	// Enable TCP Keepalives on TCP connections
 	if tc, ok := mc.netConn.(*net.TCPConn); ok {
 		if err := tc.SetKeepAlive(true); err != nil {
-			mc.Close()
+			// Don't send COM_QUIT before handshake.
+			mc.netConn.Close()
+			mc.netConn = nil
 			return nil, err
 		}
 	}


### PR DESCRIPTION
When SetKeepAlive fails, panic occured because mc.Close() uses
unset mc.buf.  Since this is before handshake, we should close
socket without sending COM_QUIT.