### PR TITLE
Fix "index out of range" in interpolateParams

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -135,6 +135,11 @@ func (mc *mysqlConn) Prepare(query string) (driver.Stmt, error) {
 }
 
 func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (string, error) {
+	// Number of ? should be same to len(args)
+	if strings.Count(query, "?") != len(args) {
+		return "", driver.ErrSkip
+	}
+
 	buf := mc.buf.takeCompleteBuffer()
 	if buf == nil {
 		// can not take the buffer. Something must be wrong with the connection
@@ -153,9 +158,6 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 		buf = append(buf, query[i:i+q]...)
 		i += q
 
-		if argPos >= len(args) {
-			return "", driver.ErrSkip
-		}
 		arg := args[argPos]
 		argPos++
 

--- a/connection.go
+++ b/connection.go
@@ -153,6 +153,9 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 		buf = append(buf, query[i:i+q]...)
 		i += q
 
+		if argPos >= len(args) {
+			return "", driver.ErrSkip
+		}
 		arg := args[argPos]
 		argPos++
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -49,6 +49,7 @@ func TestInterpolateParamsTooManyPlaceholders(t *testing.T) {
 }
 
 // We don't support placeholder in string literal for now.
+// https://github.com/go-sql-driver/mysql/pull/490
 func TestInterpolateParamsPlaceholderInString(t *testing.T) {
 	mc := &mysqlConn{
 		buf:              newBuffer(nil),
@@ -59,6 +60,7 @@ func TestInterpolateParamsPlaceholderInString(t *testing.T) {
 	}
 
 	q, err := mc.interpolateParams("SELECT 'abc?xyz',?", []driver.Value{int64(42)})
+	// When InterpolateParams support string literal, this should return `"SELECT 'abc?xyz', 42`
 	if err != driver.ErrSkip {
 		t.Errorf("Expected err=driver.ErrSkip, got err=%#v, q=%#v", err, q)
 	}

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,6 +1,6 @@
 // Go MySQL Driver - A MySQL-Driver for Go's database/sql package
 //
-// Copyright 2013 The Go-MySQL-Driver Authors. All rights reserved.
+// Copyright 2016 The Go-MySQL-Driver Authors. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
@@ -43,6 +43,22 @@ func TestInterpolateParamsTooManyPlaceholders(t *testing.T) {
 	}
 
 	q, err := mc.interpolateParams("SELECT ?+?", []driver.Value{int64(42)})
+	if err != driver.ErrSkip {
+		t.Errorf("Expected err=driver.ErrSkip, got err=%#v, q=%#v", err, q)
+	}
+}
+
+// We don't support placeholder in string literal for now.
+func TestInterpolateParamsPlaceholderInString(t *testing.T) {
+	mc := &mysqlConn{
+		buf:              newBuffer(nil),
+		maxPacketAllowed: maxPacketSize,
+		cfg: &Config{
+			InterpolateParams: true,
+		},
+	}
+
+	q, err := mc.interpolateParams("SELECT 'abc?xyz',?", []driver.Value{int64(42)})
 	if err != driver.ErrSkip {
 		t.Errorf("Expected err=driver.ErrSkip, got err=%#v, q=%#v", err, q)
 	}

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,0 +1,49 @@
+// Go MySQL Driver - A MySQL-Driver for Go's database/sql package
+//
+// Copyright 2013 The Go-MySQL-Driver Authors. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package mysql
+
+import (
+	"database/sql/driver"
+	"testing"
+)
+
+func TestInterpolateParams(t *testing.T) {
+	mc := &mysqlConn{
+		buf:              newBuffer(nil),
+		maxPacketAllowed: maxPacketSize,
+		cfg: &Config{
+			InterpolateParams: true,
+		},
+	}
+
+	q, err := mc.interpolateParams("SELECT ?+?", []driver.Value{int64(42), "gopher"})
+	if err != nil {
+		t.Errorf("Expected err=nil, got %#v", err)
+		return
+	}
+	expected := `SELECT 42+'gopher'`
+	if q != expected {
+		t.Errorf("Expected: %q\nGot: %q", expected, q)
+	}
+}
+
+func TestInterpolateParamsTooManyPlaceholders(t *testing.T) {
+	mc := &mysqlConn{
+		buf:              newBuffer(nil),
+		maxPacketAllowed: maxPacketSize,
+		cfg: &Config{
+			InterpolateParams: true,
+		},
+	}
+
+	q, err := mc.interpolateParams("SELECT ?+?", []driver.Value{int64(42)})
+	if err != driver.ErrSkip {
+		t.Errorf("Expected err=driver.ErrSkip, got err=%#v, q=%#v", err, q)
+	}
+}


### PR DESCRIPTION
### Description
When number of placeholder is larger than number of argument,
interpolateParams cause runtime error.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file

