### PR TITLE
LOAD LOCAL can send file larger than max_allowed_packet

### DIFF
--- a/infile.go
+++ b/infile.go
@@ -96,6 +96,10 @@ func deferredClose(err *error, closer io.Closer) {
 func (mc *mysqlConn) handleInFileRequest(name string) (err error) {
 	var rdr io.Reader
 	var data []byte
+	packetSize := 16 * 1024 // 16KB is small enough for disk readahead and large enough for TCP
+	if mc.maxWriteSize < packetSize {
+		packetSize = mc.maxWriteSize
+	}
 
 	if idx := strings.Index(name, "Reader::"); idx == 0 || (idx > 0 && name[idx-1] == '/') { // io.Reader
 		// The server might return an an absolute path. See issue #355.
@@ -108,8 +112,6 @@ func (mc *mysqlConn) handleInFileRequest(name string) (err error) {
 		if inMap {
 			rdr = handler()
 			if rdr != nil {
-				data = make([]byte, 4+mc.maxWriteSize)
-
 				if cl, ok := rdr.(io.Closer); ok {
 					defer deferredClose(&err, cl)
 				}
@@ -134,12 +136,8 @@ func (mc *mysqlConn) handleInFileRequest(name string) (err error) {
 				// get file size
 				if fi, err = file.Stat(); err == nil {
 					rdr = file
-					if fileSize := int(fi.Size()); fileSize <= mc.maxWriteSize {
-						data = make([]byte, 4+fileSize)
-					} else if fileSize <= mc.maxPacketAllowed {
-						data = make([]byte, 4+mc.maxWriteSize)
-					} else {
-						err = fmt.Errorf("local file '%s' too large: size: %d, max: %d", name, fileSize, mc.maxPacketAllowed)
+					if fileSize := int(fi.Size()); fileSize < packetSize {
+						packetSize = fileSize
 					}
 				}
 			}
@@ -150,6 +148,7 @@ func (mc *mysqlConn) handleInFileRequest(name string) (err error) {
 
 	// send content packets
 	if err == nil {
+		data := make([]byte, 4+packetSize)
 		var n int
 		for err == nil {
 			n, err = rdr.Read(data[4:])


### PR DESCRIPTION
### Description
"LOAD LOCAL INFILE" query can send file larger than `max_allowed_packet`.  But go-sql-driver/mysql returns error when file is large.

http://dba.stackexchange.com/questions/13160/does-the-max-allowed-packet-variable-have-any-effect-on-load-local-infile

Additionally, some user set `max_allowed_packet` very large (e.g. 1GB).
Since max size of MySQL packet is 16MB, using it for buffer size is not good.
Typical readahead buffer size of Linux is 128KB.  So large buffer size may cause performance penalty. (#364).
I choose 16KB for buffer size (default of `net_buffer_length`, http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_net_buffer_length).

### Checklist
- [x] Code compiles correctly
- [x] Created tests, if possible
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file