### PR TITLE
defer getWarnings() after fetching resultsets.

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -31,6 +31,7 @@ type mysqlConn struct {
 	sequence         uint8
 	parseTime        bool
 	strict           bool
+	warningCount     uint16
 }
 
 // Handles parameters set in DSN after the connection is established

--- a/driver.go
+++ b/driver.go
@@ -175,6 +175,10 @@ func handleAuthResult(mc *mysqlConn, oldCipher []byte) error {
 		}
 		_, err = mc.readResultOK()
 	}
+
+	if err == nil && mc.strict && mc.warningCount > 0 {
+		return mc.getWarnings()
+	}
 	return err
 }
 

--- a/errors.go
+++ b/errors.go
@@ -89,6 +89,7 @@ type MySQLWarning struct {
 }
 
 func (mc *mysqlConn) getWarnings() (err error) {
+	mc.warningCount = 0
 	rows, err := mc.Query("SHOW WARNINGS", nil)
 	if err != nil {
 		return

--- a/infile.go
+++ b/infile.go
@@ -175,6 +175,9 @@ func (mc *mysqlConn) handleInFileRequest(name string) (err error) {
 	// read OK packet
 	if err == nil {
 		_, err = mc.readResultOK()
+		if err == nil && mc.strict && mc.warningCount > 0 {
+			err = mc.getWarnings()
+		}
 		return err
 	}
 


### PR DESCRIPTION
### Description

Don't query "SHOW WARNINGS" in `handleOkPacket()`.  Defer it to end of query.

fixes #602, maybe.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
