### PR TITLE
Add support for 'traceQueries' DSN configuration parameter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Daniël van Eeden <git at myname.nl>
 DisposaBoy <disposaboy at dby.me>
 Egor Smolyakov <egorsmkv at gmail.com>
 Frederick Mayle <frederickmayle at gmail.com>
+Giuseppe Mazzotta <gdm85@users.noreply.github.com>
 Gustavo Kristic <gkristic at gmail.com>
 Hanno Braun <mail at hannobraun.com>
 Henri Yandell <flamefew at gmail.com>

--- a/README.md
+++ b/README.md
@@ -309,6 +309,16 @@ Default:        0
 
 I/O write timeout. The value must be a decimal number with a unit suffix (*"ms"*, *"s"*, *"m"*, *"h"*), such as *"30s"*, *"0.5m"* or *"1m30s"*.
 
+##### `traceQueries`
+
+```
+Type:           bool
+Valid values:   true, false
+Default:        false
+```
+
+Print all SQL queries with their arguments to the default error logger before executing them on the MySQL server.
+
 
 ##### System Variables
 
@@ -446,4 +456,3 @@ Please read the [MPL 2.0 FAQ](https://www.mozilla.org/en-US/MPL/2.0/FAQ/) if you
 You can read the full terms here: [LICENSE](https://raw.github.com/go-sql-driver/mysql/master/LICENSE)
 
 ![Go Gopher and MySQL Dolphin](https://raw.github.com/wiki/go-sql-driver/mysql/go-mysql-driver_m.jpg "Golang Gopher transporting the MySQL Dolphin in a wheelbarrow")
-

--- a/connection.go
+++ b/connection.go
@@ -11,9 +11,11 @@ package mysql
 import (
 	"database/sql/driver"
 	"io"
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -31,6 +33,15 @@ type mysqlConn struct {
 	sequence         uint8
 	parseTime        bool
 	strict           bool
+
+	// used only in case of TraceQueries = true
+	traceQueriesLock sync.RWMutex
+	traceStatements  map[uint32]string
+}
+
+// String returns an unique identifier for the MySQL connection.
+func (mc *mysqlConn) String() string {
+	return fmt.Sprintf("{%p-%s}", mc, mc.netConn.LocalAddr())
 }
 
 // Handles parameters set in DSN after the connection is established
@@ -130,6 +141,12 @@ func (mc *mysqlConn) Prepare(query string) (driver.Stmt, error) {
 		if columnCount > 0 {
 			err = mc.readUntilEOF()
 		}
+	}
+
+	if stmt.mc.cfg.TraceQueries && err == nil {
+		stmt.mc.traceQueriesLock.Lock()
+		stmt.mc.traceStatements[stmt.id] = query
+		stmt.mc.traceQueriesLock.Unlock()
 	}
 
 	return stmt, err
@@ -289,6 +306,10 @@ func (mc *mysqlConn) Exec(query string, args []driver.Value) (driver.Result, err
 
 // Internal function to execute commands
 func (mc *mysqlConn) exec(query string) error {
+	if mc.cfg.TraceQueries {
+		errLog.Print("[mysql trace]", mc.String(), "executing: {", query, "}")
+	}
+
 	// Send command
 	if err := mc.writeCommandPacketStr(comQuery, query); err != nil {
 		return err
@@ -332,6 +353,9 @@ func (mc *mysqlConn) Query(query string, args []driver.Value) (driver.Rows, erro
 		query = prepared
 		args = nil
 	}
+	if mc.cfg.TraceQueries {
+		errLog.Print("[mysql trace]", mc.String(), "executing: {", query, " ", args, "}")
+	}
 	// Send command
 	err := mc.writeCommandPacketStr(comQuery, query)
 	if err == nil {
@@ -363,6 +387,9 @@ func (mc *mysqlConn) Query(query string, args []driver.Value) (driver.Rows, erro
 // Gets the value of the given MySQL System Variable
 // The returned byte slice is only valid until the next read
 func (mc *mysqlConn) getSystemVar(name string) ([]byte, error) {
+	if mc.cfg.TraceQueries {
+		errLog.Print("[mysql trace]", mc.String(), "executing: {", "SELECT @@"+name, "}")
+	}
 	// Send command
 	if err := mc.writeCommandPacketStr(comQuery, "SELECT @@"+name); err != nil {
 		return nil, err

--- a/driver.go
+++ b/driver.go
@@ -131,6 +131,11 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 		return nil, err
 	}
 
+	// Enable debugging features
+	if mc.cfg.TraceQueries {
+		mc.traceStatements = map[uint32]string{}
+	}
+
 	return mc, nil
 }
 

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -39,8 +39,8 @@ var testDSNs = []struct {
 	"user:password@tcp(localhost:5555)/dbname?charset=utf8mb4,utf8&tls=skip-verify",
 	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "localhost:5555", DBName: "dbname", Params: map[string]string{"charset": "utf8mb4,utf8"}, Collation: "utf8_general_ci", Loc: time.UTC, TLSConfig: "skip-verify"},
 }, {
-	"user:password@/dbname?loc=UTC&timeout=30s&readTimeout=1s&writeTimeout=1s&allowAllFiles=1&clientFoundRows=true&allowOldPasswords=TRUE&collation=utf8mb4_unicode_ci&maxAllowedPacket=16777216",
-	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Collation: "utf8mb4_unicode_ci", Loc: time.UTC, Timeout: 30 * time.Second, ReadTimeout: time.Second, WriteTimeout: time.Second, AllowAllFiles: true, AllowOldPasswords: true, ClientFoundRows: true, MaxAllowedPacket: 16777216},
+	"user:password@/dbname?loc=UTC&timeout=30s&readTimeout=1s&writeTimeout=1s&allowAllFiles=1&clientFoundRows=true&allowOldPasswords=TRUE&collation=utf8mb4_unicode_ci&maxAllowedPacket=16777216&traceQueries=true",
+	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Collation: "utf8mb4_unicode_ci", Loc: time.UTC, Timeout: 30 * time.Second, ReadTimeout: time.Second, WriteTimeout: time.Second, AllowAllFiles: true, AllowOldPasswords: true, ClientFoundRows: true, MaxAllowedPacket: 16777216, TraceQueries: true},
 }, {
 	"user:p@ss(word)@tcp([de:ad:be:ef::ca:fe]:80)/dbname?loc=Local",
 	&Config{User: "user", Passwd: "p@ss(word)", Net: "tcp", Addr: "[de:ad:be:ef::ca:fe]:80", DBName: "dbname", Collation: "utf8_general_ci", Loc: time.Local},

--- a/packets.go
+++ b/packets.go
@@ -887,6 +887,12 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 	const minPktLen = 4 + 1 + 4 + 1 + 4
 	mc := stmt.mc
 
+	if mc.cfg.TraceQueries {
+		mc.traceQueriesLock.RLock()
+		errLog.Print("[mysql trace]", mc.String(), "executing: {stmt#", stmt.id, " ", mc.traceStatements[stmt.id], " ", args, "}")
+		mc.traceQueriesLock.RUnlock()
+	}
+
 	// Reset packet-sequence
 	mc.sequence = 0
 

--- a/statement.go
+++ b/statement.go
@@ -50,13 +50,18 @@ func (stmt *mysqlStmt) Exec(args []driver.Value) (driver.Result, error) {
 		errLog.Print(ErrInvalidConn)
 		return nil, driver.ErrBadConn
 	}
+	mc := stmt.mc
+	if mc.cfg.TraceQueries {
+		mc.traceQueriesLock.RLock()
+		errLog.Print("[mysql trace]", mc.String(), "executing: {stmt#", stmt.id, " ", mc.traceStatements[stmt.id], " ", args, "}")
+		mc.traceQueriesLock.RUnlock()
+	}
+
 	// Send command
 	err := stmt.writeExecutePacket(args)
 	if err != nil {
 		return nil, err
 	}
-
-	mc := stmt.mc
 
 	mc.affectedRows = 0
 	mc.insertId = 0
@@ -94,13 +99,18 @@ func (stmt *mysqlStmt) Query(args []driver.Value) (driver.Rows, error) {
 		errLog.Print(ErrInvalidConn)
 		return nil, driver.ErrBadConn
 	}
+	mc := stmt.mc
+	if mc.cfg.TraceQueries {
+		mc.traceQueriesLock.RLock()
+		errLog.Print("[mysql trace]", mc.String(), "executing: {stmt#", stmt.id, " ", mc.traceStatements[stmt.id], " ", args, "}")
+		mc.traceQueriesLock.RUnlock()
+	}
+
 	// Send command
 	err := stmt.writeExecutePacket(args)
 	if err != nil {
 		return nil, err
 	}
-
-	mc := stmt.mc
 
 	// Read Result
 	resLen, err := mc.readResultSetHeaderPacket()


### PR DESCRIPTION
### Description

This is a proposal for a way to trace each and every SQL query being executed by the driver. I do not expect it to be merged in its current form but rather please give me some feedback about how to achieve the purpose:
- being able to trace the SQL connections executed by a single goroutine

Right now I am printing them to `errLog`, although I'd possibly use a separate logger (as these are not really errors). It's also a common desire to be able to turn on/off the feature at runtime, which would require yet another mutex (I am not particularly happy about the one introduced here either).
### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file

**Edit:** renamed the parameter from debugQueries to traceQueries
