### PR TITLE
parse dsn fix

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -288,11 +288,16 @@ func ParseDSN(dsn string) (cfg *Config, err error) {
 					if dsn[j] == '@' {
 						// username[:password]
 						// Find the first ':' in dsn[:j]
-						for k = 0; k < j; k++ {
+						for k = j - 1; k >= 0; k-- {
 							if dsn[k] == ':' {
 								cfg.Passwd = dsn[k+1 : j]
 								break
 							}
+						}
+
+						// no ':' in dsn[:j]
+						if k < 0 {
+							k = j
 						}
 						cfg.User = dsn[:k]
 

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -24,6 +24,9 @@ var testDSNs = []struct {
 	"username:password@protocol(address)/dbname?param=value",
 	&Config{User: "username", Passwd: "password", Net: "protocol", Addr: "address", DBName: "dbname", Params: map[string]string{"param": "value"}, Collation: "utf8_general_ci", Loc: time.UTC},
 }, {
+	"user:name:password@protocol(address)/dbname?param=value",
+	&Config{User: "user:name", Passwd: "password", Net: "protocol", Addr: "address", DBName: "dbname", Params: map[string]string{"param": "value"}, Collation: "utf8_general_ci", Loc: time.UTC},
+}, {
 	"username:password@protocol(address)/dbname?param=value&columnsWithAlias=true",
 	&Config{User: "username", Passwd: "password", Net: "protocol", Addr: "address", DBName: "dbname", Params: map[string]string{"param": "value"}, Collation: "utf8_general_ci", Loc: time.UTC, ColumnsWithAlias: true},
 }, {


### PR DESCRIPTION
#591 

### Description
I encounter the case ':' in username, ParseDSN can't get the expect result.

my scripts parse "[username[:password]" part reversely, and compatible with old code.



## Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
