### PR TITLE
Stop repeated queries

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -35,7 +35,7 @@ func (mc *mysqlConn) readPacket() ([]byte, error) {
 			}
 			errLog.Print(err)
 			mc.Close()
-			return nil, driver.ErrBadConn
+			return nil, err
 		}
 
 		// packet length [24 bit]
@@ -57,7 +57,7 @@ func (mc *mysqlConn) readPacket() ([]byte, error) {
 			if prevData == nil {
 				errLog.Print(ErrMalformPkt)
 				mc.Close()
-				return nil, driver.ErrBadConn
+				return nil, ErrMalformPkt
 			}
 
 			return prevData, nil
@@ -71,7 +71,7 @@ func (mc *mysqlConn) readPacket() ([]byte, error) {
 			}
 			errLog.Print(err)
 			mc.Close()
-			return nil, driver.ErrBadConn
+			return nil, err
 		}
 
 		// return data if this was the last packet

--- a/packets_test.go
+++ b/packets_test.go
@@ -9,7 +9,6 @@
 package mysql
 
 import (
-	"database/sql/driver"
 	"errors"
 	"net"
 	"testing"
@@ -252,8 +251,8 @@ func TestReadPacketFail(t *testing.T) {
 	conn.data = []byte{0x00, 0x00, 0x00, 0x00}
 	conn.maxReads = 1
 	_, err := mc.readPacket()
-	if err != driver.ErrBadConn {
-		t.Errorf("expected ErrBadConn, got %v", err)
+	if err != ErrMalformPkt {
+		t.Errorf("expected %v, got %v", ErrMalformPkt, err)
 	}
 
 	// reset
@@ -264,8 +263,8 @@ func TestReadPacketFail(t *testing.T) {
 	// fail to read header
 	conn.closed = true
 	_, err = mc.readPacket()
-	if err != driver.ErrBadConn {
-		t.Errorf("expected ErrBadConn, got %v", err)
+	if err != errConnClosed {
+		t.Errorf("expected %v, got %v", errConnClosed, err)
 	}
 
 	// reset
@@ -277,7 +276,7 @@ func TestReadPacketFail(t *testing.T) {
 	// fail to read body
 	conn.maxReads = 1
 	_, err = mc.readPacket()
-	if err != driver.ErrBadConn {
-		t.Errorf("expected ErrBadConn, got %v", err)
+	if err != errConnTooManyReads {
+		t.Errorf("expected %v, got %v", errConnTooManyReads, err)
 	}
 }


### PR DESCRIPTION
### Description

This pull request fixes the following issue.

- duplicate operations cause by `maxBadConnRetries` #582
- Whackamole queries when KILL'ing #295

It is separated from #302.
Handling errors of WRITE operations still needs more consideration, while I think that handling errors of READ operations can be fixed.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
