### PR TITLE
SELECT FLOAT to float64

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -1275,6 +1275,7 @@ func TestSelectFloatToFloat64(t *testing.T) {
 		}
 	}
 
+	runTests(t, dsn, createTest("SELECT f FROM test"))
 	runTests(t, dsn, createTest("SELECT f FROM test WHERE 1=?", 1))
 	runTests(t, dsn+"&parseTime=true", createTest("SELECT IFNULL(f, 0) f FROM test"))
 	runTests(t, dsn, createTest("SELECT IFNULL(f, 0) f FROM test"))

--- a/driver_test.go
+++ b/driver_test.go
@@ -1245,6 +1245,39 @@ func TestTimezoneConversion(t *testing.T) {
 	}
 }
 
+func TestSelectFloatToFloat64(t *testing.T) {
+	createTest := func(query string, args ...interface{}) func(dbt *DBTest) {
+		return func(dbt *DBTest) {
+			v := float64(0.050551)
+
+			// Create table
+			dbt.mustExec("CREATE TABLE test (f FLOAT)")
+			dbt.mustExec("INSERT INTO test VALUE (?)", v)
+
+			// Retrieve
+			rows := dbt.mustQuery(query, args...)
+			if !rows.Next() {
+				dbt.Fatal("Didn't get any rows out")
+			}
+
+			var f float64
+			err := rows.Scan(&f)
+			if err != nil {
+				dbt.Fatal("Err", err)
+			}
+
+			// Check that dates match
+			if f != v {
+				dbt.Errorf("Float values don't match.\n")
+				dbt.Errorf(" Inserted: %v\n", v)
+				dbt.Errorf(" Selected: %v\n", f)
+			}
+		}
+	}
+
+	runTests(t, dsn, createTest("SELECT f FROM test WHERE 1=?", 1))
+}
+
 // Special cases
 
 func TestRowsClose(t *testing.T) {

--- a/driver_test.go
+++ b/driver_test.go
@@ -1275,10 +1275,15 @@ func TestSelectFloatToFloat64(t *testing.T) {
 		}
 	}
 
-	runTests(t, dsn, createTest("SELECT f FROM test"))
-	runTests(t, dsn, createTest("SELECT f FROM test WHERE 1=?", 1))
-	runTests(t, dsn+"&parseTime=true", createTest("SELECT IFNULL(f, 0) f FROM test"))
-	runTests(t, dsn, createTest("SELECT IFNULL(f, 0) f FROM test"))
+	dsns := []string{
+		dsn + "&parseTime=true",
+		dsn + "&parseTime=false",
+	}
+	for _, testdsn := range dsns {
+		runTests(t, testdsn, createTest("SELECT f FROM test"))              // not prepared statement
+		runTests(t, testdsn, createTest("SELECT f FROM test WHERE 1=?", 1)) // prepared statement
+		runTests(t, testdsn, createTest("SELECT IFNULL(f, 0) f FROM test")) // not prepared statement with IFNULL
+	}
 }
 
 // Special cases

--- a/driver_test.go
+++ b/driver_test.go
@@ -1276,6 +1276,7 @@ func TestSelectFloatToFloat64(t *testing.T) {
 	}
 
 	runTests(t, dsn, createTest("SELECT f FROM test WHERE 1=?", 1))
+	runTests(t, dsn+"&parseTime=true", createTest("SELECT IFNULL(f, 0) f FROM test"))
 }
 
 // Special cases

--- a/driver_test.go
+++ b/driver_test.go
@@ -1277,6 +1277,7 @@ func TestSelectFloatToFloat64(t *testing.T) {
 
 	runTests(t, dsn, createTest("SELECT f FROM test WHERE 1=?", 1))
 	runTests(t, dsn+"&parseTime=true", createTest("SELECT IFNULL(f, 0) f FROM test"))
+	runTests(t, dsn, createTest("SELECT IFNULL(f, 0) f FROM test"))
 }
 
 // Special cases

