### PR TITLE
pr-451 with additional tests and some documentation editing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Asta Xie <xiemengjun at gmail.com>
 Bulat Gaifullin <gaifullinbf at gmail.com>
 Carlos Nieto <jose.carlos at menteslibres.net>
 Chris Moos <chris at tech9computers.com>
+Chris Piraino <piraino.chris at gmail.com>
 Daniel Nichter <nil at codenode.com>
 Daniël van Eeden <git at myname.nl>
 Dave Protasowski <dprotaso at gmail.com>
@@ -34,6 +35,7 @@ INADA Naoki <songofacandy at gmail.com>
 Jacek Szwec <szwec.jacek at gmail.com>
 James Harr <james.harr at gmail.com>
 Jian Zhen <zhenjl at gmail.com>
+John Shahid <jvshahid at gmail.com>
 Joshua Prunier <joshua.prunier at gmail.com>
 Julien Lefevre <julien.lefevr at gmail.com>
 Julien Schmidt <go-sql-driver at julienschmidt.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -60,6 +60,7 @@ Runrioter Wung <runrioter at gmail.com>
 Soroush Pour <me at soroushjp.com>
 Stan Putrya <root.vagner at gmail.com>
 Stanley Gunawan <gunawan.stanley at gmail.com>
+Thomas Parrott <tomp at tomp.uk>
 Xiangyu Hu <xiangyu.hu at outlook.com>
 Xiaobing Jiang <s7v7nislands at gmail.com>
 Xiuming Chen <cc at cxm.cc>

--- a/packets_test.go
+++ b/packets_test.go
@@ -115,9 +115,9 @@ func TestReadPacketWrongSequenceID(t *testing.T) {
 	}
 
 	// too low sequence id
-	conn.data = []byte{0x01, 0x00, 0x00, 0x00, 0xff}
+	conn.data = []byte{0x01, 0x00, 0x00, 0x01, 0xff}
 	conn.maxReads = 1
-	mc.sequence = 1
+	mc.sequence = 2
 	_, err := mc.readPacket()
 	if err != ErrPktSync {
 		t.Errorf("expected ErrPktSync, got %v", err)


### PR DESCRIPTION
### Description

This is another attempt to get the changes in #451 to be merged. We have preserved the author of the original commit and made the suggested documentation changes and added a test case. I will attempt to explain what the issue is trying to fix:

We have a MariaDB cluster with a proxy routing traffic to one node in the cluster. During rolling updates, the active node will send `ER_CONNECTION_CLOSED` err packet and close the connection. This causes the driver to return `ErrPktSync` to the client. Given that the driver is not returning `ErrBadConn` golang will not retry the query (or close the connection). This pushes the responsibility of retrying on the client which is totally acceptable. **Except** If there are few hundred  connections open (in our case `300`) any retry logic with reasonable number of retries (in our case `3`) isn't sufficient. What will end up happening, golang will pick another connection from the pool of closed connections and the client will get another `ErrPktSync`.

I'm happy to talk more about different solutions to the problem we are having.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
