### PR TITLE
allow successful TravisCI runs in forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,4 +86,5 @@ script:
   - go test -v -covermode=count -coverprofile=coverage.out
   - go vet ./...
   - test -z "$(gofmt -d -s . | tee /dev/stderr)"
+after_script:
   - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci


### PR DESCRIPTION
Most forks won't be in goveralls and so this command in travis.yml was,
previously, failing and causing the build to fail.

Now, it doesn't!

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
