### PR TITLE
travis: Add MySQL 5.7 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,25 @@ go:
   - 1.7
   - tip
 
+matrix:
+  include:
+    sudo: required
+    dist: trusty
+    go: 1.8
+    services:
+      - docker
+    before_install:
+      - docker pull mysql:5.7
+      - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret mysql:5.7 --innodb_log_file_size=1G
+      - sleep 30
+      - cp .travis/docker.cnf ~/.my.cnf
+      - mysql --print-defaults
+      - .travis/wait_mysql.sh
+    before_script:
+      - export MYSQL_TEST_USER=gotest
+      - export MYSQL_TEST_PASS=secret
+      - export MYSQL_TEST_ADDR=127.0.0.1:3307
+      - export MYSQL_TEST_CONCURRENT=1
+
 before_script:
   - mysql -e 'create database gotest;'

--- a/.travis/docker.cnf
+++ b/.travis/docker.cnf
@@ -1,0 +1,5 @@
+[client]
+user = gotest
+password = secret
+host = 127.0.0.1
+port = 3307

--- a/.travis/wait_mysql.sh
+++ b/.travis/wait_mysql.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+while :
+do
+    sleep 3
+    if mysql -e 'select version()'; then
+        break
+    fi
+done


### PR DESCRIPTION
### Description

Add travis test for MySQL 5.7 using docker.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
