### PR TITLE
add support for authentication plugins.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Aaron Hopkins <go-sql-driver at die.net>
 Arne Hormann <arnehormann at gmail.com>
 Carlos Nieto <jose.carlos at menteslibres.net>
 Chris Moos <chris at tech9computers.com>
+Craig Wilson <craiggwilson@gmail.com>
 Daniel Nichter <nil at codenode.com>
 Daniël van Eeden <git at myname.nl>
 DisposaBoy <disposaboy at dby.me>

--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,129 @@
+package mysql
+
+import "bytes"
+
+const (
+	mysqlClearPassword    = "mysql_clear_password"
+	mysqlNativePassword   = "mysql_native_password"
+	mysqlOldPassword      = "mysql_old_password"
+	defaultAuthPluginName = mysqlNativePassword
+)
+
+var authPluginFactories map[string]func(*Config) AuthPlugin
+
+func init() {
+	authPluginFactories = make(map[string]func(*Config) AuthPlugin)
+	authPluginFactories[mysqlClearPassword] = func(cfg *Config) AuthPlugin {
+		return &clearTextPlugin{cfg}
+	}
+	authPluginFactories[mysqlNativePassword] = func(cfg *Config) AuthPlugin {
+		return &nativePasswordPlugin{cfg}
+	}
+	authPluginFactories[mysqlOldPassword] = func(cfg *Config) AuthPlugin {
+		return &oldPasswordPlugin{cfg}
+	}
+}
+
+// RegisterAuthPlugin registers an authentication plugin to be used during
+// negotiation with the server. If a plugin with the given name already exists,
+// it will be overwritten.
+func RegisterAuthPlugin(name string, factory func(*Config) AuthPlugin) {
+	authPluginFactories[name] = factory
+}
+
+// AuthPlugin handles authenticating a user.
+type AuthPlugin interface {
+	// Next takes a server's challenge and returns
+	// the bytes to send back or an error.
+	Next(challenge []byte) ([]byte, error)
+}
+
+type clearTextPlugin struct {
+	cfg *Config
+}
+
+func (p *clearTextPlugin) Next(challenge []byte) ([]byte, error) {
+	if !p.cfg.AllowCleartextPasswords {
+		return nil, ErrCleartextPassword
+	}
+
+	// NUL-terminated
+	return append([]byte(p.cfg.Passwd), 0), nil
+}
+
+type nativePasswordPlugin struct {
+	cfg *Config
+}
+
+func (p *nativePasswordPlugin) Next(challenge []byte) ([]byte, error) {
+	// NOTE: this seems to always be disabled...
+	// if !p.cfg.AllowNativePasswords {
+	// 	return nil, ErrNativePassword
+	// }
+
+	return scramblePassword(challenge, []byte(p.cfg.Passwd)), nil
+}
+
+type oldPasswordPlugin struct {
+	cfg *Config
+}
+
+func (p *oldPasswordPlugin) Next(challenge []byte) ([]byte, error) {
+	if !p.cfg.AllowOldPasswords {
+		return nil, ErrOldPassword
+	}
+
+	// NUL-terminated
+	return append(scrambleOldPassword(challenge, []byte(p.cfg.Passwd)), 0), nil
+}
+
+func handleAuthResult(mc *mysqlConn, plugin AuthPlugin, oldCipher []byte) error {
+	data, err := mc.readPacket()
+	if err != nil {
+		return err
+	}
+
+	var authData []byte
+
+	// packet indicator
+	switch data[0] {
+	case iOK:
+		return mc.handleOkPacket(data)
+
+	case iEOF: // auth switch
+		if len(data) > 1 {
+			pluginEndIndex := bytes.IndexByte(data, 0x00)
+			pluginName := string(data[1:pluginEndIndex])
+			if apf, ok := authPluginFactories[pluginName]; ok {
+				plugin = apf(mc.cfg)
+			} else {
+				return ErrUnknownPlugin
+			}
+
+			if len(data) > pluginEndIndex+1 {
+				authData = data[pluginEndIndex+1 : len(data)-1]
+			}
+		} else {
+			// https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::OldAuthSwitchRequest
+			plugin = authPluginFactories[mysqlOldPassword](mc.cfg)
+			authData = oldCipher
+		}
+	case iAuthContinue:
+		// continue packet for a plugin.
+		authData = data[1:] // strip off the continue flag
+	default: // Error otherwise
+		return mc.handleErrorPacket(data)
+	}
+
+	authData, err = plugin.Next(authData)
+	if err != nil {
+		return err
+	}
+
+	err = mc.writeAuthDataPacket(authData)
+	if err != nil {
+		return err
+	}
+
+	return handleAuthResult(mc, plugin, authData)
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,72 @@
+package mysql
+
+import "testing"
+import "bytes"
+
+func TestAuthPlugin_Cleartext(t *testing.T) {
+	cfg := &Config{
+		Passwd: "funny",
+	}
+
+	plugin := authPluginFactories[mysqlClearPassword](cfg)
+
+	_, err := plugin.Next(nil)
+	if err == nil {
+		t.Fatalf("expected error when AllowCleartextPasswords is false")
+	}
+
+	cfg.AllowCleartextPasswords = true
+
+	actual, err := plugin.Next(nil)
+	if err != nil {
+		t.Fatalf("expected no error but got: %s", err)
+	}
+
+	expected := append([]byte("funny"), 0)
+	if bytes.Compare(actual, expected) != 0 {
+		t.Fatalf("expected data to be %v, but got: %v", expected, actual)
+	}
+}
+
+func TestAuthPlugin_NativePassword(t *testing.T) {
+	cfg := &Config{
+		Passwd: "pass ",
+	}
+
+	plugin := authPluginFactories[mysqlNativePassword](cfg)
+
+	actual, err := plugin.Next([]byte{9, 8, 7, 6, 5, 4, 3, 2})
+	if err != nil {
+		t.Fatalf("expected no error but got: %s", err)
+	}
+
+	expected := []byte{195, 146, 3, 213, 111, 95, 252, 192, 97, 226, 173, 176, 91, 175, 131, 138, 89, 45, 75, 179}
+	if bytes.Compare(actual, expected) != 0 {
+		t.Fatalf("expected data to be %v, but got: %v", expected, actual)
+	}
+}
+
+func TestAuthPlugin_OldPassword(t *testing.T) {
+	cfg := &Config{
+		Passwd: "pass ",
+	}
+
+	plugin := authPluginFactories[mysqlOldPassword](cfg)
+
+	_, err := plugin.Next(nil)
+	if err == nil {
+		t.Fatalf("expected error when AllowOldPasswords is false")
+	}
+
+	cfg.AllowOldPasswords = true
+
+	actual, err := plugin.Next([]byte{9, 8, 7, 6, 5, 4, 3, 2})
+	if err != nil {
+		t.Fatalf("expected no error but got: %s", err)
+	}
+
+	expected := []byte{71, 87, 92, 90, 67, 91, 66, 81, 0}
+	if bytes.Compare(actual, expected) != 0 {
+		t.Fatalf("expected data to be %v, but got: %v", expected, actual)
+	}
+}

--- a/connection.go
+++ b/connection.go
@@ -30,6 +30,7 @@ type mysqlConn struct {
 	sequence         uint8
 	parseTime        bool
 	strict           bool
+	authPlugin       AuthPlugin
 }
 
 // Handles parameters set in DSN after the connection is established
@@ -92,6 +93,10 @@ func (mc *mysqlConn) Close() (err error) {
 // closed the network connection.
 func (mc *mysqlConn) cleanup() {
 	// Makes cleanup idempotent
+	if mc.authPlugin != nil {
+		mc.authPlugin.Close()
+		mc.authPlugin = nil
+	}
 	if mc.netConn != nil {
 		if err := mc.netConn.Close(); err != nil {
 			errLog.Print(err)

--- a/const.go
+++ b/const.go
@@ -18,10 +18,11 @@ const (
 // http://dev.mysql.com/doc/internals/en/client-server-protocol.html
 
 const (
-	iOK          byte = 0x00
-	iLocalInFile byte = 0xfb
-	iEOF         byte = 0xfe
-	iERR         byte = 0xff
+	iOK           byte = 0x00
+	iAuthContinue byte = 0x01
+	iLocalInFile  byte = 0xfb
+	iEOF          byte = 0xfe
+	iERR          byte = 0xff
 )
 
 // https://dev.mysql.com/doc/internals/en/capability-flags.html#packet-Protocol::CapabilityFlags


### PR DESCRIPTION
### Description
Currently, the driver does not support authentication plugins. I have refactored the code to support plugins and the existing authentication verification to be plugin-based. That is to say that cleartext, native, and old are now plugins.  All tests pass on windows, although I have not tested on linux, so before merging, it would be great if that were vetted as well.  I don't believe this warrants README file changes.

Motivation for this is that my company (MongoDB) needs to use a different authentication mechanism. We have developed the auth plugin separately and tested it against this implementation. 

Thanks for your consideration.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
