### PR TITLE
Export function to initialize Config with defaults

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -86,7 +86,7 @@ func (cfg *Config) normalize() error {
 		case "unix":
 			cfg.Addr = "/tmp/mysql.sock"
 		default:
-			errors.New("default addr for network '" + cfg.Net + "' unknown")
+			return errors.New("default addr for network '" + cfg.Net + "' unknown")
 		}
 
 	} else if cfg.Net == "tcp" {

--- a/dsn.go
+++ b/dsn.go
@@ -28,7 +28,9 @@ var (
 	errInvalidDSNUnsafeCollation = errors.New("invalid DSN: interpolateParams can not be used with unsafe collations")
 )
 
-// Config is a configuration parsed from a DSN string
+// Config is a configuration parsed from a DSN string.
+// If a new Config is created instead of being parsed from a DSN string,
+// the NewConfig function should be used, which sets default values.
 type Config struct {
 	User             string            // Username
 	Passwd           string            // Password (requires User)
@@ -57,6 +59,7 @@ type Config struct {
 	RejectReadOnly          bool // Reject read-only connections
 }
 
+// NewConfig creates a new Config and sets default values.
 func NewConfig() *Config {
 	return &Config{
 		Collation:            defaultCollation,

--- a/dsn.go
+++ b/dsn.go
@@ -57,6 +57,13 @@ type Config struct {
 	RejectReadOnly          bool // Reject read-only connections
 }
 
+func NewConfig() *Config {
+	return &Config{
+		Collation:            defaultCollation,
+		Loc:                  time.UTC,
+		AllowNativePasswords: true,
+	}
+}
 // FormatDSN formats the given Config into a DSN string which can be passed to
 // the driver.
 func (cfg *Config) FormatDSN() string {
@@ -273,11 +280,7 @@ func (cfg *Config) FormatDSN() string {
 // ParseDSN parses the DSN string to a Config
 func ParseDSN(dsn string) (cfg *Config, err error) {
 	// New config with some default values
-	cfg = &Config{
-		Loc:                  time.UTC,
-		Collation:            defaultCollation,
-		AllowNativePasswords: true,
-	}
+	cfg = NewConfig()
 
 	// [user[:password]@][net[(addr)]]/dbname[?param1=value1&paramN=valueN]
 	// Find the last '/' (since the password or the net addr might contain a '/')

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -98,6 +98,7 @@ func TestDSNParserInvalid(t *testing.T) {
 		"(/",                          // no closing brace
 		"net(addr)//",                 // unescaped
 		"User:pass@tcp(1.2.3.4:3306)", // no trailing slash
+		"net()/",                      // unknown default addr
 		//"/dbname?arg=/some/unescaped/path",
 	}
 


### PR DESCRIPTION
### Description
Export a `NewConfig` function which sets default values for consistency with parsed DSNs.

Updates #671, #499 

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
