### PR TITLE
Implement driver.Pinger

### DIFF
--- a/connection_go18.go
+++ b/connection_go18.go
@@ -1,0 +1,11 @@
+// +build go1.8
+
+package mysql
+
+import (
+	"context"
+)
+
+func (mc *mysqlConn) Ping(ctx context.Context) error {
+	return mc.writeCommandPacket(comPing)
+}

--- a/connection_go18.go
+++ b/connection_go18.go
@@ -7,5 +7,18 @@ import (
 )
 
 func (mc *mysqlConn) Ping(ctx context.Context) error {
-	return mc.writeCommandPacket(comPing)
+	err := mc.writeCommandPacket(comPing)
+	if err != nil {
+		return err
+	}
+
+	select {
+	case <-ctx.Done():
+		mc.Close()
+		return ctx.Err()
+	default:
+	}
+
+	_, err = mc.readResultOK()
+	return err
 }

--- a/driver_go18_test.go
+++ b/driver_go18_test.go
@@ -3,7 +3,9 @@
 package mysql
 
 import (
+	"context"
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
 	"reflect"
 	"testing"
@@ -185,6 +187,21 @@ func TestSkipResults(t *testing.T) {
 
 		if err := rows.Err(); err != nil {
 			dbt.Error("expected nil; got ", err)
+		}
+	})
+}
+
+func TestPing(t *testing.T) {
+	runTests(t, dsn, func(dbt *DBTest) {
+		mysqlDriver := dbt.db.Driver().(driver.Driver)
+		conn, err := mysqlDriver.Open(dsn)
+		if err != nil {
+			dbt.Fatalf("error opening conn: %s", err)
+		}
+		pinger := conn.(driver.Pinger)
+		err = pinger.Ping(context.Background())
+		if err != nil {
+			dbt.Fatalf("error on ping: %s", err)
 		}
 	})
 }


### PR DESCRIPTION
The `Pinger` interface was added in Go 1.8.

This implementation ignores the context parameter to `Ping` because wiring it in
would be a much larger change.

Fixes #505.