### PR TITLE
Fix old_password authentication via OldAuthSwitchRequest

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -499,6 +499,7 @@ func (mc *mysqlConn) readResultOK() ([]byte, error) {
 					return cipher, ErrUnknownPlugin
 				}
 			} else {
+				// https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::OldAuthSwitchRequest
 				return nil, ErrOldPassword
 			}
 


### PR DESCRIPTION
### Description
If CLIENT_PLUGIN_AUTH capability is not supported, no new cipher is sent and we have to keep using the cipher sent in the init packet.

Fixes #518