### PR TITLE
Travis: test with MariaDB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,20 @@ go:
   - 1.2
   - 1.3
   - 1.4
+  - 1.5
   - tip
 
+matrix:
+  include:
+    - go: 1.5
+      addons:
+         mariadb: 5.5
+    - go: 1.5
+      addons:
+         mariadb: "10.0"
+    - go: 1.5
+      addons:
+         mariadb: 10.1
+
 before_script:
-  - mysql -e 'create database gotest;'
+  - mysql -e "create database /*M!50701 IF NOT EXISTS */ gotest;"

--- a/driver_test.go
+++ b/driver_test.go
@@ -833,8 +833,8 @@ func TestLongData(t *testing.T) {
 		maxAllowedPacketSize--
 
 		// don't get too ambitious
-		if maxAllowedPacketSize > 1<<25 {
-			maxAllowedPacketSize = 1 << 25
+		if maxAllowedPacketSize > 1<<23 {
+			maxAllowedPacketSize = 1 << 23
 		}
 
 		dbt.mustExec("CREATE TABLE test (value LONGBLOB)")


### PR DESCRIPTION
I this added tests for go-1.5 and mariadb.

Unfortunately the default config of 10.0/10.1 is causing failing tests (https://travis-ci.org/grooverdan/mysql-1/builds/76959693) so I needed to lower  1<<25 limit to 1<<23 (24 was still too high).
