### PR TITLE
Add clientPluginAuth (CLIENT_PLUGIN_AUTH) for authentication handshake

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -214,6 +214,7 @@ func (mc *mysqlConn) writeAuthPacket(cipher []byte) error {
 		clientLongPassword |
 		clientTransactions |
 		clientLocalFiles |
+		clientPluginAuth |
 		mc.flags&clientLongFlag
 
 	if mc.cfg.clientFoundRows {


### PR DESCRIPTION
This flag is necessary for successful login via auth_socket.so plugin (https://dev.mysql.com/doc/mysql-security-excerpt/5.5/en/socket-authentication-plugin.html)

Fixes #330