### PR TITLE
packets: do not call function on nulled value

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -1143,10 +1143,11 @@ func (rows *binaryRows) readRow(dest []driver.Value) error {
 			}
 			return io.EOF
 		}
+		mc := rows.mc
 		rows.mc = nil
 
 		// Error otherwise
-		return rows.mc.handleErrorPacket(data)
+		return mc.handleErrorPacket(data)
 	}
 
 	// NULL-bitmap,  [(column-count + 7 + 2) / 8 bytes]


### PR DESCRIPTION
### Description
I just found this obvious mistake while skimming through the code.
Unfortunately I wasn't able to come up with a test which produces an error exactly when a row is read and not before. If you have an idea, let me know.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
