### PR TITLE
Add initial support for connection attributes.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Aaron Hopkins <go-sql-driver at die.net>
 Arne Hormann <arnehormann at gmail.com>
 Carlos Nieto <jose.carlos at menteslibres.net>
 Chris Moos <chris at tech9computers.com>
+Daniël van Eeden <daniel.van.eeden at myname.nl>
 DisposaBoy <disposaboy at dby.me>
 Frederick Mayle <frederickmayle at gmail.com>
 Gustavo Kristic <gkristic at gmail.com>


### PR DESCRIPTION
This sets attribute _client_name with the value "Go MySQL Driver"

Here processlist_id=58 is the connection from the Go MySQL Driver.
```
mysql> select * from performance_schema.session_connect_attrs; show processlist;
+----------------+-----------------+------------------+------------------+
| PROCESSLIST_ID | ATTR_NAME       | ATTR_VALUE       | ORDINAL_POSITION |
+----------------+-----------------+------------------+------------------+
|              3 | _os             | Linux            |                0 |
|              3 | _client_name    | libmysql         |                1 |
|              3 | _pid            | 3891             |                2 |
|              3 | _client_version | 5.7.7-rc         |                3 |
|              3 | _platform       | x86_64           |                4 |
|              3 | program_name    | Slave I/O Thread |                5 |
|              3 | channel_name    | NULL             |                6 |
|              6 | _os             | Linux            |                0 |
|              6 | _client_name    | libmysql         |                1 |
|              6 | _pid            | 3618             |                2 |
|              6 | _client_version | 5.7.7-rc         |                3 |
|              6 | _platform       | x86_64           |                4 |
|              6 | program_name    | Slave I/O Thread |                5 |
|              6 | channel_name    | testc1           |                6 |
|             58 | _client_name    | Go MySQL Driver  |                0 |
|             59 | _os             | Linux            |                0 |
|             59 | _client_name    | libmysql         |                1 |
|             59 | _pid            | 14429            |                2 |
|             59 | _client_version | 5.7.7-rc         |                3 |
|             59 | _platform       | x86_64           |                4 |
|             59 | program_name    | mysql            |                5 |
+----------------+-----------------+------------------+------------------+
21 rows in set (0.00 sec)
```

This could later be extended to:
* Send more information 
 * _os
 * _client_version
 * _pid
 * _platform
 * program_name
* Send custom information
 * e.g. Key/Value pairs

The attributes send by the C library use _<name> and the application using the C library usually sets program_name to $0

