### PR TITLE
ISSUE-647: Only register driver if not already registered.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Jacek Szwec <szwec.jacek at gmail.com>
 James Harr <james.harr at gmail.com>
 Jeff Hodges <jeff at somethingsimilar.com>
 Jian Zhen <zhenjl at gmail.com>
+Jonathan Turner <jt at jtnet.co.uk>
 Joshua Prunier <joshua.prunier at gmail.com>
 Julien Lefevre <julien.lefevr at gmail.com>
 Julien Schmidt <go-sql-driver at julienschmidt.com>

--- a/driver.go
+++ b/driver.go
@@ -190,5 +190,15 @@ func handleAuthResult(mc *mysqlConn, oldCipher []byte) error {
 }
 
 func init() {
-	sql.Register("mysql", &MySQLDriver{})
+	dn := "mysql"
+	var r bool
+	for _, d := range sql.Drivers() {
+		if d == dn {
+			r = true
+			break
+		}
+	}
+	if !r {
+		sql.Register(dn, &MySQLDriver{})
+	}
 }


### PR DESCRIPTION
### Description
The init function first searches for a driver registered with the name "mysql" if found it does not try and register again.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible) - Not sure how I would test this.
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
