### PR TITLE
Add _binary prefix when interpolating []byte data.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Frederick Mayle <frederickmayle at gmail.com>
 Gustavo Kristic <gkristic at gmail.com>
 Hanno Braun <mail at hannobraun.com>
 Henri Yandell <flamefew at gmail.com>
+Hirotaka Yamamoto <ymmt2005 at gmail.com>
 INADA Naoki <songofacandy at gmail.com>
 James Harr <james.harr at gmail.com>
 Jian Zhen <zhenjl at gmail.com>

--- a/connection.go
+++ b/connection.go
@@ -253,7 +253,7 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 			if v == nil {
 				buf = append(buf, "NULL"...)
 			} else {
-				buf = append(buf, '\'')
+				buf = append(buf, "_binary'"...)
 				if mc.status&statusNoBackslashEscapes == 0 {
 					buf = escapeBytesBackslash(buf, v)
 				} else {


### PR DESCRIPTION
This PR is a revise of #381.

Since 5.6.27, mysql server produces a warning if string literals cannot
be interpreted in a given character set (see Bug #20238729).
As a consequence, the driver may fail to insert []byte data into
BLOB columns when interpolateParams is true in strict SQL mode.

This commit adds "_binary" encoding prefix when interpolating []byte data
to avoid that warning.

http://dev.mysql.com/doc/refman/5.7/en/charset-literal.html