### PR TITLE
avoid returning empty MySQLWarnings in odd edge case scenario

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,6 +49,7 @@ Xiangyu Hu <xiangyu.hu at outlook.com>
 Xiaobing Jiang <s7v7nislands at gmail.com>
 Xiuming Chen <cc at cxm.cc>
 Zhenye Xie <xiezhenye at gmail.com>
+Ruben de Vries <ruben at rubensayshi.com>
 
 # Organizations
 

--- a/errors.go
+++ b/errors.go
@@ -122,6 +122,10 @@ func (mc *mysqlConn) getWarnings() (err error) {
 			warnings = append(warnings, warning)
 
 		case io.EOF:
+			if len(warnings) == 0 {
+				return nil
+			}
+
 			return warnings
 
 		default:


### PR DESCRIPTION
### Description
Was running into a weird edge case where the first 'row' was already EOF and result was empty `MySQLWarnings{}` when in `strict=true` mode.

Unfortunately unable to figure out what is really going on or reproduce it in isolation from main project.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
