### PR TITLE
QueryUnescape the tlsConfig name during DSN parsing.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,6 +26,7 @@ Jian Zhen <zhenjl at gmail.com>
 Joshua Prunier <joshua.prunier at gmail.com>
 Julien Schmidt <go-sql-driver at julienschmidt.com>
 Kamil Dziedzic <kamil at klecza.pl>
+Kevin Malachowski <kevin at chowski.com>
 Leonardo YongUk Kim <dalinaum at gmail.com>
 Lucas Liu <extrafliu at gmail.com>
 Luke Scott <luke at webconnex.com>

--- a/utils.go
+++ b/utils.go
@@ -267,6 +267,8 @@ func parseDSNParams(cfg *config, params string) (err error) {
 				if boolValue {
 					cfg.tls = &tls.Config{}
 				}
+			} else if value, err := url.QueryUnescape(value); err != nil {
+				return fmt.Errorf("Invalid value for tls config name: %v", err)
 			} else {
 				if strings.ToLower(value) == "skip-verify" {
 					cfg.tls = &tls.Config{InsecureSkipVerify: true}

--- a/utils_test.go
+++ b/utils_test.go
@@ -13,6 +13,7 @@ import (
 	"crypto/tls"
 	"encoding/binary"
 	"fmt"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -114,6 +115,23 @@ func TestDSNWithCustomTLS(t *testing.T) {
 	}
 
 	DeregisterTLSConfig("utils_test")
+}
+
+func TestDSNWithCustomTLS_queryEscape(t *testing.T) {
+	const configKey = "&%!:"
+	dsn := "user:password@tcp(localhost:5555)/dbname?tls=" + url.QueryEscape(configKey)
+	name := "foohost"
+	tlsCfg := tls.Config{ServerName: name}
+
+	RegisterTLSConfig(configKey, &tlsCfg)
+
+	cfg, err := parseDSN(dsn)
+
+	if err != nil {
+		t.Error(err.Error())
+	} else if cfg.tls.ServerName != name {
+		t.Errorf("Did not get the correct TLS ServerName (%s) parsing DSN (%s).", name, dsn)
+	}
 }
 
 func TestDSNUnsafeCollation(t *testing.T) {


### PR DESCRIPTION
Also add unit test.

Before this change, calling RegisterTLSConfig with a key that is invalid in a URL doesn't work. This change fixes the issue by unescaping the TLS config name during DSN parsing.