### PR TITLE
Support Rows.ColumnTypes Interface

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -64,6 +64,7 @@ Xiangyu Hu <xiangyu.hu at outlook.com>
 Xiaobing Jiang <s7v7nislands at gmail.com>
 Xiuming Chen <cc at cxm.cc>
 Zhenye Xie <xiezhenye at gmail.com>
+xiaoyu chen <358860528 at qq.com>
 
 # Organizations
 

--- a/rows.go
+++ b/rows.go
@@ -11,6 +11,7 @@ package mysql
 import (
 	"database/sql/driver"
 	"io"
+	"reflect"
 )
 
 type mysqlField struct {
@@ -63,6 +64,37 @@ func (rows *mysqlRows) Columns() []string {
 
 	rows.rs.columnNames = columns
 	return columns
+}
+func (rows *mysqlRows) ColumnTypeScanType(index int) reflect.Type {
+	if index >= len(rows.rs.columns) {
+		return reflect.TypeOf(nil)
+	}
+
+	fieldtype := rows.rs.columns[index].fieldType
+	switch fieldtype {
+	case fieldTypeInt24, fieldTypeTiny, fieldTypeShort, fieldTypeLong:
+		return reflect.TypeOf(0)
+	case fieldTypeLongLong:
+		var val int64 = 0
+		return reflect.TypeOf(val)
+	case fieldTypeFloat:
+		var val float32 = 0.0
+		return reflect.TypeOf(val)
+	case fieldTypeDouble:
+		var val float64 = 0.0
+		return reflect.TypeOf(val)
+	case fieldTypeTinyBLOB,
+		fieldTypeMediumBLOB,
+		fieldTypeLongBLOB,
+		fieldTypeBLOB,
+		fieldTypeVarString,
+		fieldTypeString,
+		fieldTypeDate, fieldTypeDateTime:
+		return reflect.TypeOf("")
+	default:
+		return reflect.TypeOf(nil)
+	}
+
 }
 
 func (rows *mysqlRows) Close() (err error) {


### PR DESCRIPTION
support dynamic get the mysql Field to golang type.
ColumnTypes, _ := rows.ColumnTypes()
scanArgs := make([]interface{}, len(ColumnTypes))
for i, _ := range ColumnTypes {
scanArgs[i] = MakeRefType(ColumnTypes[i].ScanType())
fmt.Println("ColumnTypes[i].ScanType()",i,ColumnTypes[i].ScanType())
}
err = rows.Scan(scanArgs...)

### Description
Please explain the changes you made here.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
