### PR TITLE
start the watcher after handshake. fix #626

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -66,11 +66,6 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 	mc.parseTime = mc.cfg.ParseTime
 	mc.strict = mc.cfg.Strict
 
-	// Call startWatcher for context support (From Go 1.8)
-	if s, ok := interface{}(mc).(watcher); ok {
-		s.startWatcher()
-	}
-
 	// Connect to Server
 	if dial, ok := dials[mc.cfg.Net]; ok {
 		mc.netConn, err = dial(mc.cfg.Addr)
@@ -90,6 +85,11 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 			mc.netConn = nil
 			return nil, err
 		}
+	}
+
+	// Call startWatcher for context support (From Go 1.8)
+	if s, ok := interface{}(mc).(watcher); ok {
+		s.startWatcher()
 	}
 
 	mc.buf = newBuffer(mc.netConn)


### PR DESCRIPTION
### Description

start the watcher after handshake.
because `mc.cleanup` is not called when handshake fails.
fix #626

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
