### PR TITLE
Fix tests with MySQL 5.7.9

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -1018,7 +1018,7 @@ func TestFoundRows(t *testing.T) {
 
 func TestStrict(t *testing.T) {
 	// ALLOW_INVALID_DATES to get rid of stricter modes - we want to test for warnings, not errors
-	relaxedDsn := dsn + "&sql_mode=ALLOW_INVALID_DATES"
+	relaxedDsn := dsn + "&sql_mode='ALLOW_INVALID_DATES,NO_AUTO_CREATE_USER'"
 	// make sure the MySQL version is recent enough with a separate connection
 	// before running the test
 	conn, err := MySQLDriver{}.Open(relaxedDsn)
@@ -1643,7 +1643,7 @@ func TestSqlInjection(t *testing.T) {
 
 	dsns := []string{
 		dsn,
-		dsn + "&sql_mode=NO_BACKSLASH_ESCAPES",
+		dsn + "&sql_mode='NO_BACKSLASH_ESCAPES,NO_AUTO_CREATE_USER'",
 	}
 	for _, testdsn := range dsns {
 		runTests(t, testdsn, createTest("1 OR 1=1"))
@@ -1673,7 +1673,7 @@ func TestInsertRetrieveEscapedData(t *testing.T) {
 
 	dsns := []string{
 		dsn,
-		dsn + "&sql_mode=NO_BACKSLASH_ESCAPES",
+		dsn + "&sql_mode='NO_BACKSLASH_ESCAPES,NO_AUTO_CREATE_USER'",
 	}
 	for _, testdsn := range dsns {
 		runTests(t, testdsn, testData)


### PR DESCRIPTION
From [MySQL's reference manual](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html):

> NO_AUTO_CREATE_USER will be removed in a future MySQL release, at which point its effect will be enabled at all times (GRANT will not create accounts). 

This pull request makes all tests pass against MySQL 5.7.9.

I was getting the following error before the changes:

```bash
luiz@asus:~/Code/Go/src/github.com/refl/mysql$ go test github.com/refl/mysql
--- FAIL: TestStrict (0.02s)
    driver_test.go:116: Error on Exec CREATE TABLE test (a TINYINT NOT NULL, b CHAR(4)): Warning 3090: Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
--- FAIL: TestSqlInjection (2.30s)
    driver_test.go:116: Error on Exec CREATE TABLE test (v INTEGER): Warning 3090: Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
--- FAIL: TestInsertRetrieveEscapedData (1.71s)
    driver_test.go:116: Error on Exec CREATE TABLE test (v VARCHAR(255)): Warning 3090: Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
FAIL
FAIL    github.com/refl/mysql    43.664s
```