### PR TITLE
Added support for custom string types in ConvertValue.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Asta Xie <xiemengjun at gmail.com>
 Bulat Gaifullin <gaifullinbf at gmail.com>
 Carlos Nieto <jose.carlos at menteslibres.net>
 Chris Moos <chris at tech9computers.com>
+Daniel Montoya <dsmontoyam at gmail.com>
 Daniel Nichter <nil at codenode.com>
 Daniël van Eeden <git at myname.nl>
 Dave Protasowski <dprotaso at gmail.com>

--- a/statement.go
+++ b/statement.go
@@ -157,6 +157,8 @@ func (c converter) ConvertValue(v interface{}) (driver.Value, error) {
 		return int64(u64), nil
 	case reflect.Float32, reflect.Float64:
 		return rv.Float(), nil
+	case reflect.String:
+		return rv.String(), nil
 	}
 	return nil, fmt.Errorf("unsupported type %T, a %s", v, rv.Kind())
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -15,6 +15,7 @@ type customString string
 func TestConvertValueCustomTypes(t *testing.T) {
 	var cstr customString = "string"
 	c := converter{}
+  
 	if _, err := c.ConvertValue(cstr); err != nil {
 		t.Errorf("custom string type should be valid")
 	}

--- a/statement_test.go
+++ b/statement_test.go
@@ -1,3 +1,11 @@
+// Go MySQL Driver - A MySQL-Driver for Go's database/sql package
+//
+// Copyright 2017 The Go-MySQL-Driver Authors. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package mysql
 
 import "testing"

--- a/statement_test.go
+++ b/statement_test.go
@@ -1,0 +1,13 @@
+package mysql
+
+import "testing"
+
+type customString string
+
+func TestConvertValueCustomTypes(t *testing.T) {
+	var cstr customString = "string"
+	c := converter{}
+	if _, err := c.ConvertValue(cstr); err != nil {
+		t.Errorf("custom string type should be valid")
+	}
+}

--- a/statement_test.go
+++ b/statement_test.go
@@ -15,7 +15,6 @@ type customString string
 func TestConvertValueCustomTypes(t *testing.T) {
 	var cstr customString = "string"
 	c := converter{}
-  
 	if _, err := c.ConvertValue(cstr); err != nil {
 		t.Errorf("custom string type should be valid")
 	}


### PR DESCRIPTION
### Description
For some reason reflect.String is not considered in the switch statement. This PR add it to a case so custom string types can be converted.
### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
