### PR TITLE
packets: implemented compression protocol

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Aaron Hopkins <go-sql-driver at die.net>
 Achille Roussel <achille.roussel at gmail.com>
 Arne Hormann <arnehormann at gmail.com>
 Asta Xie <xiemengjun at gmail.com>
+B Lamarche <blam413 at gmail.com>
 Bulat Gaifullin <gaifullinbf at gmail.com>
 Carlos Nieto <jose.carlos at menteslibres.net>
 Chris Moos <chris at tech9computers.com>

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -224,6 +224,7 @@ func BenchmarkInterpolation(b *testing.B) {
 		maxWriteSize:     maxPacketSize - 1,
 		buf:              newBuffer(nil),
 	}
+	mc.reader = &mc.buf
 
 	args := []driver.Value{
 		int64(42424242),

--- a/compress.go
+++ b/compress.go
@@ -1,0 +1,217 @@
+package mysql
+
+import (
+	"bytes"
+	"compress/zlib"
+	"io"
+)
+
+const (
+	minCompressLength = 50
+)
+
+type packetReader interface {
+	readNext(need int) ([]byte, error)
+}
+
+type compressedReader struct {
+	buf      packetReader
+	bytesBuf []byte
+	mc       *mysqlConn
+}
+
+type compressedWriter struct {
+	connWriter io.Writer
+	mc         *mysqlConn
+}
+
+func NewCompressedReader(buf packetReader, mc *mysqlConn) *compressedReader {
+	return &compressedReader{
+		buf:      buf,
+		bytesBuf: make([]byte, 0),
+		mc:       mc,
+	}
+}
+
+func NewCompressedWriter(connWriter io.Writer, mc *mysqlConn) *compressedWriter {
+	return &compressedWriter{
+		connWriter: connWriter,
+		mc:         mc,
+	}
+}
+
+func (cr *compressedReader) readNext(need int) ([]byte, error) {
+	for len(cr.bytesBuf) < need {
+		err := cr.uncompressPacket()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	data := make([]byte, need)
+
+	copy(data, cr.bytesBuf[:len(data)])
+
+	cr.bytesBuf = cr.bytesBuf[len(data):]
+
+	return data, nil
+}
+
+func (cr *compressedReader) uncompressPacket() error {
+	header, err := cr.buf.readNext(7) // size of compressed header
+
+	if err != nil {
+		return err
+	}
+
+	// compressed header structure
+	comprLength := int(uint32(header[0]) | uint32(header[1])<<8 | uint32(header[2])<<16)
+	uncompressedLength := int(uint32(header[4]) | uint32(header[5])<<8 | uint32(header[6])<<16)
+	compressionSequence := uint8(header[3])
+
+	if compressionSequence != cr.mc.compressionSequence {
+		return ErrPktSync
+	}
+
+	cr.mc.compressionSequence++
+
+	comprData, err := cr.buf.readNext(comprLength)
+	if err != nil {
+		return err
+	}
+
+	// if payload is uncompressed, its length will be specified as zero, and its
+	// true length is contained in comprLength
+	if uncompressedLength == 0 {
+		cr.bytesBuf = append(cr.bytesBuf, comprData...)
+		return nil
+	}
+
+	// write comprData to a bytes.buffer, then read it using zlib into data
+	var b bytes.Buffer
+	b.Write(comprData)
+	r, err := zlib.NewReader(&b)
+
+	if r != nil {
+		defer r.Close()
+	}
+
+	if err != nil {
+		return err
+	}
+
+	data := make([]byte, uncompressedLength)
+	lenRead := 0
+
+	// http://grokbase.com/t/gg/golang-nuts/146y9ppn6b/go-nuts-stream-compression-with-compress-flate
+	for lenRead < uncompressedLength {
+
+		tmp := data[lenRead:]
+
+		n, err := r.Read(tmp)
+		lenRead += n
+
+		if err == io.EOF {
+			if lenRead < uncompressedLength {
+				return io.ErrUnexpectedEOF
+			}
+			break
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	cr.bytesBuf = append(cr.bytesBuf, data...)
+
+	return nil
+}
+
+func (cw *compressedWriter) Write(data []byte) (int, error) {
+	// when asked to write an empty packet, do nothing
+	if len(data) == 0 {
+		return 0, nil
+	}
+	totalBytes := len(data)
+
+	length := len(data) - 4
+
+	maxPayloadLength := maxPacketSize - 4
+
+	for length >= maxPayloadLength {
+		// cut off a slice of size max payload length
+		dataSmall := data[:maxPayloadLength]
+		lenSmall := len(dataSmall)
+
+		var b bytes.Buffer
+		writer := zlib.NewWriter(&b)
+		_, err := writer.Write(dataSmall)
+		writer.Close()
+		if err != nil {
+			return 0, err
+		}
+
+		err = cw.writeComprPacketToNetwork(b.Bytes(), lenSmall)
+		if err != nil {
+			return 0, err
+		}
+
+		length -= maxPayloadLength
+		data = data[maxPayloadLength:]
+	}
+
+	lenSmall := len(data)
+
+	// do not compress if packet is too small
+	if lenSmall < minCompressLength {
+		err := cw.writeComprPacketToNetwork(data, 0)
+		if err != nil {
+			return 0, err
+		}
+
+		return totalBytes, nil
+	}
+
+	var b bytes.Buffer
+	writer := zlib.NewWriter(&b)
+
+	_, err := writer.Write(data)
+	writer.Close()
+
+	if err != nil {
+		return 0, err
+	}
+
+	err = cw.writeComprPacketToNetwork(b.Bytes(), lenSmall)
+
+	if err != nil {
+		return 0, err
+	}
+	return totalBytes, nil
+}
+
+func (cw *compressedWriter) writeComprPacketToNetwork(data []byte, uncomprLength int) error {
+	data = append([]byte{0, 0, 0, 0, 0, 0, 0}, data...)
+
+	comprLength := len(data) - 7
+
+	// compression header
+	data[0] = byte(0xff & comprLength)
+	data[1] = byte(0xff & (comprLength >> 8))
+	data[2] = byte(0xff & (comprLength >> 16))
+
+	data[3] = cw.mc.compressionSequence
+
+	//this value is never greater than maxPayloadLength
+	data[4] = byte(0xff & uncomprLength)
+	data[5] = byte(0xff & (uncomprLength >> 8))
+	data[6] = byte(0xff & (uncomprLength >> 16))
+
+	if _, err := cw.connWriter.Write(data); err != nil {
+		return err
+	}
+
+	cw.mc.compressionSequence++
+	return nil
+}

--- a/compress_test.go
+++ b/compress_test.go
@@ -1,0 +1,220 @@
+package mysql
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"testing"
+)
+
+func makeRandByteSlice(size int) []byte {
+	randBytes := make([]byte, size)
+	rand.Read(randBytes)
+	return randBytes
+}
+
+func newMockConn() *mysqlConn {
+	newConn := &mysqlConn{}
+	return newConn
+}
+
+type mockBuf struct {
+	reader io.Reader
+}
+
+func newMockBuf(reader io.Reader) *mockBuf {
+	return &mockBuf{
+		reader: reader,
+	}
+}
+
+func (mb *mockBuf) readNext(need int) ([]byte, error) {
+
+	data := make([]byte, need)
+	_, err := mb.reader.Read(data)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// compressHelper compresses uncompressedPacket and checks state variables
+func compressHelper(t *testing.T, mc *mysqlConn, uncompressedPacket []byte) []byte {
+	// get status variables
+
+	cs := mc.compressionSequence
+
+	var b bytes.Buffer
+	connWriter := &b
+
+	cw := NewCompressedWriter(connWriter, mc)
+
+	n, err := cw.Write(uncompressedPacket)
+
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if n != len(uncompressedPacket) {
+		t.Fatal(fmt.Sprintf("expected to write %d bytes, wrote %d bytes", len(uncompressedPacket), n))
+	}
+
+	if len(uncompressedPacket) > 0 {
+
+		if mc.compressionSequence != (cs + 1) {
+			t.Fatal(fmt.Sprintf("mc.compressionSequence updated incorrectly, expected %d and saw %d", (cs + 1), mc.compressionSequence))
+		}
+
+	} else {
+		if mc.compressionSequence != cs {
+			t.Fatal(fmt.Sprintf("mc.compressionSequence updated incorrectly for case of empty write, expected %d and saw %d", cs, mc.compressionSequence))
+		}
+	}
+
+	return b.Bytes()
+}
+
+// roundtripHelper compresses then uncompresses uncompressedPacket and checks state variables
+func roundtripHelper(t *testing.T, cSend *mysqlConn, cReceive *mysqlConn, uncompressedPacket []byte) []byte {
+	compressed := compressHelper(t, cSend, uncompressedPacket)
+	return uncompressHelper(t, cReceive, compressed, len(uncompressedPacket))
+}
+
+// uncompressHelper uncompresses compressedPacket and checks state variables
+func uncompressHelper(t *testing.T, mc *mysqlConn, compressedPacket []byte, expSize int) []byte {
+	// get status variables
+	cs := mc.compressionSequence
+
+	// mocking out buf variable
+	mockConnReader := bytes.NewReader(compressedPacket)
+	mockBuf := newMockBuf(mockConnReader)
+
+	cr := NewCompressedReader(mockBuf, mc)
+
+	uncompressedPacket, err := cr.readNext(expSize)
+	if err != nil {
+		if err != io.EOF {
+			t.Fatal(fmt.Sprintf("non-nil/non-EOF error when reading contents: %s", err.Error()))
+		}
+	}
+
+	if expSize > 0 {
+		if mc.compressionSequence != (cs + 1) {
+			t.Fatal(fmt.Sprintf("mc.compressionSequence updated incorrectly, expected %d and saw %d", (cs + 1), mc.compressionSequence))
+		}
+	} else {
+		if mc.compressionSequence != cs {
+			t.Fatal(fmt.Sprintf("mc.compressionSequence updated incorrectly for case of empty read, expected %d and saw %d", cs, mc.compressionSequence))
+		}
+	}
+	return uncompressedPacket
+}
+
+// TestCompressedReaderThenWriter tests reader and writer seperately.
+func TestCompressedReaderThenWriter(t *testing.T) {
+
+	makeTestUncompressedPacket := func(size int) []byte {
+		uncompressedHeader := make([]byte, 4)
+		uncompressedHeader[0] = byte(size)
+		uncompressedHeader[1] = byte(size >> 8)
+		uncompressedHeader[2] = byte(size >> 16)
+
+		payload := make([]byte, size)
+		for i := range payload {
+			payload[i] = 'b'
+		}
+
+		uncompressedPacket := append(uncompressedHeader, payload...)
+		return uncompressedPacket
+	}
+
+	tests := []struct {
+		compressed   []byte
+		uncompressed []byte
+		desc         string
+	}{
+		{compressed: []byte{5, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 'a'},
+			uncompressed: []byte{1, 0, 0, 0, 'a'},
+			desc:         "a"},
+		{compressed: []byte{10, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 'g', 'o', 'l', 'a', 'n', 'g'},
+			uncompressed: []byte{6, 0, 0, 0, 'g', 'o', 'l', 'a', 'n', 'g'},
+			desc:         "golang"},
+		{compressed: []byte{19, 0, 0, 0, 104, 0, 0, 120, 156, 74, 97, 96, 96, 72, 162, 3, 0, 4, 0, 0, 255, 255, 182, 165, 38, 173},
+			uncompressed: makeTestUncompressedPacket(100),
+			desc:         "100 bytes letter b"},
+		{compressed: []byte{63, 0, 0, 0, 236, 128, 0, 120, 156, 236, 192, 129, 0, 0, 0, 8, 3, 176, 179, 70, 18, 110, 24, 129, 124, 187, 77, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 168, 241, 1, 0, 0, 255, 255, 42, 107, 93, 24},
+			uncompressed: makeTestUncompressedPacket(33000),
+			desc:         "33000 bytes letter b"},
+	}
+
+	for _, test := range tests {
+		s := fmt.Sprintf("Test compress uncompress with %s", test.desc)
+
+		// test uncompression only
+		c := newMockConn()
+		uncompressed := uncompressHelper(t, c, test.compressed, len(test.uncompressed))
+		if bytes.Compare(uncompressed, test.uncompressed) != 0 {
+			t.Fatal(fmt.Sprintf("%s: uncompression failed", s))
+		}
+
+		// test compression only
+		c = newMockConn()
+		compressed := compressHelper(t, c, test.uncompressed)
+		if bytes.Compare(compressed, test.compressed) != 0 {
+			t.Fatal(fmt.Sprintf("%s: compression failed", s))
+		}
+	}
+}
+
+// TestRoundtrip tests two connections, where one is reading and the other is writing
+func TestRoundtrip(t *testing.T) {
+
+	tests := []struct {
+		uncompressed []byte
+		desc         string
+	}{
+		{uncompressed: []byte("a"),
+			desc: "a"},
+		{uncompressed: []byte{0},
+			desc: "0 byte"},
+		{uncompressed: []byte("hello world"),
+			desc: "hello world"},
+		{uncompressed: make([]byte, 100),
+			desc: "100 bytes"},
+		{uncompressed: make([]byte, 32768),
+			desc: "32768 bytes"},
+		{uncompressed: make([]byte, 330000),
+			desc: "33000 bytes"},
+		{uncompressed: make([]byte, 0),
+			desc: "nothing"},
+		{uncompressed: makeRandByteSlice(10),
+			desc: "10 rand bytes",
+		},
+		{uncompressed: makeRandByteSlice(100),
+			desc: "100 rand bytes",
+		},
+		{uncompressed: makeRandByteSlice(32768),
+			desc: "32768 rand bytes",
+		},
+		{uncompressed: makeRandByteSlice(33000),
+			desc: "33000 rand bytes",
+		},
+	}
+
+	cSend := newMockConn()
+
+	cReceive := newMockConn()
+
+	for _, test := range tests {
+		s := fmt.Sprintf("Test roundtrip with %s", test.desc)
+		//t.Run(s, func(t *testing.T) {
+
+		uncompressed := roundtripHelper(t, cSend, cReceive, test.uncompressed)
+		if bytes.Compare(uncompressed, test.uncompressed) != 0 {
+			t.Fatal(fmt.Sprintf("%s: roundtrip failed", s))
+		}
+
+		//})
+	}
+}

--- a/connection.go
+++ b/connection.go
@@ -28,19 +28,22 @@ type mysqlContext interface {
 }
 
 type mysqlConn struct {
-	buf              buffer
-	netConn          net.Conn
-	affectedRows     uint64
-	insertId         uint64
-	cfg              *Config
-	maxAllowedPacket int
-	maxWriteSize     int
-	writeTimeout     time.Duration
-	flags            clientFlag
-	status           statusFlag
-	sequence         uint8
-	parseTime        bool
-	strict           bool
+	buf                 buffer
+	netConn             net.Conn
+	affectedRows        uint64
+	insertId            uint64
+	cfg                 *Config
+	maxAllowedPacket    int
+	maxWriteSize        int
+	writeTimeout        time.Duration
+	flags               clientFlag
+	status              statusFlag
+	sequence            uint8
+	compressionSequence uint8
+	parseTime           bool
+	strict              bool
+	reader              packetReader
+	writer              io.Writer
 
 	// for context support (Go 1.8+)
 	watching bool

--- a/connection_test.go
+++ b/connection_test.go
@@ -21,6 +21,7 @@ func TestInterpolateParams(t *testing.T) {
 			InterpolateParams: true,
 		},
 	}
+	mc.reader = &mc.buf
 
 	q, err := mc.interpolateParams("SELECT ?+?", []driver.Value{int64(42), "gopher"})
 	if err != nil {
@@ -41,6 +42,7 @@ func TestInterpolateParamsTooManyPlaceholders(t *testing.T) {
 			InterpolateParams: true,
 		},
 	}
+	mc.reader = &mc.buf
 
 	q, err := mc.interpolateParams("SELECT ?+?", []driver.Value{int64(42)})
 	if err != driver.ErrSkip {
@@ -58,6 +60,8 @@ func TestInterpolateParamsPlaceholderInString(t *testing.T) {
 			InterpolateParams: true,
 		},
 	}
+
+	mc.reader = &mc.buf
 
 	q, err := mc.interpolateParams("SELECT 'abc?xyz',?", []driver.Value{int64(42)})
 	// When InterpolateParams support string literal, this should return `"SELECT 'abc?xyz', 42`

--- a/dsn.go
+++ b/dsn.go
@@ -56,6 +56,7 @@ type Config struct {
 	ParseTime               bool // Parse time values to time.Time
 	RejectReadOnly          bool // Reject read-only connections
 	Strict                  bool // Return warnings as errors
+	Compression             bool // Compress packets
 }
 
 // FormatDSN formats the given Config into a DSN string which can be passed to
@@ -445,7 +446,11 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 
 		// Compression
 		case "compress":
-			return errors.New("compression not implemented yet")
+			var isBool bool
+			cfg.Compression, isBool = readBool(value)
+			if !isBool {
+				return errors.New("invalid bool value: " + value)
+			}
 
 		// Enable client side placeholder substitution
 		case "interpolateParams":

--- a/packets.go
+++ b/packets.go
@@ -28,7 +28,7 @@ func (mc *mysqlConn) readPacket() ([]byte, error) {
 	var prevData []byte
 	for {
 		// read packet header
-		data, err := mc.buf.readNext(4)
+		data, err := mc.reader.readNext(4)
 		if err != nil {
 			if cerr := mc.canceled.Value(); cerr != nil {
 				return nil, cerr
@@ -64,7 +64,7 @@ func (mc *mysqlConn) readPacket() ([]byte, error) {
 		}
 
 		// read packet body [pktLen bytes]
-		data, err = mc.buf.readNext(pktLen)
+		data, err = mc.reader.readNext(pktLen)
 		if err != nil {
 			if cerr := mc.canceled.Value(); cerr != nil {
 				return nil, cerr
@@ -118,7 +118,7 @@ func (mc *mysqlConn) writePacket(data []byte) error {
 			}
 		}
 
-		n, err := mc.netConn.Write(data[:4+size])
+		n, err := mc.writer.Write(data[:4+size])
 		if err == nil && n == 4+size {
 			mc.sequence++
 			if size != maxPacketSize {
@@ -247,6 +247,10 @@ func (mc *mysqlConn) writeAuthPacket(cipher []byte) error {
 
 	if mc.cfg.ClientFoundRows {
 		clientFlags |= clientFoundRows
+	}
+
+	if mc.cfg.Compression {
+		clientFlags |= clientCompress
 	}
 
 	// To enable TLS / SSL
@@ -416,6 +420,7 @@ func (mc *mysqlConn) writeNativeAuthPacket(cipher []byte) error {
 func (mc *mysqlConn) writeCommandPacket(command byte) error {
 	// Reset Packet Sequence
 	mc.sequence = 0
+	mc.compressionSequence = 0
 
 	data := mc.buf.takeSmallBuffer(4 + 1)
 	if data == nil {
@@ -434,6 +439,7 @@ func (mc *mysqlConn) writeCommandPacket(command byte) error {
 func (mc *mysqlConn) writeCommandPacketStr(command byte, arg string) error {
 	// Reset Packet Sequence
 	mc.sequence = 0
+	mc.compressionSequence = 0
 
 	pktLen := 1 + len(arg)
 	data := mc.buf.takeBuffer(pktLen + 4)
@@ -456,6 +462,7 @@ func (mc *mysqlConn) writeCommandPacketStr(command byte, arg string) error {
 func (mc *mysqlConn) writeCommandPacketUint32(command byte, arg uint32) error {
 	// Reset Packet Sequence
 	mc.sequence = 0
+	mc.compressionSequence = 0
 
 	data := mc.buf.takeSmallBuffer(4 + 1 + 4)
 	if data == nil {

--- a/packets_test.go
+++ b/packets_test.go
@@ -94,6 +94,8 @@ func TestReadPacketSingleByte(t *testing.T) {
 		buf: newBuffer(conn),
 	}
 
+	mc.reader = &mc.buf
+
 	conn.data = []byte{0x01, 0x00, 0x00, 0x00, 0xff}
 	conn.maxReads = 1
 	packet, err := mc.readPacket()
@@ -113,6 +115,7 @@ func TestReadPacketWrongSequenceID(t *testing.T) {
 	mc := &mysqlConn{
 		buf: newBuffer(conn),
 	}
+	mc.reader = &mc.buf
 
 	// too low sequence id
 	conn.data = []byte{0x01, 0x00, 0x00, 0x00, 0xff}
@@ -141,6 +144,8 @@ func TestReadPacketSplit(t *testing.T) {
 	mc := &mysqlConn{
 		buf: newBuffer(conn),
 	}
+
+	mc.reader = &mc.buf
 
 	data := make([]byte, maxPacketSize*2+4*3)
 	const pkt2ofs = maxPacketSize + 4
@@ -247,6 +252,7 @@ func TestReadPacketFail(t *testing.T) {
 		buf:     newBuffer(conn),
 		closech: make(chan struct{}),
 	}
+	mc.reader = &mc.buf
 
 	// illegal empty (stand-alone) packet
 	conn.data = []byte{0x00, 0x00, 0x00, 0x00}


### PR DESCRIPTION
### Description
Please explain the changes you made here.
I implemented the SQL compression protocol. This is activated in the connection string by using `compress=1`. 

### Checklist
- [X] Code compiles correctly
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing
- [X] Extended the README / documentation, if necessary
- [X] Added myself / the copyright holder to the AUTHORS file
