### PR TITLE
Added support for multi-statements.

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -214,6 +214,7 @@ func (mc *mysqlConn) writeAuthPacket(cipher []byte) error {
 		clientLongPassword |
 		clientTransactions |
 		clientLocalFiles |
+		clientMultiStatements |
 		mc.flags&clientLongFlag
 
 	if mc.cfg.clientFoundRows {


### PR DESCRIPTION
Added support for multi-statements to execute multiple statements in one go. This is especially useful to create whole schemas from a single database dump generated from `mysqldump`.