### PR TITLE
Mark connections as bad on MariaDB shutdown

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,9 +42,9 @@ Runrioter Wung <runrioter at gmail.com>
 Soroush Pour <me at soroushjp.com>
 Stan Putrya <root.vagner at gmail.com>
 Stanley Gunawan <gunawan.stanley at gmail.com>
+Thomas Parrott <tomp at tomp.uk>
 Xiaobing Jiang <s7v7nislands at gmail.com>
 Xiuming Chen <cc at cxm.cc>
-Thomas Parrott <tomp at tomp.uk>
 
 # Organizations
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -44,6 +44,7 @@ Stan Putrya <root.vagner at gmail.com>
 Stanley Gunawan <gunawan.stanley at gmail.com>
 Xiaobing Jiang <s7v7nislands at gmail.com>
 Xiuming Chen <cc at cxm.cc>
+Thomas Parrott <tomp at tomp.uk>
 
 # Organizations
 

--- a/packets.go
+++ b/packets.go
@@ -53,7 +53,7 @@ func (mc *mysqlConn) readPacket() ([]byte, error) {
 			//When MariaDB server is shutdown connection killed packet is sent
 			//with a zero sequence number.
 			//Continue to process it so the specific error can be detected.
-			if data[3] > 0 {
+			if data[3] != 0 {
 				return nil, ErrPktSync
 			}
 		}

--- a/packets.go
+++ b/packets.go
@@ -535,6 +535,7 @@ func (mc *mysqlConn) handleErrorPacket(data []byte) error {
 	//If error code is for Connection was killed, then return bad connection.
 	//https://mariadb.com/kb/en/mariadb/mariadb-error-codes/
 	if errno == 1927 {
+		errLog.Print(string(data[pos:]))
 		return driver.ErrBadConn
 	}
 

--- a/packets.go
+++ b/packets.go
@@ -535,7 +535,7 @@ func (mc *mysqlConn) handleErrorPacket(data []byte) error {
 	//If error code is for Connection was killed, then return bad connection.
 	//https://mariadb.com/kb/en/mariadb/mariadb-error-codes/
 	if errno == 1927 {
-		errLog.Print(string(data[pos:]))
+		errLog.Print("Error ", errno, ": ", string(data[pos:]))
 		return driver.ErrBadConn
 	}
 

--- a/packets.go
+++ b/packets.go
@@ -50,6 +50,8 @@ func (mc *mysqlConn) readPacket() ([]byte, error) {
 				return nil, ErrPktSyncMul
 			}
 
+			//When MySQL server is shutdown a packet with a zero sequence seems
+			//to be sent to the old connection which is read on next query.
 			if data[3] == 0 {
 				mc.Close()
 				return nil, driver.ErrBadConn

--- a/packets.go
+++ b/packets.go
@@ -49,8 +49,15 @@ func (mc *mysqlConn) readPacket() ([]byte, error) {
 			if data[3] > mc.sequence {
 				return nil, ErrPktSyncMul
 			}
+
+			if data[3] == 0 {
+				mc.Close()
+				return nil, driver.ErrBadConn
+			}
+
 			return nil, ErrPktSync
 		}
+
 		mc.sequence++
 
 		// Read packet body [pktLen bytes]


### PR DESCRIPTION
### Description

Fix to address query when first query is run after MySQL is restarted.
Addresses issue https://github.com/go-sql-driver/mysql/issues/449
### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
