### PR TITLE
Add maxAllowedPacket DSN Parameter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,6 +43,7 @@ Soroush Pour <me at soroushjp.com>
 Stan Putrya <root.vagner at gmail.com>
 Stanley Gunawan <gunawan.stanley at gmail.com>
 Xiaobing Jiang <s7v7nislands at gmail.com>
+Zhenye Xie <xiezhenye at gmail.com>
 Xiuming Chen <cc at cxm.cc>
 
 # Organizations

--- a/AUTHORS
+++ b/AUTHORS
@@ -43,8 +43,8 @@ Soroush Pour <me at soroushjp.com>
 Stan Putrya <root.vagner at gmail.com>
 Stanley Gunawan <gunawan.stanley at gmail.com>
 Xiaobing Jiang <s7v7nislands at gmail.com>
-Zhenye Xie <xiezhenye at gmail.com>
 Xiuming Chen <cc at cxm.cc>
+Zhenye Xie <xiezhenye at gmail.com>
 
 # Organizations
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Type:          decimal number
 Default:       0
 ```
 
-Max MySQL packet size allowed in bytes. Use `maxPacketAllowed` == 0 to fetch the `max_allowed_packet` variable from server.
+Max packet size allowed in bytes. Use `maxPacketAllowed` = 0 to automatically fetch the `max_allowed_packet` variable from server.
 
 
 ##### System Variables

--- a/README.md
+++ b/README.md
@@ -299,13 +299,13 @@ Default:        0
 I/O write timeout. The value must be a decimal number with an unit suffix ( *"ms"*, *"s"*, *"m"*, *"h"* ), such as *"30s"*, *"0.5m"* or *"1m30s"*.
 
 
-##### `maxPacketAllowed`
+##### `maxAllowedPacket`
 ```
 Type:          decimal number
 Default:       0
 ```
 
-Max packet size allowed in bytes. Use `maxPacketAllowed` = 0 to automatically fetch the `max_allowed_packet` variable from server.
+Max packet size allowed in bytes. Use `maxAllowedPacket` = 0 to automatically fetch the `max_allowed_packet` variable from server.
 
 
 ##### System Variables

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Type:          decimal number
 Default:       0
 ```
 
