### PR TITLE
Optimize value conversions back and forth between driver.Value and concrete types.

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -993,7 +993,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 
 			// cache types and values
 			var err error
-			switch v := arg.(type) {
+			switch v := unpack(arg).(type) {
 			case int64:
 				paramValues = stmt.writeInt(paramTypes[i+i:], paramValues, v)
 

--- a/packets.go
+++ b/packets.go
@@ -992,108 +992,53 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 			}
 
 			// cache types and values
+			var err error
 			switch v := arg.(type) {
 			case int64:
-				paramTypes[i+i] = fieldTypeLongLong
-				paramTypes[i+i+1] = 0x00
-
-				if cap(paramValues)-len(paramValues)-8 >= 0 {
-					paramValues = paramValues[:len(paramValues)+8]
-					binary.LittleEndian.PutUint64(
-						paramValues[len(paramValues)-8:],
-						uint64(v),
-					)
-				} else {
-					paramValues = append(paramValues,
-						uint64ToBytes(uint64(v))...,
-					)
-				}
+				paramValues = stmt.writeInt(paramTypes[i+i:], paramValues, v)
 
 			case float64:
-				paramTypes[i+i] = fieldTypeDouble
-				paramTypes[i+i+1] = 0x00
-
-				if cap(paramValues)-len(paramValues)-8 >= 0 {
-					paramValues = paramValues[:len(paramValues)+8]
-					binary.LittleEndian.PutUint64(
-						paramValues[len(paramValues)-8:],
-						math.Float64bits(v),
-					)
-				} else {
-					paramValues = append(paramValues,
-						uint64ToBytes(math.Float64bits(v))...,
-					)
-				}
+				paramValues = stmt.writeFloat(paramTypes[i+i:], paramValues, v)
 
 			case bool:
-				paramTypes[i+i] = fieldTypeTiny
-				paramTypes[i+i+1] = 0x00
-
-				if v {
-					paramValues = append(paramValues, 0x01)
-				} else {
-					paramValues = append(paramValues, 0x00)
-				}
+				paramValues = stmt.writeBool(paramTypes[i+i:], paramValues, v)
 
 			case []byte:
-				// Common case (non-nil value) first
-				if v != nil {
-					paramTypes[i+i] = fieldTypeString
-					paramTypes[i+i+1] = 0x00
-
-					if len(v) < mc.maxAllowedPacket-pos-len(paramValues)-(len(args)-(i+1))*64 {
-						paramValues = appendLengthEncodedInteger(paramValues,
-							uint64(len(v)),
-						)
-						paramValues = append(paramValues, v...)
-					} else {
-						if err := stmt.writeCommandLongData(i, v); err != nil {
-							return err
-						}
-					}
-					continue
-				}
-
-				// Handle []byte(nil) as a NULL value
-				nullMask[i/8] |= 1 << (uint(i) & 7)
-				paramTypes[i+i] = fieldTypeNULL
-				paramTypes[i+i+1] = 0x00
+				paramValues, err = stmt.writeBytes(paramTypes[i+i:], paramValues, nullMask, pos, len(args), i, v)
 
 			case string:
-				paramTypes[i+i] = fieldTypeString
-				paramTypes[i+i+1] = 0x00
-
-				if len(v) < mc.maxAllowedPacket-pos-len(paramValues)-(len(args)-(i+1))*64 {
-					paramValues = appendLengthEncodedInteger(paramValues,
-						uint64(len(v)),
-					)
-					paramValues = append(paramValues, v...)
-				} else {
-					if err := stmt.writeCommandLongData(i, []byte(v)); err != nil {
-						return err
-					}
-				}
+				paramValues, err = stmt.writeString(paramTypes[i+i:], paramValues, nullMask, pos, len(args), i, v)
 
 			case time.Time:
-				paramTypes[i+i] = fieldTypeString
-				paramTypes[i+i+1] = 0x00
+				paramValues = stmt.writeTime(paramTypes[i+i:], paramValues, v)
 
-				var a [64]byte
-				var b = a[:0]
+				// also handle pointers so the application may use this as an
+				// optimization to avoid dynamic memory allocations caused by
+				// runtime.convT2E when generating the argument list.
+			case *int64:
+				paramValues = stmt.writeInt(paramTypes[i+i:], paramValues, *v)
 
-				if v.IsZero() {
-					b = append(b, "0000-00-00"...)
-				} else {
-					b = v.In(mc.cfg.Loc).AppendFormat(b, timeFormat)
-				}
+			case *float64:
+				paramValues = stmt.writeFloat(paramTypes[i+i:], paramValues, *v)
 
-				paramValues = appendLengthEncodedInteger(paramValues,
-					uint64(len(b)),
-				)
-				paramValues = append(paramValues, b...)
+			case *bool:
+				paramValues = stmt.writeBool(paramTypes[i+i:], paramValues, *v)
+
+			case *[]byte:
+				paramValues, err = stmt.writeBytes(paramTypes[i+i:], paramValues, nullMask, pos, len(args), i, *v)
+
+			case *string:
+				paramValues, err = stmt.writeString(paramTypes[i+i:], paramValues, nullMask, pos, len(args), i, *v)
+
+			case *time.Time:
+				paramValues = stmt.writeTime(paramTypes[i+i:], paramValues, *v)
 
 			default:
-				return fmt.Errorf("can not convert type: %T", arg)
+				err = fmt.Errorf("can not convert type: %T", arg)
+			}
+
+			if err != nil {
+				return err
 			}
 		}
 
