### PR TITLE
Use mc.buf as scratchpad for intarpolation

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -222,6 +222,7 @@ func BenchmarkInterpolation(b *testing.B) {
 		},
 		maxPacketAllowed: maxPacketSize,
 		maxWriteSize:     maxPacketSize - 1,
+		buf:              newBuffer(nil),
 	}
 
 	args := []driver.Value{


### PR DESCRIPTION
```
benchmark                  old ns/op     new ns/op     delta
BenchmarkInterpolation     1900          1403          -26.16%

benchmark                  old allocs     new allocs     delta
BenchmarkInterpolation     2              1              -50.00%

benchmark                  old bytes     new bytes     delta
BenchmarkInterpolation     448           160           -64.29%
```