### PR TITLE
Add context support

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,10 +419,9 @@ Version 1.0 of the driver recommended adding `&charset=utf8` (alias for `SET NAM
 See http://dev.mysql.com/doc/refman/5.7/en/charset-unicode.html for more details on MySQL's Unicode support.
 
 ## Context Support
-Since go1.8, context is introduced to `database/sql` for better control on timeout and cancellation.
-New interfaces such as `driver.QueryerContext`, `driver.ExecerContext` are introduced. See more details on [context support to database/sql package](https://golang.org/doc/go1.8#database_sql, "sql").
-
-In Go-MySQL-Driver, we implemented these interfaces for structs `mysqlConn`, `mysqlStmt` and `mysqlTx`.
+Go 1.8 added some `database/sql` methods that accept a `context.Context` parameter for better control over timeout and cancellation.
+See more details on [context support to database/sql package](https://golang.org/doc/go1.8#database_sql, "sql").
+Go-MySQL-Driver supports context deadlines, but not cancellation.
 
 ## Testing / Development
 To run the driver tests you may need to adjust the configuration. See the [Testing Wiki-Page](https://github.com/go-sql-driver/mysql/wiki/Testing "Testing") for details.

--- a/README.md
+++ b/README.md
@@ -418,6 +418,11 @@ Version 1.0 of the driver recommended adding `&charset=utf8` (alias for `SET NAM
 
 See http://dev.mysql.com/doc/refman/5.7/en/charset-unicode.html for more details on MySQL's Unicode support.
 
+## Context Support
+Since go1.8, context is introduced to `database/sql` for better control on timeout and cancellation.
+New interfaces such as `driver.QueryerContext`, `driver.ExecerContext` are introduced. See more details on [context support to database/sql package](https://golang.org/doc/go1.8#database_sql, "sql").
+
+In Go-MySQL-Driver, we implemented these interfaces for structs `mysqlConn`, `mysqlStmt` and `mysqlTx`.
 
 ## Testing / Development
 To run the driver tests you may need to adjust the configuration. See the [Testing Wiki-Page](https://github.com/go-sql-driver/mysql/wiki/Testing "Testing") for details.

--- a/connection.go
+++ b/connection.go
@@ -42,7 +42,7 @@ func (mc *mysqlConn) handleParams() (err error) {
 			charsets := strings.Split(val, ",")
 			for i := range charsets {
 				// ignore errors here - a charset may not exist
-				err = mc.exec("SET NAMES " + charsets[i])
+				err = mc.exec(backgroundCtx(), "SET NAMES "+charsets[i])
 				if err == nil {
 					break
 				}
@@ -53,7 +53,7 @@ func (mc *mysqlConn) handleParams() (err error) {
 
 		// System Vars
 		default:
-			err = mc.exec("SET " + param + "=" + val + "")
+			err = mc.exec(backgroundCtx(), "SET "+param+"="+val+"")
 			if err != nil {
 				return
 			}
@@ -63,12 +63,17 @@ func (mc *mysqlConn) handleParams() (err error) {
 	return
 }
 
+// Begin implements driver.Conn interface
 func (mc *mysqlConn) Begin() (driver.Tx, error) {
+	return mc.beginTx(backgroundCtx(), txOptions{})
+}
+
+func (mc *mysqlConn) beginTx(ctx mysqlContext, opts txOptions) (driver.Tx, error) {
 	if mc.netConn == nil {
 		errLog.Print(ErrInvalidConn)
 		return nil, driver.ErrBadConn
 	}
-	err := mc.exec("START TRANSACTION")
+	err := mc.exec(ctx, "START TRANSACTION")
 	if err == nil {
 		return &mysqlTx{mc}, err
 	}
@@ -79,7 +84,7 @@ func (mc *mysqlConn) Begin() (driver.Tx, error) {
 func (mc *mysqlConn) Close() (err error) {
 	// Makes Close idempotent
 	if mc.netConn != nil {
-		err = mc.writeCommandPacket(comQuit)
+		err = mc.writeCommandPacket(backgroundCtx(), comQuit)
 	}
 
 	mc.cleanup()
@@ -104,12 +109,16 @@ func (mc *mysqlConn) cleanup() {
 }
 
 func (mc *mysqlConn) Prepare(query string) (driver.Stmt, error) {
+	return mc.prepareContext(backgroundCtx(), query)
+}
+
+func (mc *mysqlConn) prepareContext(ctx mysqlContext, query string) (driver.Stmt, error) {
 	if mc.netConn == nil {
 		errLog.Print(ErrInvalidConn)
 		return nil, driver.ErrBadConn
 	}
 	// Send command
-	err := mc.writeCommandPacketStr(comStmtPrepare, query)
+	err := mc.writeCommandPacketStr(ctx, comStmtPrepare, query)
 	if err != nil {
 		return nil, err
 	}
@@ -258,6 +267,10 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 }
 
 func (mc *mysqlConn) Exec(query string, args []driver.Value) (driver.Result, error) {
+	return mc.ExecContext(backgroundCtx(), query, args)
+}
+
+func (mc *mysqlConn) ExecContext(ctx mysqlContext, query string, args []driver.Value) (driver.Result, error) {
 	if mc.netConn == nil {
 		errLog.Print(ErrInvalidConn)
 		return nil, driver.ErrBadConn
@@ -276,7 +289,7 @@ func (mc *mysqlConn) Exec(query string, args []driver.Value) (driver.Result, err
 	mc.affectedRows = 0
 	mc.insertId = 0
 
-	err := mc.exec(query)
+	err := mc.exec(ctx, query)
 	if err == nil {
 		return &mysqlResult{
 			affectedRows: int64(mc.affectedRows),
@@ -287,9 +300,9 @@ func (mc *mysqlConn) Exec(query string, args []driver.Value) (driver.Result, err
 }
 
 // Internal function to execute commands
-func (mc *mysqlConn) exec(query string) error {
+func (mc *mysqlConn) exec(ctx mysqlContext, query string) error {
 	// Send command
-	if err := mc.writeCommandPacketStr(comQuery, query); err != nil {
+	if err := mc.writeCommandPacketStr(ctx, comQuery, query); err != nil {
 		return err
 	}
 
@@ -314,7 +327,12 @@ func (mc *mysqlConn) exec(query string) error {
 	return mc.discardResults()
 }
 
+// Query implements driver.Queryer interface
 func (mc *mysqlConn) Query(query string, args []driver.Value) (driver.Rows, error) {
+	return mc.queryContext(backgroundCtx(), query, args)
+}
+
+func (mc *mysqlConn) queryContext(ctx mysqlContext, query string, args []driver.Value) (driver.Rows, error) {
 	if mc.netConn == nil {
 		errLog.Print(ErrInvalidConn)
 		return nil, driver.ErrBadConn
@@ -331,7 +349,7 @@ func (mc *mysqlConn) Query(query string, args []driver.Value) (driver.Rows, erro
 		query = prepared
 	}
 	// Send command
-	err := mc.writeCommandPacketStr(comQuery, query)
+	err := mc.writeCommandPacketStr(ctx, comQuery, query)
 	if err == nil {
 		// Read Result
 		var resLen int
@@ -362,7 +380,7 @@ func (mc *mysqlConn) Query(query string, args []driver.Value) (driver.Rows, erro
 // The returned byte slice is only valid until the next read
 func (mc *mysqlConn) getSystemVar(name string) ([]byte, error) {
 	// Send command
-	if err := mc.writeCommandPacketStr(comQuery, "SELECT @@"+name); err != nil {
+	if err := mc.writeCommandPacketStr(backgroundCtx(), comQuery, "SELECT @@"+name); err != nil {
 		return nil, err
 	}
 

--- a/connection.go
+++ b/connection.go
@@ -267,10 +267,10 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 }
 
 func (mc *mysqlConn) Exec(query string, args []driver.Value) (driver.Result, error) {
-	return mc.ExecContext(backgroundCtx(), query, args)
+	return mc.execContext(backgroundCtx(), query, args)
 }
 
-func (mc *mysqlConn) ExecContext(ctx mysqlContext, query string, args []driver.Value) (driver.Result, error) {
+func (mc *mysqlConn) execContext(ctx mysqlContext, query string, args []driver.Value) (driver.Result, error) {
 	if mc.netConn == nil {
 		errLog.Print(ErrInvalidConn)
 		return nil, driver.ErrBadConn

--- a/connection_ctx.go
+++ b/connection_ctx.go
@@ -26,7 +26,7 @@ func (mc *mysqlConn) Ping(ctx context.Context) error {
 		return err
 	}
 
-	if _, err := mc.readResultOK(); err != nil {
+	if _, err := mc.readResultOK(ctx); err != nil {
 		errLog.Print(err)
 		return err
 	}

--- a/connection_ctx.go
+++ b/connection_ctx.go
@@ -1,0 +1,48 @@
+// +build go1.8
+
+// Go MySQL Driver - A MySQL-Driver for Go's database/sql package
+//
+// Copyright 2012 The Go-MySQL-Driver Authors. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package mysql
+
+import (
+	"context"
+	"database/sql/driver"
+)
+
+// Ping implements driver.Pinger interface
+func (mc *mysqlConn) Ping(ctx context.Context) error {
+	if mc.netConn == nil {
+		errLog.Print(ErrInvalidConn)
+		return driver.ErrBadConn
+	}
+	if err := mc.writeCommandPacket(ctx, comPing); err != nil {
+		errLog.Print(err)
+		return err
+	}
+
+	if _, err := mc.readResultOK(); err != nil {
+		errLog.Print(err)
+		return err
+	}
+	return nil
+}
+
+// BeginTx implements driver.ConnBeginTx interface
+func (mc *mysqlConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	return mc.beginTx(ctx, txOptions(opts))
+}
+
+func (mc *mysqlConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	return mc.prepareContext(ctx, query)
+}
+
+// QueryContext implements driver.QueryerContext interface
+func (mc *mysqlConn) QueryContext(ctx context.Context, query string, args []driver.Value) (driver.Rows, error) {
+	return mc.queryContext(ctx, query, args)
+}

--- a/connection_ctx_test.go
+++ b/connection_ctx_test.go
@@ -1,0 +1,23 @@
+// +build go1.8
+
+// Go MySQL Driver - A MySQL-Driver for Go's database/sql package
+//
+// Copyright 2012 The Go-MySQL-Driver Authors. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.package mysql
+
+package mysql
+
+import (
+	"database/sql/driver"
+)
+
+var (
+	_ driver.ConnBeginTx        = &mysqlConn{}
+	_ driver.ConnPrepareContext = &mysqlConn{}
+	_ driver.ExecerContext      = &mysqlConn{}
+	_ driver.Pinger             = &mysqlConn{}
+	_ driver.QueryerContext     = &mysqlConn{}
+)

--- a/ctx_backport.go
+++ b/ctx_backport.go
@@ -59,3 +59,12 @@ var background = new(emptyCtx)
 func backgroundCtx() mysqlContext {
 	return background
 }
+
+var deadlineExceeded = deadlineExceededError{}
+
+// deadlineExceededError is copied from Go 1.7's context package.
+type deadlineExceededError struct{}
+
+func (deadlineExceededError) Error() string   { return "context deadline exceeded" }
+func (deadlineExceededError) Timeout() bool   { return true }
+func (deadlineExceededError) Temporary() bool { return true }

--- a/ctx_backport.go
+++ b/ctx_backport.go
@@ -1,0 +1,61 @@
+// +build !go1.8
+
+// Go MySQL Driver - A MySQL-Driver for Go's database/sql package
+//
+// Copyright 2012 The Go-MySQL-Driver Authors. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package mysql
+
+import (
+	"time"
+)
+
+// txOptions is defined for compatibility with Go 1.8's driver.TxOptions struct.
+type txOptions struct {
+	Isolation int
+	ReadOnly  bool
+}
+
+// mysqlContext is a copy of context.Context from Go 1.7 and later.
+type mysqlContext interface {
+	Deadline() (deadline time.Time, ok bool)
+
+	Done() <-chan struct{}
+
+	Err() error
+
+	Value(key interface{}) interface{}
+}
+
+// emptyCtx is copied from Go 1.7's context package.
+type emptyCtx int
+
+func (*emptyCtx) Deadline() (deadline time.Time, ok bool) {
+	return
+}
+
+func (*emptyCtx) Done() <-chan struct{} {
+	return nil
+}
+
+func (*emptyCtx) Err() error {
+	return nil
+}
+
+func (*emptyCtx) Value(key interface{}) interface{} {
+	return nil
+}
+
+func (e *emptyCtx) String() string {
+	return "context.Background"
+}
+
+var background = new(emptyCtx)
+
+func backgroundCtx() mysqlContext {
+	return background
+}

--- a/ctx_go18.go
+++ b/ctx_go18.go
@@ -25,3 +25,5 @@ type mysqlContext context.Context
 func backgroundCtx() mysqlContext {
 	return context.Background()
 }
+
+var deadlineExceeded = context.DeadlineExceeded

--- a/ctx_go18.go
+++ b/ctx_go18.go
@@ -1,0 +1,27 @@
+// +build go1.8
+
+// Go MySQL Driver - A MySQL-Driver for Go's database/sql package
+//
+// Copyright 2012 The Go-MySQL-Driver Authors. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package mysql
+
+import (
+	"context"
+	"database/sql/driver"
+)
+
+// The definitions below are for compatibility with older Go versions.
+// See ctx_backport.go for the definitions used in older Go versions.
+
+type txOptions driver.TxOptions
+
+type mysqlContext context.Context
+
+func backgroundCtx() mysqlContext {
+	return context.Background()
+}

--- a/driver_test.go
+++ b/driver_test.go
@@ -182,6 +182,14 @@ func TestEmptyQuery(t *testing.T) {
 	})
 }
 
+func (dbt *DBTest) TestPing(t *testing.T) {
+	runTests(t, dsn, func(dbt *DBTest) {
+		if err := dbt.db.Ping(); err != nil {
+			dbt.fail("Ping", "Ping", err)
+		}
+	})
+}
+
 func TestCRUD(t *testing.T) {
 	runTests(t, dsn, func(dbt *DBTest) {
 		// Create Table

--- a/infile.go
+++ b/infile.go
@@ -93,7 +93,7 @@ func deferredClose(err *error, closer io.Closer) {
 	}
 }
 
-func (mc *mysqlConn) handleInFileRequest(name string) (err error) {
+func (mc *mysqlConn) handleInFileRequest(ctx mysqlContext, name string) (err error) {
 	var rdr io.Reader
 	var data []byte
 	packetSize := 16 * 1024 // 16KB is small enough for disk readahead and large enough for TCP
@@ -153,7 +153,7 @@ func (mc *mysqlConn) handleInFileRequest(name string) (err error) {
 		for err == nil {
 			n, err = rdr.Read(data[4:])
 			if n > 0 {
-				if ioErr := mc.writePacket(data[:4+n]); ioErr != nil {
+				if ioErr := mc.writePacket(ctx, data[:4+n]); ioErr != nil {
 					return ioErr
 				}
 			}
@@ -167,7 +167,7 @@ func (mc *mysqlConn) handleInFileRequest(name string) (err error) {
 	if data == nil {
 		data = make([]byte, 4)
 	}
-	if ioErr := mc.writePacket(data[:4]); ioErr != nil {
+	if ioErr := mc.writePacket(ctx, data[:4]); ioErr != nil {
 		return ioErr
 	}
 

--- a/infile.go
+++ b/infile.go
@@ -173,10 +173,10 @@ func (mc *mysqlConn) handleInFileRequest(ctx mysqlContext, name string) (err err
 
 	// read OK packet
 	if err == nil {
-		_, err = mc.readResultOK()
+		_, err = mc.readResultOK(ctx)
 		return err
 	}
 
-	mc.readPacket()
+	mc.readPacket(ctx)
 	return err
 }

--- a/packets.go
+++ b/packets.go
@@ -84,12 +84,9 @@ func (mc *mysqlConn) readPacket() ([]byte, error) {
 
 // Write packet buffer 'data'
 func (mc *mysqlConn) writePacket(ctx mysqlContext, data []byte) error {
-	if ctx == nil {
-		panic("context cannot be nil")
-	}
 	ctxDeadline, isCtxDeadlineSet := ctx.Deadline()
 	if isCtxDeadlineSet && !ctxDeadline.After(time.Now()) {
-		return errors.New("timeout")
+		return deadlineExceeded
 	}
 
 	pktLen := len(data) - 4

--- a/packets.go
+++ b/packets.go
@@ -83,7 +83,15 @@ func (mc *mysqlConn) readPacket() ([]byte, error) {
 }
 
 // Write packet buffer 'data'
-func (mc *mysqlConn) writePacket(data []byte) error {
+func (mc *mysqlConn) writePacket(ctx mysqlContext, data []byte) error {
+	if ctx == nil {
+		panic("context cannot be nil")
+	}
+	ctxDeadline, isCtxDeadlineSet := ctx.Deadline()
+	if isCtxDeadlineSet && !ctxDeadline.After(time.Now()) {
+		return errors.New("timeout")
+	}
+
 	pktLen := len(data) - 4
 
 	if pktLen > mc.maxAllowedPacket {
@@ -106,8 +114,16 @@ func (mc *mysqlConn) writePacket(data []byte) error {
 		data[3] = mc.sequence
 
 		// Write packet
+		var timeNow = time.Now()
+		var deadline = timeNow
 		if mc.writeTimeout > 0 {
-			if err := mc.netConn.SetWriteDeadline(time.Now().Add(mc.writeTimeout)); err != nil {
+			deadline = timeNow.Add(mc.writeTimeout)
+			if isCtxDeadlineSet && deadline.After(ctxDeadline) {
+				deadline = ctxDeadline
+			}
+		}
+		if deadline.After(timeNow) {
+			if err := mc.netConn.SetWriteDeadline(deadline); err != nil {
 				return err
 			}
 		}
@@ -223,7 +239,7 @@ func (mc *mysqlConn) readInitPacket() ([]byte, error) {
 
 // Client Authentication Packet
 // http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::HandshakeResponse
-func (mc *mysqlConn) writeAuthPacket(cipher []byte) error {
+func (mc *mysqlConn) writeAuthPacket(ctx mysqlContext, cipher []byte) error {
 	// Adjust client flags based on server support
 	clientFlags := clientProtocol41 |
 		clientSecureConn |
@@ -292,7 +308,7 @@ func (mc *mysqlConn) writeAuthPacket(cipher []byte) error {
 	// http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::SSLRequest
 	if mc.cfg.tls != nil {
 		// Send TLS / SSL request packet
-		if err := mc.writePacket(data[:(4+4+1+23)+4]); err != nil {
+		if err := mc.writePacket(ctx, data[:(4+4+1+23)+4]); err != nil {
 			return err
 		}
 
@@ -334,12 +350,12 @@ func (mc *mysqlConn) writeAuthPacket(cipher []byte) error {
 	data[pos] = 0x00
 
 	// Send Auth packet
-	return mc.writePacket(data)
+	return mc.writePacket(ctx, data)
 }
 
 //  Client old authentication packet
 // http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::AuthSwitchResponse
-func (mc *mysqlConn) writeOldAuthPacket(cipher []byte) error {
+func (mc *mysqlConn) writeOldAuthPacket(ctx mysqlContext, cipher []byte) error {
 	// User password
 	scrambleBuff := scrambleOldPassword(cipher, []byte(mc.cfg.Passwd))
 
@@ -356,12 +372,12 @@ func (mc *mysqlConn) writeOldAuthPacket(cipher []byte) error {
 	copy(data[4:], scrambleBuff)
 	data[4+pktLen-1] = 0x00
 
-	return mc.writePacket(data)
+	return mc.writePacket(ctx, data)
 }
 
 //  Client clear text authentication packet
 // http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::AuthSwitchResponse
-func (mc *mysqlConn) writeClearAuthPacket() error {
+func (mc *mysqlConn) writeClearAuthPacket(ctx mysqlContext) error {
 	// Calculate the packet length and add a tailing 0
 	pktLen := len(mc.cfg.Passwd) + 1
 	data := mc.buf.takeSmallBuffer(4 + pktLen)
@@ -375,12 +391,12 @@ func (mc *mysqlConn) writeClearAuthPacket() error {
 	copy(data[4:], mc.cfg.Passwd)
 	data[4+pktLen-1] = 0x00
 
-	return mc.writePacket(data)
+	return mc.writePacket(ctx, data)
 }
 
 //  Native password authentication method
 // http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::AuthSwitchResponse
-func (mc *mysqlConn) writeNativeAuthPacket(cipher []byte) error {
+func (mc *mysqlConn) writeNativeAuthPacket(ctx mysqlContext, cipher []byte) error {
 	scrambleBuff := scramblePassword(cipher, []byte(mc.cfg.Passwd))
 
 	// Calculate the packet length and add a tailing 0
@@ -395,14 +411,14 @@ func (mc *mysqlConn) writeNativeAuthPacket(cipher []byte) error {
 	// Add the scramble
 	copy(data[4:], scrambleBuff)
 
-	return mc.writePacket(data)
+	return mc.writePacket(ctx, data)
 }
 
 /******************************************************************************
 *                             Command Packets                                 *
 ******************************************************************************/
 
-func (mc *mysqlConn) writeCommandPacket(command byte) error {
+func (mc *mysqlConn) writeCommandPacket(ctx mysqlContext, command byte) error {
 	// Reset Packet Sequence
 	mc.sequence = 0
 
@@ -417,10 +433,10 @@ func (mc *mysqlConn) writeCommandPacket(command byte) error {
 	data[4] = command
 
 	// Send CMD packet
-	return mc.writePacket(data)
+	return mc.writePacket(ctx, data)
 }
 
-func (mc *mysqlConn) writeCommandPacketStr(command byte, arg string) error {
+func (mc *mysqlConn) writeCommandPacketStr(ctx mysqlContext, command byte, arg string) error {
 	// Reset Packet Sequence
 	mc.sequence = 0
 
@@ -439,10 +455,10 @@ func (mc *mysqlConn) writeCommandPacketStr(command byte, arg string) error {
 	copy(data[5:], arg)
 
 	// Send CMD packet
-	return mc.writePacket(data)
+	return mc.writePacket(ctx, data)
 }
 
-func (mc *mysqlConn) writeCommandPacketUint32(command byte, arg uint32) error {
+func (mc *mysqlConn) writeCommandPacketUint32(ctx mysqlContext, command byte, arg uint32) error {
 	// Reset Packet Sequence
 	mc.sequence = 0
 
@@ -463,7 +479,7 @@ func (mc *mysqlConn) writeCommandPacketUint32(command byte, arg uint32) error {
 	data[8] = byte(arg >> 24)
 
 	// Send CMD packet
-	return mc.writePacket(data)
+	return mc.writePacket(ctx, data)
 }
 
 /******************************************************************************
@@ -525,7 +541,7 @@ func (mc *mysqlConn) readResultSetHeaderPacket() (int, error) {
 			return 0, mc.handleErrorPacket(data)
 
 		case iLocalInFile:
-			return 0, mc.handleInFileRequest(string(data[1:]))
+			return 0, mc.handleInFileRequest(backgroundCtx(), string(data[1:]))
 		}
 
 		// column count
@@ -823,7 +839,7 @@ func (stmt *mysqlStmt) readPrepareResultPacket() (uint16, error) {
 }
 
 // http://dev.mysql.com/doc/internals/en/com-stmt-send-long-data.html
-func (stmt *mysqlStmt) writeCommandLongData(paramID int, arg []byte) error {
+func (stmt *mysqlStmt) writeCommandLongData(ctx mysqlContext, paramID int, arg []byte) error {
 	maxLen := stmt.mc.maxAllowedPacket - 1
 	pktLen := maxLen
 
@@ -860,7 +876,7 @@ func (stmt *mysqlStmt) writeCommandLongData(paramID int, arg []byte) error {
 		data[10] = byte(paramID >> 8)
 
 		// Send CMD packet
-		err := stmt.mc.writePacket(data[:4+pktLen])
+		err := stmt.mc.writePacket(ctx, data[:4+pktLen])
 		if err == nil {
 			data = data[pktLen-dataOffset:]
 			continue
@@ -876,7 +892,7 @@ func (stmt *mysqlStmt) writeCommandLongData(paramID int, arg []byte) error {
 
 // Execute Prepared Statement
 // http://dev.mysql.com/doc/internals/en/com-stmt-execute.html
-func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
+func (stmt *mysqlStmt) writeExecutePacket(ctx mysqlContext, args []driver.Value) error {
 	if len(args) != stmt.paramCount {
 		return fmt.Errorf(
 			"argument count mismatch (got: %d; has: %d)",
@@ -1021,7 +1037,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 						)
 						paramValues = append(paramValues, v...)
 					} else {
-						if err := stmt.writeCommandLongData(i, v); err != nil {
+						if err := stmt.writeCommandLongData(ctx, i, v); err != nil {
 							return err
 						}
 					}
@@ -1043,7 +1059,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 					)
 					paramValues = append(paramValues, v...)
 				} else {
-					if err := stmt.writeCommandLongData(i, []byte(v)); err != nil {
+					if err := stmt.writeCommandLongData(ctx, i, []byte(v)); err != nil {
 						return err
 					}
 				}
@@ -1080,7 +1096,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 		data = data[:pos]
 	}
 
-	return mc.writePacket(data)
+	return mc.writePacket(ctx, data)
 }
 
 func (mc *mysqlConn) discardResults() error {

--- a/packets_test.go
+++ b/packets_test.go
@@ -96,7 +96,7 @@ func TestReadPacketSingleByte(t *testing.T) {
 
 	conn.data = []byte{0x01, 0x00, 0x00, 0x00, 0xff}
 	conn.maxReads = 1
-	packet, err := mc.readPacket()
+	packet, err := mc.readPacket(backgroundCtx())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +118,7 @@ func TestReadPacketWrongSequenceID(t *testing.T) {
 	conn.data = []byte{0x01, 0x00, 0x00, 0x00, 0xff}
 	conn.maxReads = 1
 	mc.sequence = 1
-	_, err := mc.readPacket()
+	_, err := mc.readPacket(backgroundCtx())
 	if err != ErrPktSync {
 		t.Errorf("expected ErrPktSync, got %v", err)
 	}
@@ -130,7 +130,7 @@ func TestReadPacketWrongSequenceID(t *testing.T) {
 
 	// too high sequence id
 	conn.data = []byte{0x01, 0x00, 0x00, 0x42, 0xff}
-	_, err = mc.readPacket()
+	_, err = mc.readPacket(backgroundCtx())
 	if err != ErrPktSyncMul {
 		t.Errorf("expected ErrPktSyncMul, got %v", err)
 	}
@@ -166,7 +166,7 @@ func TestReadPacketSplit(t *testing.T) {
 
 	conn.data = data
 	conn.maxReads = 3
-	packet, err := mc.readPacket()
+	packet, err := mc.readPacket(backgroundCtx())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +200,7 @@ func TestReadPacketSplit(t *testing.T) {
 	conn.reads = 0
 	conn.maxReads = 5
 	mc.sequence = 0
-	packet, err = mc.readPacket()
+	packet, err = mc.readPacket(backgroundCtx())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,7 +226,7 @@ func TestReadPacketSplit(t *testing.T) {
 	conn.reads = 0
 	conn.maxReads = 4
 	mc.sequence = 0
-	packet, err = mc.readPacket()
+	packet, err = mc.readPacket(backgroundCtx())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -250,7 +250,7 @@ func TestReadPacketFail(t *testing.T) {
 	// illegal empty (stand-alone) packet
 	conn.data = []byte{0x00, 0x00, 0x00, 0x00}
 	conn.maxReads = 1
-	_, err := mc.readPacket()
+	_, err := mc.readPacket(backgroundCtx())
 	if err != driver.ErrBadConn {
 		t.Errorf("expected ErrBadConn, got %v", err)
 	}
@@ -262,7 +262,7 @@ func TestReadPacketFail(t *testing.T) {
 
 	// fail to read header
 	conn.closed = true
-	_, err = mc.readPacket()
+	_, err = mc.readPacket(backgroundCtx())
 	if err != driver.ErrBadConn {
 		t.Errorf("expected ErrBadConn, got %v", err)
 	}
@@ -275,7 +275,7 @@ func TestReadPacketFail(t *testing.T) {
 
 	// fail to read body
 	conn.maxReads = 1
-	_, err = mc.readPacket()
+	_, err = mc.readPacket(backgroundCtx())
 	if err != driver.ErrBadConn {
 		t.Errorf("expected ErrBadConn, got %v", err)
 	}

--- a/statement.go
+++ b/statement.go
@@ -69,24 +69,24 @@ func (stmt *mysqlStmt) execContext(ctx mysqlContext, args []driver.Value) (drive
 	mc.insertId = 0
 
 	// Read Result
-	resLen, err := mc.readResultSetHeaderPacket()
+	resLen, err := mc.readResultSetHeaderPacket(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	if resLen > 0 {
 		// Columns
-		if err = mc.readUntilEOF(); err != nil {
+		if err = mc.readUntilEOF(ctx); err != nil {
 			return nil, err
 		}
 
 		// Rows
-		if err := mc.readUntilEOF(); err != nil {
+		if err := mc.readUntilEOF(ctx); err != nil {
 			return nil, err
 		}
 	}
 
-	if err := mc.discardResults(); err != nil {
+	if err := mc.discardResults(ctx); err != nil {
 		return nil, err
 	}
 
@@ -115,7 +115,7 @@ func (stmt *mysqlStmt) queryContext(ctx mysqlContext, args []driver.Value) (driv
 	mc := stmt.mc
 
 	// Read Result
-	resLen, err := mc.readResultSetHeaderPacket()
+	resLen, err := mc.readResultSetHeaderPacket(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -129,11 +129,11 @@ func (stmt *mysqlStmt) queryContext(ctx mysqlContext, args []driver.Value) (driv
 		// Columns
 		// If not cached, read them and cache them
 		if len(stmt.columns) == 0 {
-			rows.rs.columns, err = mc.readColumns(resLen)
+			rows.rs.columns, err = mc.readColumns(ctx, resLen)
 			stmt.columns = append(stmt.columns, rows.rs.columns)
 		} else {
 			rows.rs.columns = stmt.columns[0]
-			err = mc.readUntilEOF()
+			err = mc.readUntilEOF(ctx)
 		}
 	} else {
 		rows.rs.done = true

--- a/statement.go
+++ b/statement.go
@@ -23,6 +23,7 @@ type mysqlStmt struct {
 	columns    [][]mysqlField // cached from the first query
 }
 
+// Close implements driver.Conn interface
 func (stmt *mysqlStmt) Close() error {
 	if stmt.mc == nil || stmt.mc.netConn == nil {
 		// driver.Stmt.Close can be called more than once, thus this function
@@ -32,11 +33,12 @@ func (stmt *mysqlStmt) Close() error {
 		return driver.ErrBadConn
 	}
 
-	err := stmt.mc.writeCommandPacketUint32(comStmtClose, stmt.id)
+	err := stmt.mc.writeCommandPacketUint32(backgroundCtx(), comStmtClose, stmt.id)
 	stmt.mc = nil
 	return err
 }
 
+// NumInput implements driver.Stmt interface
 func (stmt *mysqlStmt) NumInput() int {
 	return stmt.paramCount
 }
@@ -45,13 +47,18 @@ func (stmt *mysqlStmt) ColumnConverter(idx int) driver.ValueConverter {
 	return converter{}
 }
 
+// Exec implements driver.Stmt interface
 func (stmt *mysqlStmt) Exec(args []driver.Value) (driver.Result, error) {
+	return stmt.execContext(backgroundCtx(), args)
+}
+
+func (stmt *mysqlStmt) execContext(ctx mysqlContext, args []driver.Value) (driver.Result, error) {
 	if stmt.mc.netConn == nil {
 		errLog.Print(ErrInvalidConn)
 		return nil, driver.ErrBadConn
 	}
 	// Send command
-	err := stmt.writeExecutePacket(args)
+	err := stmt.writeExecutePacket(ctx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -89,13 +96,18 @@ func (stmt *mysqlStmt) Exec(args []driver.Value) (driver.Result, error) {
 	}, nil
 }
 
+// Query implements driver.Stmt interface
 func (stmt *mysqlStmt) Query(args []driver.Value) (driver.Rows, error) {
+	return stmt.queryContext(backgroundCtx(), args)
+}
+
+func (stmt *mysqlStmt) queryContext(ctx mysqlContext, args []driver.Value) (driver.Rows, error) {
 	if stmt.mc.netConn == nil {
 		errLog.Print(ErrInvalidConn)
 		return nil, driver.ErrBadConn
 	}
 	// Send command
-	err := stmt.writeExecutePacket(args)
+	err := stmt.writeExecutePacket(ctx, args)
 	if err != nil {
 		return nil, err
 	}

--- a/statement_ctx.go
+++ b/statement_ctx.go
@@ -16,11 +16,19 @@ import (
 )
 
 // ExecContent implements driver.StmtExecContext interface
-func (stmt *mysqlStmt) ExecContext(ctx context.Context, args []driver.Value) (driver.Result, error) {
-	return stmt.execContext(ctx, args)
+func (stmt *mysqlStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	values, err := namedValueToValue(args)
+	if err != nil {
+		return nil, err
+	}
+	return stmt.execContext(ctx, values)
 }
 
 // QueryContext implements driver.StmtQueryContext interface
-func (stmt *mysqlStmt) QueryContext(ctx context.Context, args []driver.Value) (driver.Rows, error) {
-	return stmt.queryContext(ctx, args)
+func (stmt *mysqlStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	values, err := namedValueToValue(args)
+	if err != nil {
+		return nil, err
+	}
+	return stmt.queryContext(ctx, values)
 }

--- a/statement_ctx.go
+++ b/statement_ctx.go
@@ -1,0 +1,26 @@
+// +build go1.8
+
+// Go MySQL Driver - A MySQL-Driver for Go's database/sql package
+//
+// Copyright 2012 The Go-MySQL-Driver Authors. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package mysql
+
+import (
+	"context"
+	"database/sql/driver"
+)
+
+// ExecContent implements driver.StmtExecContext interface
+func (stmt *mysqlStmt) ExecContext(ctx context.Context, args []driver.Value) (driver.Result, error) {
+	return stmt.execContext(ctx, args)
+}
+
+// QueryContext implements driver.StmtQueryContext interface
+func (stmt *mysqlStmt) QueryContext(ctx context.Context, args []driver.Value) (driver.Rows, error) {
+	return stmt.queryContext(ctx, args)
+}

--- a/statement_ctx_test.go
+++ b/statement_ctx_test.go
@@ -1,0 +1,20 @@
+// +build go1.8
+
+// Go MySQL Driver - A MySQL-Driver for Go's database/sql package
+//
+// Copyright 2012 The Go-MySQL-Driver Authors. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.package mysql
+
+package mysql
+
+import (
+	"database/sql/driver"
+)
+
+var (
+	_ driver.StmtExecContext  = &mysqlStmt{}
+	_ driver.StmtQueryContext = &mysqlStmt{}
+)

--- a/transaction.go
+++ b/transaction.go
@@ -12,20 +12,22 @@ type mysqlTx struct {
 	mc *mysqlConn
 }
 
+// Commit implements driver.Tx interface
 func (tx *mysqlTx) Commit() (err error) {
 	if tx.mc == nil || tx.mc.netConn == nil {
 		return ErrInvalidConn
 	}
-	err = tx.mc.exec("COMMIT")
+	err = tx.mc.exec(backgroundCtx(), "COMMIT")
 	tx.mc = nil
 	return
 }
 
+// Rollback implements driver.Tx interface
 func (tx *mysqlTx) Rollback() (err error) {
 	if tx.mc == nil || tx.mc.netConn == nil {
 		return ErrInvalidConn
 	}
-	err = tx.mc.exec("ROLLBACK")
+	err = tx.mc.exec(backgroundCtx(), "ROLLBACK")
 	tx.mc = nil
 	return
 }


### PR DESCRIPTION
### Description

This pull request is based on @oscarzhao's work in #551, but uses a
different method of achieving backward compatibility with older Go versions
to reduce duplicated code. oscarzhao is still listed as the commit author for the first commit.

For backward compatibility with Go versions < 1.8, the file `ctx_backport.go`
contains a redefinition of `context.Context` as well as a few other things.
`ctx_go18.go` contains definitions that simply alias the actual standard library
definitions. The result is that the vast majority of the code can be shared
amongst Go versions.

This PR also adds context support to the read side of things, which wasn't in #551.

 ### Checklist

- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file