### PR TITLE
travis: submit coverage to coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ go:
   - 1.8
   - tip
 
+before_install:
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/mattn/goveralls
+
 matrix:
   include:
     - env: DB=MYSQL57
@@ -76,6 +80,7 @@ matrix:
 before_script:
   - mysql -e 'create database gotest;'
 script:
-  - go test -v
+  - go test -v -covermode=count -coverprofile=coverage.out
   - go vet ./...
   - test -z "$(gofmt -d -s . | tee /dev/stderr)"
+  - $HOME/gopath/bin/goveralls  -coverprofile=coverage.out -service=travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
       services:
         - docker
       before_install:
+        - go get golang.org/x/tools/cmd/cover
+        - go get github.com/mattn/goveralls
         - docker pull mysql:5.7
         - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
           mysql:5.7 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB
@@ -43,6 +45,8 @@ matrix:
       services:
         - docker
       before_install:
+        - go get golang.org/x/tools/cmd/cover
+        - go get github.com/mattn/goveralls
         - docker pull mariadb:5.5
         - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
           mariadb:5.5 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB
@@ -63,6 +67,8 @@ matrix:
       services:
         - docker
       before_install:
+        - go get golang.org/x/tools/cmd/cover
+        - go get github.com/mattn/goveralls
         - docker pull mariadb:10.1
         - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
           mariadb:10.1 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB
@@ -83,4 +89,4 @@ script:
   - go test -v -covermode=count -coverprofile=coverage.out
   - go vet ./...
   - test -z "$(gofmt -d -s . | tee /dev/stderr)"
-  - $HOME/gopath/bin/goveralls  -coverprofile=coverage.out -service=travis-ci
+  - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci


### PR DESCRIPTION
### Description
This adds support for coveralls.io, a site to track test coverage.
It reveals what we all feared already: our test coverage is quite low.
Our code tries to handle many edge cases for a variety of configurations, which makes it quite hard to test properly with Travis CI. Our goal should nonetheless be to greatly improve our test coverage. This external service will assist and remind us. 

An overview for this repo is available here: https://coveralls.io/github/go-sql-driver/mysql

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
