### PR TITLE
Fixed panic in interploateParams

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -144,6 +144,10 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 	buf = buf[:0]
 	argPos := 0
 
+	if len(args) != strings.Count(query, "?") {
+		return "", ErrArgsInvalid
+	}
+
 	for i := 0; i < len(query); i++ {
 		q := strings.IndexByte(query[i:], '?')
 		if q == -1 {

--- a/errors.go
+++ b/errors.go
@@ -30,6 +30,7 @@ var (
 	ErrPktSyncMul        = errors.New("commands out of sync. Did you run multiple statements at once?")
 	ErrPktTooLarge       = errors.New("packet for query is too large. Try adjusting the 'max_allowed_packet' variable on the server")
 	ErrBusyBuffer        = errors.New("busy buffer")
+	ErrArgsInvalid       = errors.New("args invalid")
 )
 
 var errLog = Logger(log.New(os.Stderr, "[mysql] ", log.Ldate|log.Ltime|log.Lshortfile))


### PR DESCRIPTION
### Description
Fixed panic in interploateParams when count of placeholds(?) different from count of args

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file