### PR TITLE
Add aurora errno to rejectReadOnly check

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ INADA Naoki <songofacandy at gmail.com>
 Jacek Szwec <szwec.jacek at gmail.com>
 James Harr <james.harr at gmail.com>
 Jeff Hodges <jeff at somethingsimilar.com>
+Jeffrey Charles <jeffreycharles at gmail.com>
 Jian Zhen <zhenjl at gmail.com>
 Joshua Prunier <joshua.prunier at gmail.com>
 Julien Lefevre <julien.lefevr at gmail.com>

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Default:        false
 ```
 
 
-`rejectreadOnly=true` causes the driver to reject read-only connections. This
+`rejectReadOnly=true` causes the driver to reject read-only connections. This
 is for a possible race condition during an automatic failover, where the mysql
 client gets connected to a read-only replica after the failover.
 
@@ -293,6 +293,11 @@ for example, using a manual failover on AWS Aurora's MySQL-compatible cluster.
 If you are not relying on read-only transactions to reject writes that aren't
 supposed to happen, setting this on some MySQL providers (such as AWS Aurora)
 is safer for failovers.
+
+Note that ERROR 1290 can be returned for a `read-only` server and this option will
+cause a retry for that error. However the same error number is used for some
+other cases. You should ensure your application will never cause an ERROR 1290
+except for `read-only` mode when enabling this option.
 
 
 ##### `timeout`

--- a/packets.go
+++ b/packets.go
@@ -571,7 +571,8 @@ func (mc *mysqlConn) handleErrorPacket(data []byte) error {
 	errno := binary.LittleEndian.Uint16(data[1:3])
 
 	// 1792: ER_CANT_EXECUTE_IN_READ_ONLY_TRANSACTION
-	if errno == 1792 && mc.cfg.RejectReadOnly {
+	// 1290: ER_OPTION_PREVENTS_STATEMENT (returned by Aurora during failover)
+	if (errno == 1792 || errno == 1290) && mc.cfg.RejectReadOnly {
 		// Oops; we are connected to a read-only connection, and won't be able
 		// to issue any write statements. Since RejectReadOnly is configured,
 		// we throw away this connection hoping this one would have write


### PR DESCRIPTION
### Description
Include errno 1290 in `rejectReadOnly` check. Aurora returns this because the database is running with the `--read-only` option.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file

(Not sure how to add a test for this easily w/o running another MySQL instance with a TCP reverse proxy, and even then it wouldn't necessarily reflect how Aurora runs in practice in the future)