-Max packet size allowed in bytes. Use `maxAllowedPacket` = 0 to automatically fetch the `max_allowed_packet` variable from server.
+Max packet size allowed in bytes. Use `maxAllowedPacket`=0 to automatically fetch the `max_allowed_packet` variable from server.
 
 
 ##### System Variables

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Type:          decimal number
 Default:       0
 ```
 
-Max packet size allowed in bytes. Use `maxAllowedPacket`=0 to automatically fetch the `max_allowed_packet` variable from server.
+Max packet size allowed in bytes. Use `maxAllowedPacket=0` to automatically fetch the `max_allowed_packet` variable from server.
 
 
 ##### System Variables

--- a/README.md
+++ b/README.md
@@ -299,6 +299,15 @@ Default:        0
 I/O write timeout. The value must be a decimal number with an unit suffix ( *"ms"*, *"s"*, *"m"*, *"h"* ), such as *"30s"*, *"0.5m"* or *"1m30s"*.
 
 
+##### `maxPacketAllowed`
+```
+Type:          decimal number
+Default:       0
+```
+
+Max MySQL packet size allowed in bytes. Use `maxPacketAllowed` == 0 to fetch the `max_allowed_packet` variable from server.
+
+
 ##### System Variables
 
 All other parameters are interpreted as system variables:

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -220,7 +220,7 @@ func BenchmarkInterpolation(b *testing.B) {
 			InterpolateParams: true,
 			Loc:               time.UTC,
 		},
-		maxPacketAllowed: maxPacketSize,
+		maxAllowedPacket: maxPacketSize,
 		maxWriteSize:     maxPacketSize - 1,
 		buf:              newBuffer(nil),
 	}

--- a/connection.go
+++ b/connection.go
@@ -22,7 +22,7 @@ type mysqlConn struct {
 	affectedRows     uint64
 	insertId         uint64
 	cfg              *Config
-	maxPacketAllowed int
+	maxAllowedPacket int
 	maxWriteSize     int
 	writeTimeout     time.Duration
 	flags            clientFlag
@@ -246,7 +246,7 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 			return "", driver.ErrSkip
 		}
 
-		if len(buf)+4 > mc.maxPacketAllowed {
+		if len(buf)+4 > mc.maxAllowedPacket {
 			return "", driver.ErrSkip
 		}
 	}

--- a/connection_test.go
+++ b/connection_test.go
@@ -16,7 +16,7 @@ import (
 func TestInterpolateParams(t *testing.T) {
 	mc := &mysqlConn{
 		buf:              newBuffer(nil),
-		maxPacketAllowed: maxPacketSize,
+		maxAllowedPacket: maxPacketSize,
 		cfg: &Config{
 			InterpolateParams: true,
 		},
@@ -36,7 +36,7 @@ func TestInterpolateParams(t *testing.T) {
 func TestInterpolateParamsTooManyPlaceholders(t *testing.T) {
 	mc := &mysqlConn{
 		buf:              newBuffer(nil),
-		maxPacketAllowed: maxPacketSize,
+		maxAllowedPacket: maxPacketSize,
 		cfg: &Config{
 			InterpolateParams: true,
 		},
@@ -53,7 +53,7 @@ func TestInterpolateParamsTooManyPlaceholders(t *testing.T) {
 func TestInterpolateParamsPlaceholderInString(t *testing.T) {
 	mc := &mysqlConn{
 		buf:              newBuffer(nil),
-		maxPacketAllowed: maxPacketSize,
+		maxAllowedPacket: maxPacketSize,
 		cfg: &Config{
 			InterpolateParams: true,
 		},

--- a/driver.go
+++ b/driver.go
@@ -50,7 +50,7 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 
 	// New mysqlConn
 	mc := &mysqlConn{
-		maxPacketAllowed: maxPacketSize,
+		maxAllowedPacket: maxPacketSize,
 		maxWriteSize:     maxPacketSize - 1,
 	}
 	mc.cfg, err = ParseDSN(dsn)
@@ -110,7 +110,7 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 	}
 
 	if mc.cfg.MaxAllowedPacket > 0 {
-		mc.maxPacketAllowed = mc.cfg.MaxAllowedPacket
+		mc.maxAllowedPacket = mc.cfg.MaxAllowedPacket
 	} else {
 		// Get max allowed packet size
 		maxap, err := mc.getSystemVar("max_allowed_packet")
@@ -118,10 +118,10 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 			mc.Close()
 			return nil, err
 		}
-		mc.maxPacketAllowed = stringToInt(maxap) - 1
+		mc.maxAllowedPacket = stringToInt(maxap) - 1
 	}
-	if mc.maxPacketAllowed < maxPacketSize {
-		mc.maxWriteSize = mc.maxPacketAllowed
+	if mc.maxAllowedPacket < maxPacketSize {
+		mc.maxWriteSize = mc.maxAllowedPacket
 	}
 
 	// Handle DSN Params

--- a/driver.go
+++ b/driver.go
@@ -109,13 +109,17 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 		return nil, err
 	}
 
-	// Get max allowed packet size
-	maxap, err := mc.getSystemVar("max_allowed_packet")
-	if err != nil {
-		mc.Close()
-		return nil, err
+	if mc.cfg.MaxPacketAllowed > 0 {
+		mc.maxPacketAllowed = mc.cfg.MaxPacketAllowed
+	} else {
+		// Get max allowed packet size
+		maxap, err := mc.getSystemVar("max_allowed_packet")
+		if err != nil {
+			mc.Close()
+			return nil, err
+		}
+		mc.maxPacketAllowed = stringToInt(maxap) - 1
 	}
-	mc.maxPacketAllowed = stringToInt(maxap) - 1
 	if mc.maxPacketAllowed < maxPacketSize {
 		mc.maxWriteSize = mc.maxPacketAllowed
 	}

--- a/driver.go
+++ b/driver.go
@@ -109,8 +109,8 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 		return nil, err
 	}
 
-	if mc.cfg.MaxPacketAllowed > 0 {
-		mc.maxPacketAllowed = mc.cfg.MaxPacketAllowed
+	if mc.cfg.MaxAllowedPacket > 0 {
+		mc.maxPacketAllowed = mc.cfg.MaxAllowedPacket
 	} else {
 		// Get max allowed packet size
 		maxap, err := mc.getSystemVar("max_allowed_packet")

--- a/dsn.go
+++ b/dsn.go
@@ -52,7 +52,7 @@ type Config struct {
 	MultiStatements         bool // Allow multiple statements in one query
 	ParseTime               bool // Parse time values to time.Time
 	Strict                  bool // Return warnings as errors
-	MaxPacketAllowed	int  // Max packet size allowed
+	MaxAllowedPacket	int  // Max packet size allowed
 }
 
 // FormatDSN formats the given Config into a DSN string which can be passed to
@@ -224,14 +224,14 @@ func (cfg *Config) FormatDSN() string {
 		buf.WriteString(cfg.WriteTimeout.String())
 	}
 
-	if cfg.MaxPacketAllowed > 0 {
+	if cfg.MaxAllowedPacket > 0 {
 		if hasParam {
 			buf.WriteString("&maxPacketAllowed=")
 		} else {
 			hasParam = true
 			buf.WriteString("?maxPacketAllowed=")
 		}
-		buf.WriteString(strconv.Itoa(cfg.MaxPacketAllowed))
+		buf.WriteString(strconv.Itoa(cfg.MaxAllowedPacket))
 	
 	}
 
@@ -510,7 +510,7 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 				return
 			}
 		case "maxPacketAllowed":
-			cfg.MaxPacketAllowed, err = strconv.Atoi(value)
+			cfg.MaxAllowedPacket, err = strconv.Atoi(value)
 			if err != nil {
 				return
 			}

--- a/dsn.go
+++ b/dsn.go
@@ -15,9 +15,9 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
-	"strconv"
 )
 
 var (
@@ -29,19 +29,20 @@ var (
 
 // Config is a configuration parsed from a DSN string
 type Config struct {
-	User         string            // Username
-	Passwd       string            // Password (requires User)
-	Net          string            // Network type
-	Addr         string            // Network address (requires Net)
-	DBName       string            // Database name
-	Params       map[string]string // Connection parameters
-	Collation    string            // Connection collation
-	Loc          *time.Location    // Location for time.Time values
-	TLSConfig    string            // TLS configuration name
-	tls          *tls.Config       // TLS configuration
-	Timeout      time.Duration     // Dial timeout
-	ReadTimeout  time.Duration     // I/O read timeout
-	WriteTimeout time.Duration     // I/O write timeout
+	User             string            // Username
+	Passwd           string            // Password (requires User)
+	Net              string            // Network type
+	Addr             string            // Network address (requires Net)
+	DBName           string            // Database name
+	Params           map[string]string // Connection parameters
+	Collation        string            // Connection collation
+	Loc              *time.Location    // Location for time.Time values
+	MaxAllowedPacket int               // Max packet size allowed
+	TLSConfig        string            // TLS configuration name
+	tls              *tls.Config       // TLS configuration
+	Timeout          time.Duration     // Dial timeout
+	ReadTimeout      time.Duration     // I/O read timeout
+	WriteTimeout     time.Duration     // I/O write timeout
 
 	AllowAllFiles           bool // Allow all files to be used with LOAD DATA LOCAL INFILE
 	AllowCleartextPasswords bool // Allows the cleartext client side plugin
@@ -52,7 +53,6 @@ type Config struct {
 	MultiStatements         bool // Allow multiple statements in one query
 	ParseTime               bool // Parse time values to time.Time
 	Strict                  bool // Return warnings as errors
-	MaxAllowedPacket	int  // Max packet size allowed
 }
 
 // FormatDSN formats the given Config into a DSN string which can be passed to
@@ -226,13 +226,13 @@ func (cfg *Config) FormatDSN() string {
 
 	if cfg.MaxAllowedPacket > 0 {
 		if hasParam {
-			buf.WriteString("&maxPacketAllowed=")
+			buf.WriteString("&maxAllowedPacket=")
 		} else {
 			hasParam = true
-			buf.WriteString("?maxPacketAllowed=")
+			buf.WriteString("?maxAllowedPacket=")
 		}
 		buf.WriteString(strconv.Itoa(cfg.MaxAllowedPacket))
-	
+
 	}
 
 	// other params
@@ -509,7 +509,7 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			if err != nil {
 				return
 			}
-		case "maxPacketAllowed":
+		case "maxAllowedPacket":
 			cfg.MaxAllowedPacket, err = strconv.Atoi(value)
 			if err != nil {
 				return

--- a/dsn.go
+++ b/dsn.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"strconv"
 )
 
 var (
@@ -51,6 +52,7 @@ type Config struct {
 	MultiStatements         bool // Allow multiple statements in one query
 	ParseTime               bool // Parse time values to time.Time
 	Strict                  bool // Return warnings as errors
+	MaxPacketAllowed	int  // Max packet size allowed
 }
 
 // FormatDSN formats the given Config into a DSN string which can be passed to
@@ -220,6 +222,17 @@ func (cfg *Config) FormatDSN() string {
 			buf.WriteString("?writeTimeout=")
 		}
 		buf.WriteString(cfg.WriteTimeout.String())
+	}
+
+	if cfg.MaxPacketAllowed > 0 {
+		if hasParam {
+			buf.WriteString("&maxPacketAllowed=")
+		} else {
+			hasParam = true
+			buf.WriteString("?maxPacketAllowed=")
+		}
+		buf.WriteString(strconv.Itoa(cfg.MaxPacketAllowed))
+	
 	}
 
 	// other params
@@ -496,7 +509,11 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			if err != nil {
 				return
 			}
-
+		case "maxPacketAllowed":
+			cfg.MaxPacketAllowed, err = strconv.Atoi(value)
+			if err != nil {
+				return
+			}
 		default:
 			// lazy init
 			if cfg.Params == nil {

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -39,7 +39,7 @@ var testDSNs = []struct {
 	"user:password@tcp(localhost:5555)/dbname?charset=utf8mb4,utf8&tls=skip-verify",
 	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "localhost:5555", DBName: "dbname", Params: map[string]string{"charset": "utf8mb4,utf8"}, Collation: "utf8_general_ci", Loc: time.UTC, TLSConfig: "skip-verify"},
 }, {
-	"user:password@/dbname?loc=UTC&timeout=30s&readTimeout=1s&writeTimeout=1s&allowAllFiles=1&clientFoundRows=true&allowOldPasswords=TRUE&collation=utf8mb4_unicode_ci&maxPacketAllowed=16777216",
+	"user:password@/dbname?loc=UTC&timeout=30s&readTimeout=1s&writeTimeout=1s&allowAllFiles=1&clientFoundRows=true&allowOldPasswords=TRUE&collation=utf8mb4_unicode_ci&maxAllowedPacket=16777216",
 	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Collation: "utf8mb4_unicode_ci", Loc: time.UTC, Timeout: 30 * time.Second, ReadTimeout: time.Second, WriteTimeout: time.Second, AllowAllFiles: true, AllowOldPasswords: true, ClientFoundRows: true, MaxAllowedPacket: 16777216},
 }, {
 	"user:p@ss(word)@tcp([de:ad:be:ef::ca:fe]:80)/dbname?loc=Local",

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -39,8 +39,8 @@ var testDSNs = []struct {
 	"user:password@tcp(localhost:5555)/dbname?charset=utf8mb4,utf8&tls=skip-verify",
 	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "localhost:5555", DBName: "dbname", Params: map[string]string{"charset": "utf8mb4,utf8"}, Collation: "utf8_general_ci", Loc: time.UTC, TLSConfig: "skip-verify"},
 }, {
-	"user:password@/dbname?loc=UTC&timeout=30s&readTimeout=1s&writeTimeout=1s&allowAllFiles=1&clientFoundRows=true&allowOldPasswords=TRUE&collation=utf8mb4_unicode_ci",
-	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Collation: "utf8mb4_unicode_ci", Loc: time.UTC, Timeout: 30 * time.Second, ReadTimeout: time.Second, WriteTimeout: time.Second, AllowAllFiles: true, AllowOldPasswords: true, ClientFoundRows: true},
+	"user:password@/dbname?loc=UTC&timeout=30s&readTimeout=1s&writeTimeout=1s&allowAllFiles=1&clientFoundRows=true&allowOldPasswords=TRUE&collation=utf8mb4_unicode_ci&maxPacketAllowed=16777216",
+	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Collation: "utf8mb4_unicode_ci", Loc: time.UTC, Timeout: 30 * time.Second, ReadTimeout: time.Second, WriteTimeout: time.Second, AllowAllFiles: true, AllowOldPasswords: true, ClientFoundRows: true, MaxPacketAllowed: 16777216},
 }, {
 	"user:p@ss(word)@tcp([de:ad:be:ef::ca:fe]:80)/dbname?loc=Local",
 	&Config{User: "user", Passwd: "p@ss(word)", Net: "tcp", Addr: "[de:ad:be:ef::ca:fe]:80", DBName: "dbname", Collation: "utf8_general_ci", Loc: time.Local},

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -40,7 +40,7 @@ var testDSNs = []struct {
 	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "localhost:5555", DBName: "dbname", Params: map[string]string{"charset": "utf8mb4,utf8"}, Collation: "utf8_general_ci", Loc: time.UTC, TLSConfig: "skip-verify"},
 }, {
 	"user:password@/dbname?loc=UTC&timeout=30s&readTimeout=1s&writeTimeout=1s&allowAllFiles=1&clientFoundRows=true&allowOldPasswords=TRUE&collation=utf8mb4_unicode_ci&maxPacketAllowed=16777216",
-	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Collation: "utf8mb4_unicode_ci", Loc: time.UTC, Timeout: 30 * time.Second, ReadTimeout: time.Second, WriteTimeout: time.Second, AllowAllFiles: true, AllowOldPasswords: true, ClientFoundRows: true, MaxPacketAllowed: 16777216},
+	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Collation: "utf8mb4_unicode_ci", Loc: time.UTC, Timeout: 30 * time.Second, ReadTimeout: time.Second, WriteTimeout: time.Second, AllowAllFiles: true, AllowOldPasswords: true, ClientFoundRows: true, MaxAllowedPacket: 16777216},
 }, {
 	"user:p@ss(word)@tcp([de:ad:be:ef::ca:fe]:80)/dbname?loc=Local",
 	&Config{User: "user", Passwd: "p@ss(word)", Net: "tcp", Addr: "[de:ad:be:ef::ca:fe]:80", DBName: "dbname", Collation: "utf8_general_ci", Loc: time.Local},

--- a/packets.go
+++ b/packets.go
@@ -80,7 +80,7 @@ func (mc *mysqlConn) readPacket() ([]byte, error) {
 func (mc *mysqlConn) writePacket(data []byte) error {
 	pktLen := len(data) - 4
 
-	if pktLen > mc.maxPacketAllowed {
+	if pktLen > mc.maxAllowedPacket {
 		return ErrPktTooLarge
 	}
 
@@ -786,7 +786,7 @@ func (stmt *mysqlStmt) readPrepareResultPacket() (uint16, error) {
 
 // http://dev.mysql.com/doc/internals/en/com-stmt-send-long-data.html
 func (stmt *mysqlStmt) writeCommandLongData(paramID int, arg []byte) error {
-	maxLen := stmt.mc.maxPacketAllowed - 1
+	maxLen := stmt.mc.maxAllowedPacket - 1
 	pktLen := maxLen
 
 	// After the header (bytes 0-3) follows before the data:
@@ -977,7 +977,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 					paramTypes[i+i] = fieldTypeString
 					paramTypes[i+i+1] = 0x00
 
-					if len(v) < mc.maxPacketAllowed-pos-len(paramValues)-(len(args)-(i+1))*64 {
+					if len(v) < mc.maxAllowedPacket-pos-len(paramValues)-(len(args)-(i+1))*64 {
 						paramValues = appendLengthEncodedInteger(paramValues,
 							uint64(len(v)),
 						)
@@ -999,7 +999,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 				paramTypes[i+i] = fieldTypeString
 				paramTypes[i+i+1] = 0x00
 
-				if len(v) < mc.maxPacketAllowed-pos-len(paramValues)-(len(args)-(i+1))*64 {
+				if len(v) < mc.maxAllowedPacket-pos-len(paramValues)-(len(args)-(i+1))*64 {
 					paramValues = appendLengthEncodedInteger(paramValues,
 						uint64(len(v)),
 					)


### PR DESCRIPTION
### Description
Add a `maxPacketAllowed` DSN param and a config field to set it directly instead of fetch from server. 

Some mysql proxy implements or other services using mysql protocol may not supports 'select @@max_allowed_packet'.  `maxPacketAllowed` param can be used to walk around these problems.

It can also be used to limit the max row size returned from server.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file