### PR TITLE
document multiStatement parameter restriction, fixes #426

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ Default:        false
 
 Allow multiple statements in one query. While this allows batch queries, it also greatly increases the risk of SQL injections. Only the result of the first query is returned, all other results are silently discarded.
 
+When `multiStatements` is used, `?` parameters must only be used in the first statement.
+
 
 ##### `parseTime`
 


### PR DESCRIPTION
### Description
Document that for `multiStatement`, all parameters have to belong to the very first statement. Fixes #426.

### Checklist
- [X] Code compiles correctly
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing
- [X] Extended the README / documentation, if necessary
- [X] Added myself / the copyright holder to the AUTHORS file

