### PR TITLE
Add support for connection attributes.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Aaron Hopkins <go-sql-driver at die.net>
 Arne Hormann <arnehormann at gmail.com>
 Carlos Nieto <jose.carlos at menteslibres.net>
 Chris Moos <chris at tech9computers.com>
+Daniël van Eeden <daniel.van.eeden at myname.nl>
 DisposaBoy <disposaboy at dby.me>
 Frederick Mayle <frederickmayle at gmail.com>
 Gustavo Kristic <gkristic at gmail.com>

--- a/driver.go
+++ b/driver.go
@@ -20,6 +20,8 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"net"
+        "os"
+        "strconv"
 )
 
 // This struct is exported to make the driver directly accessible.
@@ -29,6 +31,8 @@ type MySQLDriver struct{}
 // DialFunc is a function which can be used to establish the network connection.
 // Custom dial functions must be registered with RegisterDial
 type DialFunc func(addr string) (net.Conn, error)
+
+var pid string
 
 var dials map[string]DialFunc
 
@@ -145,5 +149,6 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 }
 
 func init() {
+	pid = strconv.Itoa(os.Getpid())
 	sql.Register("mysql", &MySQLDriver{})
 }


### PR DESCRIPTION
This sets attribute _client_name with the value "Go MySQL Driver"
Also sets _os, _platform, _pid and program_name by default.

This supersedes #333 