### PR TITLE
make tls=true do the same thing as tls=.  otherwise it's pretty useless.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Aaron Hopkins <go-sql-driver at die.net>
 Arne Hormann <arnehormann at gmail.com>
 Carlos Nieto <jose.carlos at menteslibres.net>
 Chris Moos <chris at tech9computers.com>
+Chris Toshok <toshok at honeycomb.io>
 Daniel Nichter <nil at codenode.com>
 Daniël van Eeden <git at myname.nl>
 DisposaBoy <disposaboy at dby.me>

--- a/README.md
+++ b/README.md
@@ -293,11 +293,11 @@ Default:        OS default
 
 ```
 Type:           bool / string
-Valid Values:   true, false, skip-verify, <name>
+Valid Values:   true, false, skip-verify, <name>, <empty>
 Default:        false
 ```
 
-`tls=true` enables TLS / SSL encrypted connection to the server. Use `skip-verify` if you want to use a self-signed or invalid certificate (server side). Use a custom value registered with [`mysql.RegisterTLSConfig`](https://godoc.org/github.com/go-sql-driver/mysql#RegisterTLSConfig).
+Every value other than `false` enables TLS/SSL encrypted connection to the server.  Use `skip-verify` if you want to use a self-signed or invalid certificate (server side).  Use a custom `<name>` if you've registered it with [`mysql.RegisterTLSConfig`](https://godoc.org/github.com/go-sql-driver/mysql#RegisterTLSConfig).  Both `true` and `<empty>` will use use the `host` from the address for the expected `ServerName`.
 
 ##### `writeTimeout`
 

--- a/dsn.go
+++ b/dsn.go
@@ -493,7 +493,13 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			if isBool {
 				if boolValue {
 					cfg.TLSConfig = "true"
-					cfg.tls = &tls.Config{}
+
+					var host string
+					host, _, err = net.SplitHostPort(cfg.Addr)
+					if err != nil {
+						return
+					}
+					cfg.tls = &tls.Config{ServerName: host}
 				} else {
 					cfg.TLSConfig = "false"
 				}

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -161,6 +161,18 @@ func TestDSNWithCustomTLS(t *testing.T) {
 		t.Errorf("did not get the correct ServerName (%s) parsing DSN (%s).", name, tst)
 	}
 
+	// tls=true should also pick localhost
+	tst = baseDSN + "true"
+	name = "localhost"
+	tlsCfg.ServerName = ""
+	cfg, err = ParseDSN(tst)
+
+	if err != nil {
+		t.Error(err.Error())
+	} else if cfg.tls.ServerName != name {
+		t.Errorf("did not get the correct ServerName (%s) parsing DSN (%s).", name, tst)
+	}
+
 	DeregisterTLSConfig("utils_test")
 }
 


### PR DESCRIPTION
### Description

`tls=true` in the dsn creates an empty `tls.Config{}`, which when used results in the error:

```
either ServerName or InsecureSkipVerify must be specified in the tls.Config
```

This change makes `tls=true` behave the same as `tls=`, that is it uses the hostname portion of the addr as the ServerName.

Fixes #527 

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
