### PR TITLE
Add a param 'unescapeUser' to format dns like 'testdb%25dbuser:password@...'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,7 +44,7 @@ Stan Putrya <root.vagner at gmail.com>
 Stanley Gunawan <gunawan.stanley at gmail.com>
 Xiaobing Jiang <s7v7nislands at gmail.com>
 Xiuming Chen <cc at cxm.cc>
-
+Dajun Qin <dajun.qin at gmail.com>
 # Organizations
 
 Barracuda Networks, Inc.

--- a/README.md
+++ b/README.md
@@ -299,6 +299,16 @@ Default:        0
 I/O write timeout. The value must be a decimal number with an unit suffix ( *"ms"*, *"s"*, *"m"*, *"h"* ), such as *"30s"*, *"0.5m"* or *"1m30s"*.
 
 
+##### `unescapeUser`
+
+```
+Type:           bool
+Default:        false
+```
+
+`unescapeUser=true` let the library unescape `user`, sometimes the dsn looks like "testdb%25dbuser..." .
+
+
 ##### System Variables
 
 All other parameters are interpreted as system variables:

--- a/dsn.go
+++ b/dsn.go
@@ -51,7 +51,7 @@ type Config struct {
 	MultiStatements         bool // Allow multiple statements in one query
 	ParseTime               bool // Parse time values to time.Time
 	Strict                  bool // Return warnings as errors
-	UnEscapeUser            bool // UnEscape username such as testdb%25testuesr:password.....
+	UnescapeUser            bool // UnEscape username such as testdb%25testuesr:password.....
 }
 
 // FormatDSN formats the given Config into a DSN string which can be passed to
@@ -354,14 +354,14 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 		switch value := param[1]; param[0] {
 
 		// Disable INFILE whitelist / enable all files
-		case "unEscapeUser":
+		case "unescapeUser":
 			var isBool bool
-			cfg.UnEscapeUser, isBool = readBool(value)
+			cfg.UnescapeUser, isBool = readBool(value)
 			if !isBool {
 				return errors.New("invalid bool value: " + value)
 			}
 
-			if cfg.UnEscapeUser {
+			if cfg.UnescapeUser {
 				var err error
 				cfg.User, err = url.QueryUnescape(cfg.User)
 				if err != nil {

--- a/dsn.go
+++ b/dsn.go
@@ -51,6 +51,7 @@ type Config struct {
 	MultiStatements         bool // Allow multiple statements in one query
 	ParseTime               bool // Parse time values to time.Time
 	Strict                  bool // Return warnings as errors
+	UnEscapeUser            bool // UnEscape username such as testdb%25testuesr:password.....
 }
 
 // FormatDSN formats the given Config into a DSN string which can be passed to
@@ -353,6 +354,21 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 		switch value := param[1]; param[0] {
 
 		// Disable INFILE whitelist / enable all files
+		case "unEscapeUser":
+			var isBool bool
+			cfg.UnEscapeUser, isBool = readBool(value)
+			if !isBool {
+				return errors.New("invalid bool value: " + value)
+			}
+
+			if cfg.UnEscapeUser {
+				var err error
+				cfg.User, err = url.QueryUnescape(cfg.User)
+				if err != nil {
+					return errors.New("user unescape failed: " + err.Error())
+				}
+			}
+
 		case "allowAllFiles":
 			var isBool bool
 			cfg.AllowAllFiles, isBool = readBool(value)

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -231,7 +231,7 @@ func BenchmarkParseDSN(b *testing.B) {
 }
 
 func TestUnescapeUser(t *testing.T) {
-	dsn := "testdb%25dbuser:password@tcp(localhost:5555)/?unEscapeUser=true"
+	dsn := "testdb%25dbuser:password@tcp(localhost:5555)/?unescapeUser=true"
 	user := "testdb%dbuser"
 	cfg, err := ParseDSN(dsn)
 

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -229,3 +229,15 @@ func BenchmarkParseDSN(b *testing.B) {
 		}
 	}
 }
+
+func TestUnescapeUser(t *testing.T) {
+	dsn := "testdb%25dbuser:password@tcp(localhost:5555)/?unEscapeUser=true"
+	user := "testdb%dbuser"
+	cfg, err := ParseDSN(dsn)
+
+	if err != nil {
+		t.Error(err.Error())
+	} else if cfg.User != user {
+		t.Errorf("expected %v, got %v", user, dsn)
+	}
+}


### PR DESCRIPTION
### Description
First ,the format : "testdb%dbuser:password.." is used in MySQL on Azure...

Recently I used some other projects such as Telegraf(https://github.com/influxdata/telegraf)  which using this library to connect to MySQL.

These projects check dsn using url.Parse(), if I use "testdb%dbuser:password.." , error is "invalid URL escape %db". I tried to use a escaped value like "testdb%25dbuser:password...", error is "2001 user is not found from the service " because the username is wrong (with %25 not %) 

So I make some changes to make it working.

I don't know this matter belongs to this library or the projects which using this library.

Correct me if I have any mistake.

Thanks!

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
