### PR TITLE
Fix number reads bytes for mysql 5.6

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Runrioter Wung <runrioter at gmail.com>
 Soroush Pour <me at soroushjp.com>
 Xiaobing Jiang <s7v7nislands at gmail.com>
 Xiuming Chen <cc at cxm.cc>
+Stan Putrya <root.vagner at gmail.com>
 
 # Organizations
 

--- a/utils.go
+++ b/utils.go
@@ -777,6 +777,9 @@ func skipLengthEncodedString(b []byte) (int, error) {
 
 // returns the number read, whether the value is NULL and the number of bytes read
 func readLengthEncodedInteger(b []byte) (uint64, bool, int) {
+	if len(b) == 0 {
+		return 0, true, 1
+	}
 	switch b[0] {
 
 	// 251: NULL

--- a/utils.go
+++ b/utils.go
@@ -777,6 +777,7 @@ func skipLengthEncodedString(b []byte) (int, error) {
 
 // returns the number read, whether the value is NULL and the number of bytes read
 func readLengthEncodedInteger(b []byte) (uint64, bool, int) {
+	// See issue #349
 	if len(b) == 0 {
 		return 0, true, 1
 	}


### PR DESCRIPTION
There is fix situation then mysql return 0 bytes for NULL column. This situation can be called with run statement "show slave hosts" at mysql 5.6 with slave mysql 5.5. In this case we got panic: out of range