### PR TITLE
README: Include Difference in Connection Strings depending on Cloud SQL Generation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Julien Lefevre <julien.lefevr at gmail.com>
 Julien Schmidt <go-sql-driver at julienschmidt.com>
 Kamil Dziedzic <kamil at klecza.pl>
 Kevin Malachowski <kevin at chowski.com>
+Lennart Rudolph <lrudolph at hmc.edu>
 Leonardo YongUk Kim <dalinaum at gmail.com>
 Luca Looz <luca.looz92 at gmail.com>
 Lucas Liu <extrafliu at gmail.com>

--- a/README.md
+++ b/README.md
@@ -337,9 +337,14 @@ TCP on a remote host, e.g. Amazon RDS:
 id:password@tcp(your-amazonaws-uri.com:3306)/dbname
 ```
 
-Google Cloud SQL on App Engine:
+Google Cloud SQL on App Engine (First Generation MySQL Server):
 ```
 user@cloudsql(project-id:instance-name)/dbname
+```
+
+Google Cloud SQL on App Engine (Second Generation MySQL Server):
+```
+user@cloudsql(project-id:regionname:instance-name)/dbname
 ```
 
 TCP using default port (3306) on localhost:


### PR DESCRIPTION
### Description
I updated the information in the README.md file to reflect the different connection strings for different generations of Google Cloud SQL servers.

For a Second Generation Google Cloud SQL server one should use this connection string:
`user@cloudsql(project-id:regionname:instance-name)/dbname`

For a First Generation Google Cloud SQL server one should use this connection string:
`user@cloudsql(project-id:instance-name)/dbname`

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file

Fixes #481, #484