@@ -1109,6 +1054,121 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 	}
 
 	return mc.writePacket(data)
+}
+
+func (stmt *mysqlStmt) writeInt(paramTypes []byte, paramValues []byte, value int64) []byte {
+	paramTypes[0] = fieldTypeLongLong
+	paramTypes[1] = 0x00
+
+	if cap(paramValues)-len(paramValues)-8 >= 0 {
+		paramValues = paramValues[:len(paramValues)+8]
+		binary.LittleEndian.PutUint64(
+			paramValues[len(paramValues)-8:],
+			uint64(value),
+		)
+	} else {
+		paramValues = append(paramValues,
+			uint64ToBytes(uint64(value))...,
+		)
+	}
+
+	return paramValues
+}
+
+func (stmt *mysqlStmt) writeFloat(paramTypes []byte, paramValues []byte, value float64) []byte {
+	paramTypes[0] = fieldTypeDouble
+	paramTypes[1] = 0x00
+
+	if cap(paramValues)-len(paramValues)-8 >= 0 {
+		paramValues = paramValues[:len(paramValues)+8]
+		binary.LittleEndian.PutUint64(
+			paramValues[len(paramValues)-8:],
+			math.Float64bits(value),
+		)
+	} else {
+		paramValues = append(paramValues,
+			uint64ToBytes(math.Float64bits(value))...,
+		)
+	}
+
+	return paramValues
+}
+
+func (stmt *mysqlStmt) writeBool(paramTypes []byte, paramValues []byte, value bool) []byte {
+	paramTypes[0] = fieldTypeTiny
+	paramTypes[1] = 0x00
+
+	if value {
+		paramValues = append(paramValues, 0x01)
+	} else {
+		paramValues = append(paramValues, 0x00)
+	}
+
+	return paramValues
+}
+
+func (stmt *mysqlStmt) writeBytes(paramTypes []byte, paramValues []byte, nullMask []byte, pos int, argc int, index int, value []byte) ([]byte, error) {
+	// Common case (non-nil value) first
+	if value != nil {
+		paramTypes[0] = fieldTypeString
+		paramTypes[1] = 0x00
+
+		if len(value) < stmt.mc.maxAllowedPacket-pos-len(paramValues)-(argc-(index+1))*64 {
+			paramValues = appendLengthEncodedInteger(paramValues,
+				uint64(len(value)),
+			)
+			paramValues = append(paramValues, value...)
+		} else {
+			if err := stmt.writeCommandLongData(index, value); err != nil {
+				return paramValues, err
+			}
+		}
+	} else {
+		// Handle []byte(nil) as a NULL value
+		nullMask[index/8] |= 1 << (uint(index) & 7)
+		paramTypes[0] = fieldTypeNULL
+		paramTypes[1] = 0x00
+	}
+	return paramValues, nil
+}
+
+func (stmt *mysqlStmt) writeString(paramTypes []byte, paramValues []byte, nullMask []byte, pos int, argc int, index int, value string) ([]byte, error) {
+	paramTypes[0] = fieldTypeString
+	paramTypes[1] = 0x00
+
+	if len(value) < stmt.mc.maxAllowedPacket-pos-len(paramValues)-(argc-(index+1))*64 {
+		paramValues = appendLengthEncodedInteger(paramValues,
+			uint64(len(value)),
+		)
+		paramValues = append(paramValues, value...)
+	} else {
+		if err := stmt.writeCommandLongData(index, []byte(value)); err != nil {
+			return nil, err
+		}
+	}
+
+	return paramValues, nil
+}
+
+func (stmt *mysqlStmt) writeTime(paramTypes []byte, paramValues []byte, value time.Time) []byte {
+	paramTypes[0] = fieldTypeString
+	paramTypes[1] = 0x00
+
+	var a [64]byte
+	var b = a[:0]
+
+	if value.IsZero() {
+		b = append(b, "0000-00-00"...)
+	} else {
+		b = value.In(stmt.mc.cfg.Loc).AppendFormat(b, timeFormat)
+	}
+
+	paramValues = appendLengthEncodedInteger(paramValues,
+		uint64(len(b)),
+	)
+	paramValues = append(paramValues, b...)
+
+	return paramValues
 }
 
 func (mc *mysqlConn) discardResults() error {

--- a/packets.go
+++ b/packets.go
@@ -993,7 +993,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 
 			// cache types and values
 			var err error
-			switch v := unpack(arg).(type) {
+			switch v := unhack(arg).(type) {
 			case int64:
 				paramValues = stmt.writeInt(paramTypes[i+i:], paramValues, v)
 

--- a/statement.go
+++ b/statement.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"reflect"
 	"strconv"
+	"time"
 )
 
 type mysqlStmt struct {
@@ -41,7 +42,7 @@ func (stmt *mysqlStmt) NumInput() int {
 }
 
 func (stmt *mysqlStmt) ColumnConverter(idx int) driver.ValueConverter {
-	return converter{}
+	return &converter{}
 }
 
 func (stmt *mysqlStmt) Exec(args []driver.Value) (driver.Result, error) {
@@ -132,8 +133,13 @@ func (stmt *mysqlStmt) query(args []driver.Value) (*binaryRows, error) {
 
 type converter struct{}
 
-func (c converter) ConvertValue(v interface{}) (driver.Value, error) {
+func (c *converter) ConvertValue(v interface{}) (driver.Value, error) {
 	if driver.IsValue(v) {
+		return v, nil
+	}
+
+	switch v.(type) {
+	case *[]byte, *bool, *float64, *int64, *string, *time.Time:
 		return v, nil
 	}
 


### PR DESCRIPTION
### Description
Due to issues with the design of the driver API (see https://github.com/golang/go/issues/6918) there are dynamic memory allocations that happen when converting back and forth between the concrete types and `driver.Value`.
The change presented here allows the application to work around this situation by passing values by pointer to pre-allocated values of the base types supported by the database/sql package.

Here's a profile showing the issue:
<img width="219" alt="screen shot 2017-06-10 at 2 05 25 pm" src="https://user-images.githubusercontent.com/865510/27006320-ef1defbe-4de5-11e7-9567-a351076f14c9.png">

Here are some performance numbers before and after (the benchmark is from a private repo, I can craft a benchmark in go-sql-driver/mysql to highlight the problem if you wish):

```
BenchmarkJobDB/open_a_transaction,_put_jobs,_commit,_and_dispose-4         	     200	  66371357 ns/op	 1531183 B/op	   20208 allocs/op
PASS
ok  	github.com/segmentio/centrifuge/mysql	20.728s
```
```
BenchmarkJobDB/open_a_transaction,_put_jobs,_commit,_and_dispose-4         	     200	  64491960 ns/op	 1162803 B/op	    4209 allocs/op
PASS
ok  	github.com/segmentio/centrifuge/mysql	19.421s
```
```
benchmark                                                              old ns/op     new ns/op     delta
BenchmarkJobDB/open_a_transaction,_put_jobs,_commit,_and_dispose-4     66371357      64491960      -2.83%

benchmark                                                              old allocs     new allocs     delta
BenchmarkJobDB/open_a_transaction,_put_jobs,_commit,_and_dispose-4     20208          4209           -79.17%

benchmark                                                              old bytes     new bytes     delta
BenchmarkJobDB/open_a_transaction,_put_jobs,_commit,_and_dispose-4     1531183       1162803       -24.06%
```

What this is doing is making Go believe that an interface that holds a `*int64` is holding a value to a `int64` (and similar for other types) so [this check](https://golang.org/src/database/sql/convert.go#L113) passes in the database/sql package, then once the value comes back into the driver, it converts it back to the actual type it's supposed to have.

Honestly I'm a bit sad/ashamed of having to hack the Go type system to work around this issue, but the gains are so massive that I believe the change deserves to be at least discussed.

Because this is likely non-portable and may break in future versions of Go I think we should make it an opt-in features enabled by a runtime flag.

Please take a look and let me know what you think.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
