### PR TITLE
dsn: escape and unescape user field

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Aaron Hopkins <go-sql-driver at die.net>
 Achille Roussel <achille.roussel at gmail.com>
 Arne Hormann <arnehormann at gmail.com>
 Asta Xie <xiemengjun at gmail.com>
+Brandon Bennett <bbennett at fb.com>
 Bulat Gaifullin <gaifullinbf at gmail.com>
 Carlos Nieto <jose.carlos at menteslibres.net>
 Chris Moos <chris at tech9computers.com>

--- a/dsn.go
+++ b/dsn.go
@@ -104,7 +104,7 @@ func (cfg *Config) FormatDSN() string {
 
 	// [username[:password]@]
 	if len(cfg.User) > 0 {
-		buf.WriteString(cfg.User)
+		buf.WriteString(url.QueryEscape(cfg.User))
 		if len(cfg.Passwd) > 0 {
 			buf.WriteByte(':')
 			buf.WriteString(cfg.Passwd)
@@ -337,8 +337,14 @@ func ParseDSN(dsn string) (cfg *Config, err error) {
 								break
 							}
 						}
-						cfg.User = dsn[:k]
 
+						// username may have encoded characters, try to decode
+						// them
+						user, err := url.QueryUnescape(dsn[:k])
+						if err != nil {
+							return nil, fmt.Errorf("invalid username: %v", err)
+						}
+						cfg.User = user
 						break
 					}
 				}

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -48,6 +48,9 @@ var testDSNs = []struct {
 	"user:p@ss(word)@tcp([de:ad:be:ef::ca:fe]:80)/dbname?loc=Local",
 	&Config{User: "user", Passwd: "p@ss(word)", Net: "tcp", Addr: "[de:ad:be:ef::ca:fe]:80", DBName: "dbname", Collation: "utf8_general_ci", Loc: time.Local, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true},
 }, {
+	"foo%3Abar%40%28baz%29@/dbname",
+	&Config{User: "foo:bar@(baz)", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Collation: "utf8_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true},
+}, {
 	"/dbname",
 	&Config{Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Collation: "utf8_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true},
 }, {
@@ -228,6 +231,17 @@ func TestDSNUnsafeCollation(t *testing.T) {
 	_, err = ParseDSN("/dbname?collation=utf8mb4_general_ci&interpolateParams=true")
 	if err != nil {
 		t.Errorf("expected %v, got %v", nil, err)
+	}
+}
+
+func TestEscapedUser(t *testing.T) {
+	expected := "foo%3Abar%40%28baz%29@/"
+	cfg := NewConfig()
+	cfg.User = "foo:bar@(baz)"
+	actual := cfg.FormatDSN()
+
+	if actual != expected {
+		t.Errorf("user was not escaped: want: %#v, got %#v", expected, actual)
 	}
 }
 


### PR DESCRIPTION
### Description
Sometimes usernames may have characters that need encoding such as : or
@.  This fixes the problem by url escaping the username on FormatDSN and
unescaping it on ParseDSN.

Although the DSNs are not proper URIs escaping of username is defined in
https://www.ietf.org/rfc/rfc3986.txt

Fixes: #688

### Checklist
- [X] Code compiles correctly
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing
- [X] Extended the README / documentation, if necessary
- [X] Added myself / the copyright holder to the AUTHORS file
