### PR TITLE
Use hostname from DSN as default for TLS if tls=true

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -494,6 +494,10 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 				if boolValue {
 					cfg.TLSConfig = "true"
 					cfg.tls = &tls.Config{}
+					host, _, err := net.SplitHostPort(cfg.Addr)
+					if err == nil {
+						cfg.tls.ServerName = host
+					}
 				} else {
 					cfg.TLSConfig = "false"
 				}


### PR DESCRIPTION
### Description
There is some code to set the `ServerName` in the tlsConfig to the hostname from the DSN, but this
seems to be only used if `tls` is set to something other than true/false/skip-verify.

I think this should also be used if `tls` is set to true.

I don't think `tls=true` really works at all with the current code. The current code does work with custom/false/skip-verify. This surprises me and leads me to wonder my understanding of `tls=true` is correct.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
don't think any change is needed
- [x] Added myself / the copyright holder to the AUTHORS file
I'm already listed