### PR TITLE
add rejectReadOnly option (to fix AWS Aurora failover)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,4 +59,5 @@ Zhenye Xie <xiezhenye at gmail.com>
 
 Barracuda Networks, Inc.
 Google Inc.
+Keybase Inc.
 Stripe Inc.

--- a/README.md
+++ b/README.md
@@ -267,6 +267,29 @@ Default:        0
 
 I/O read timeout. The value must be a decimal number with a unit suffix (*"ms"*, *"s"*, *"m"*, *"h"*), such as *"30s"*, *"0.5m"* or *"1m30s"*.
 
+##### `rejectReadOnly`
+
+```
+Type:           bool
+Valid Values:   true, false
+Default:        false
+```
+
+
+RejectreadOnly causes mysql driver to reject read-only connections. This is
+specifically for AWS Aurora: During a failover, there seems to be a race
+condition on Aurora, where we get connected to the [old master before
+failover], i.e. the [new read-only slave after failover].
+
+Note that this should be a fairly rare case, as automatic failover normally
+happens when master is down, and the race condition shouldn't happen unless it
+comes back up online as soon as the failover is kicked off. But it's pretty
+easy to reproduce using a manual failover. In case this happens, we should
+reconnect to the Aurora cluster by returning a driver.ErrBadConnection.
+
+tl;dr: Set this if you are using Aurora.
+
+
 ##### `strict`
 
 ```

--- a/README.md
+++ b/README.md
@@ -276,14 +276,14 @@ Default:        false
 ```
 
 
-RejectreadOnly causes the driver to reject read-only connections. This is for a
-possible race condition during an automatic failover, where the mysql client
-gets connected to a read-only replica after the failover. 
+`rejectreadOnly=true` causes the driver to reject read-only connections. This
+is for a possible race condition during an automatic failover, where the mysql
+client gets connected to a read-only replica after the failover. 
 
 Note that this should be a fairly rare case, as an automatic failover normally
 happens when the primary is down, and the race condition shouldn't happen
 unless it comes back up online as soon as the failover is kicked off. On the
-other hand, when this happens, an mysql application can get stuck on a
+other hand, when this happens, a MySQL application can get stuck on a
 read-only connection until restarted. It is however fairly easy to reproduce,
 for example, using a manual failover on AWS Aurora's MySQL-compatible cluster.
 

