### PR TITLE
new parse timer flag invalidTimeAsZero

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -30,6 +30,7 @@ type mysqlConn struct {
 	status           statusFlag
 	sequence         uint8
 	parseTime        bool
+	invalidTimeAsZero bool
 	strict           bool
 }
 
@@ -73,6 +74,14 @@ func (mc *mysqlConn) handleParams() (err error) {
 		case "parseTime":
 			var isBool bool
 			mc.parseTime, isBool = readBool(val)
+			if !isBool {
+				return errors.New("Invalid Bool value: " + val)
+			}
+
+		// time.Time parsing
+		case "invalidTimeAsZero":
+			var isBool bool
+			mc.invalidTimeAsZero, isBool = readBool(val)
 			if !isBool {
 				return errors.New("Invalid Bool value: " + val)
 			}

--- a/connection.go
+++ b/connection.go
@@ -19,19 +19,19 @@ import (
 )
 
 type mysqlConn struct {
-	buf              buffer
-	netConn          net.Conn
-	affectedRows     uint64
-	insertId         uint64
-	cfg              *config
-	maxPacketAllowed int
-	maxWriteSize     int
-	flags            clientFlag
-	status           statusFlag
-	sequence         uint8
-	parseTime        bool
+	buf               buffer
+	netConn           net.Conn
+	affectedRows      uint64
+	insertId          uint64
+	cfg               *config
+	maxPacketAllowed  int
+	maxWriteSize      int
+	flags             clientFlag
+	status            statusFlag
+	sequence          uint8
+	parseTime         bool
 	invalidTimeAsZero bool
-	strict           bool
+	strict            bool
 }
 
 type config struct {

--- a/packets.go
+++ b/packets.go
@@ -632,6 +632,10 @@ func (rows *textRows) readRow(dest []driver.Value) error {
 							string(dest[i].([]byte)),
 							mc.cfg.loc,
 						)
+						if mc.invalidTimeAsZero {
+							dest[i] = time.Time{}
+							err = nil
+						}
 						if err == nil {
 							continue
 						}

--- a/packets.go
+++ b/packets.go
@@ -632,10 +632,16 @@ func (rows *textRows) readRow(dest []driver.Value) error {
 							string(dest[i].([]byte)),
 							mc.cfg.loc,
 						)
-						if mc.invalidTimeAsZero {
-							dest[i] = time.Time{}
-							err = nil
+
+						if err != nil && mc.invalidTimeAsZero {
+							//in some mysql configurations - possible to store dates in not valid format,
+							//so we just will interpretate them as zero-date
+							if _, ok := err.(*time.ParseError); ok {
+								dest[i] = time.Time{}
+								err = nil
+							}
 						}
+
 						if err == nil {
 							continue
 						}


### PR DESCRIPTION
Current behavior of driver is: 
if parseTime == true, then we try to parse date and if can't return error. 
In our case invalid date is not error, it's not critical error, just replace invalid date by zero date time.Time{} is ok for us. 
So, i would like to add new flag which will configure this behavior.
