### PR TITLE
Fix error reported by `go vet`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ Arne Hormann <arnehormann at gmail.com>
 Carlos Nieto <jose.carlos at menteslibres.net>
 Chris Moos <chris at tech9computers.com>
 Daniel Nichter <nil at codenode.com>
+Daniël van Eeden <git at myname.nl>
 DisposaBoy <disposaboy at dby.me>
 Frederick Mayle <frederickmayle at gmail.com>
 Gustavo Kristic <gkristic at gmail.com>

--- a/driver_test.go
+++ b/driver_test.go
@@ -305,7 +305,7 @@ func TestMultiQuery(t *testing.T) {
 		if rows.Next() {
 			rows.Scan(&out)
 			if 5 != out {
-				dbt.Errorf("5 != %t", out)
+				dbt.Errorf("5 != %d", out)
 			}
 
 			if rows.Next() {


### PR DESCRIPTION
### Description
Fix error reported by `go vet`

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file

```
$ go vet
driver_test.go:308: arg out for printf verb %t of wrong type: int
exit status 1
```