--- a/packets.go
+++ b/packets.go
@@ -617,28 +617,31 @@ func (rows *textRows) readRow(dest []driver.Value) error {
 		pos += n
 		if err == nil {
 			if !isNull {
-				if !mc.parseTime {
+				// @todo hacky fix, please make it better
+				if i > len(rows.columns)-1 {
 					continue
-				} else {
-					switch rows.columns[i].fieldType {
-					case fieldTypeTimestamp, fieldTypeDateTime,
-						fieldTypeDate, fieldTypeNewDate:
-						dest[i], err = parseDateTime(
-							string(dest[i].([]byte)),
-							mc.cfg.loc,
-						)
-						if err == nil {
-							continue
-						}
-					case fieldTypeFloat:
-						val, err := strconv.ParseFloat(string(dest[i].([]byte)), 32)
-						dest[i] = float32(val)
-						if err == nil {
-							continue
-						}
-					default:
+				}
+				switch rows.columns[i].fieldType {
+				case fieldTypeTimestamp, fieldTypeDateTime,
+					fieldTypeDate, fieldTypeNewDate:
+					if !mc.parseTime {
 						continue
 					}
+					dest[i], err = parseDateTime(
+						string(dest[i].([]byte)),
+						mc.cfg.loc,
+					)
+					if err == nil {
+						continue
+					}
+				case fieldTypeFloat:
+					val, err := strconv.ParseFloat(string(dest[i].([]byte)), 32)
+					dest[i] = float32(val)
+					if err == nil {
+						continue
+					}
+				default:
+					continue
 				}
 
 			} else {

--- a/packets.go
+++ b/packets.go
@@ -1037,7 +1037,7 @@ func (rows *binaryRows) readRow(dest []driver.Value) error {
 			continue
 
 		case fieldTypeFloat:
-			dest[i] = float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos : pos+4])))
+			dest[i] = float32(math.Float32frombits(binary.LittleEndian.Uint32(data[pos : pos+4])))
 			pos += 4
 			continue
 

--- a/packets.go
+++ b/packets.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"strconv"
 	"time"
 )
 
@@ -626,6 +627,12 @@ func (rows *textRows) readRow(dest []driver.Value) error {
 							string(dest[i].([]byte)),
 							mc.cfg.loc,
 						)
+						if err == nil {
+							continue
+						}
+					case fieldTypeFloat:
+						val, err := strconv.ParseFloat(string(dest[i].([]byte)), 32)
+						dest[i] = float32(val)
 						if err == nil {
 							continue
 						}

--- a/packets.go
+++ b/packets.go
@@ -1047,7 +1047,7 @@ func (rows *binaryRows) readRow(dest []driver.Value) error {
 			continue
 
 		case fieldTypeFloat:
-			dest[i] = float32(math.Float32frombits(binary.LittleEndian.Uint32(data[pos : pos+4])))
+			dest[i] = math.Float32frombits(binary.LittleEndian.Uint32(data[pos : pos+4]))
 			pos += 4
 			continue
 


### PR DESCRIPTION
Hi all,

While I was trying out https://github.com/go-sql-driver/mysql/pull/297 I discovered some of tests in internal project started to fail when emulated queries were used instead of prepared statements.
I checked query log with `substitutePlaceholder=true` and `substitutePlaceholder=false`. All queries were identical, didn't matter if they were prepared by MySQL or by driver (tests run 2000+ queries) - so https://github.com/go-sql-driver/mysql/pull/297 was 100% correct!

So I investigated further... Tests were failing at some floats where expected value was e.g. `0.050551000982522964` but with `substitutePlaceholder=true` I got `0.050551`. I checked data, and actually correct value was `0.050551`. So actually turning  `substitutePlaceholder=true` on provided correct data.

I found out that in some cases switching from MySQL prepared statements to driver prepared statements changed the way how data was parsed by driver. With `substitutePlaceholder=false` data was parsed by `func (rows *binaryRows) readRow` (https://github.com/go-sql-driver/mysql/blob/master/packets.go#L962) while switching to `substitutePlaceholder=true` changed the behavior and data got parsed by `func (rows *textRows) readRow` (https://github.com/go-sql-driver/mysql/blob/master/packets.go#L595). After some investigation I came to conclusion that currently selecting FLOAT to float64 is incorrectly handled. I've attached failing test cases with fixes. With one fix I'm not happy - it's an ugly hack because I couldn't figure out what's going on here: https://github.com/go-sql-driver/mysql/blob/master/packets.go#L619 I couldn't figure out when `rows.columns` is filled with data... I wanted simply to check for `rows.columns[i].fieldType` but it looks like it doesn't always have data and so it was throwing panics... I've added dirty hack `if i > len(rows.columns)-1 { continue }` and it works but I bet there is a better way to handle that ;)

Summary:
"CREATE TABLE test (f FLOAT)"
"INSERT INTO test VALUE (0.050551)"
* "SELECT f FROM test", always worked correctly (actually this still confuses me, why this worked?) 
* "SELECT f FROM test WHERE 1=?", required fix in `(rows *binaryRows) readRow`
* "SELECT NULL(f, 0) f FROM test", required fix in `(rows *textRows) readRow` (why this is different than first example?)