### PR TITLE
Actually zero out the bytes in the HandshakeResponse320

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -282,7 +282,10 @@ func (mc *mysqlConn) writeAuthPacket(cipher []byte) error {
 	}
 
 	// Filler [23 bytes] (all 0x00)
-	pos := 13 + 23
+	pos := 13
+	for ; pos < 13+23; pos++ {
+		data[pos] = 0
+	}
 
 	// User [null terminated string]
 	if len(mc.cfg.user) > 0 {


### PR DESCRIPTION
:
The specification says these bytes should be zero but the
current implementation simply ignores them. Since
takeSmallBuffer ends up reusing a buffer for this packet the
values might not be all zeros.