--- a/README.md
+++ b/README.md
@@ -276,18 +276,20 @@ Default:        false
 ```
 
 
-RejectreadOnly causes mysql driver to reject read-only connections. This is
-specifically for AWS Aurora: During a failover, there seems to be a race
-condition on Aurora, where we get connected to the [old master before
-failover], i.e. the [new read-only slave after failover].
+RejectreadOnly causes the driver to reject read-only connections. This is for a
+possible race condition during an automatic failover, where the mysql client
+gets connected to a read-only replica after the failover. 
 
-Note that this should be a fairly rare case, as automatic failover normally
-happens when master is down, and the race condition shouldn't happen unless it
-comes back up online as soon as the failover is kicked off. But it's pretty
-easy to reproduce using a manual failover. In case this happens, we should
-reconnect to the Aurora cluster by returning a driver.ErrBadConnection.
+Note that this should be a fairly rare case, as an automatic failover normally
+happens when the primary is down, and the race condition shouldn't happen
+unless it comes back up online as soon as the failover is kicked off. On the
+other hand, when this happens, an mysql application can get stuck on a
+read-only connection until restarted. It is however fairly easy to reproduce,
+for example, using a manual failover on AWS Aurora's MySQL-compatible cluster.
 
-tl;dr: Set this if you are using Aurora.
+If you are not relying on read-only transactions to reject writes that aren't
+supposed to happen, setting this on some MySQL providers (such as AWS Aurora)
+is safer for failovers.
 
 
 ##### `strict`

--- a/dsn.go
+++ b/dsn.go
@@ -53,7 +53,7 @@ type Config struct {
 	InterpolateParams       bool // Interpolate placeholders into query string
 	MultiStatements         bool // Allow multiple statements in one query
 	ParseTime               bool // Parse time values to time.Time
-	RejectReadOnly          bool // Reject read-only connections; see README.md
+	RejectReadOnly          bool // Reject read-only connections
 	Strict                  bool // Return warnings as errors
 }
 

--- a/dsn.go
+++ b/dsn.go
@@ -53,22 +53,8 @@ type Config struct {
 	InterpolateParams       bool // Interpolate placeholders into query string
 	MultiStatements         bool // Allow multiple statements in one query
 	ParseTime               bool // Parse time values to time.Time
+	RejectReadOnly          bool // Reject read-only connections; see README.md
 	Strict                  bool // Return warnings as errors
-
-	// RejectreadOnly causes mysql driver to reject read-only connections. This
-	// is specifically for AWS Aurora: During a failover, there seems to be a
-	// race condition on Aurora, where we get connected to the [old master
-	// before failover], i.e. the [new read-only slave after failover].
-	//
-	// Note that this should be a fairly rare case, as automatic failover
-	// normally happens when master is down, and the race condition shouldn't
-	// happen unless it comes back up online as soon as the failover is kicked
-	// off. But it's pretty easy to reproduce using a manual failover. In case
-	// this happens, we should reconnect to the Aurora cluster by returning a
-	// driver.ErrBadConnection.
-	//
-	// tl;dr: Set this if you are using Aurora.
-	RejectReadOnly bool
 }
 
 // FormatDSN formats the given Config into a DSN string which can be passed to

--- a/packets.go
+++ b/packets.go
@@ -551,6 +551,11 @@ func (mc *mysqlConn) handleErrorPacket(data []byte) error {
 	// Error Number [16 bit uint]
 	errno := binary.LittleEndian.Uint16(data[1:3])
 
+	// 1792: ER_CANT_EXECUTE_IN_READ_ONLY_TRANSACTION
+	if errno == 1792 && mc.cfg.RejectReadOnly {
+		return driver.ErrBadConn
+	}
+
 	pos := 3
 
 	// SQL State [optional: # + 5bytes string]

--- a/packets.go
+++ b/packets.go
@@ -556,8 +556,8 @@ func (mc *mysqlConn) handleErrorPacket(data []byte) error {
 		// Oops; we are connected to a read-only connection, and won't be able
 		// to issue any write statements. Since RejectReadOnly is configured,
 		// we throw away this connection hoping this one would have write
-		// permission. This is specifically for an AWS Aurora behavior during
-		// failover. See README.md for more.
+		// permission. This is specifically for a possible race condition
+		// during failover (e.g. on AWS Aurora). See README.md for more.
 		//
 		// We explicitly close the connection before returning
 		// driver.ErrBadConn to ensure that `database/sql` purges this

--- a/packets.go
+++ b/packets.go
@@ -553,6 +553,16 @@ func (mc *mysqlConn) handleErrorPacket(data []byte) error {
 
 	// 1792: ER_CANT_EXECUTE_IN_READ_ONLY_TRANSACTION
 	if errno == 1792 && mc.cfg.RejectReadOnly {
+		// Oops; we are connected to a read-only connection, and won't be able
+		// to issue any write statements. Since RejectReadOnly is configured,
+		// we throw away this connection hoping this one would have write
+		// permission. This is specifically for an AWS Aurora behavior during
+		// failover. See README.md for more.
+		//
+		// We explicitly close the connection before returning
+		// driver.ErrBadConn to ensure that `database/sql` purges this
+		// connection and initiates a new one for next statement next time.
+		mc.Close()
 		return driver.ErrBadConn
 	}
 


### PR DESCRIPTION
### Description

Hi there, we use this (awesome) driver with AWS Aurora's MySQL-compatible Cluster. In some recent manual tests with Aurora's automatic failover, we noticed that there might be a race condition in Aurora's failover implementation, where our servers (mysql client) get connected to a read-only replica after failover.

This should be a rare case, since normally during a failover the primary is unreachable before failover to the read replica, and reconnecting should only succeed with the new primary (writable) instance). However, in an event where the old primary (new read-only) replica recovers before failover completes, this could still happen. In addition, if we manually trigger a failover from AWS's web control panel, both replicas are still accessible, making this is very easy to reproduce.

This PR adds a `rejectReadOnly` option to DSN, which when set to `true`, causes the driver to drop the connection if error 1792 (`ER_CANT_EXECUTE_IN_READ_ONLY_TRANSACTION`) is received. This way, the connection pool (from `database/sql`) purges the connection, and makes a new one for the next statement, bringing the storage layer back to healthy state.

This is apparently an AWS bug, and they should be fixing it. We are making this PR because 1) it's a much longer process to get AWS to fix the bug (assuming they acknowledge), while adding an option to the driver is a quick fix for everybody; 2) if the same behavior happens with other service providers, this can be a useful remedy too.


### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file