### PR TITLE
Make gofmt happy

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -1375,7 +1375,6 @@ func TestTimezoneConversion(t *testing.T) {
 
 	// Regression test for timezone handling
 	tzTest := func(dbt *DBTest) {
-
 		// Create table
 		dbt.mustExec("CREATE TABLE test (ts TIMESTAMP)")
 

--- a/dsn.go
+++ b/dsn.go
@@ -398,7 +398,6 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 
 		// cfg params
 		switch value := param[1]; param[0] {
-
 		// Disable INFILE whitelist / enable all files
 		case "allowAllFiles":
 			var isBool bool

--- a/utils.go
+++ b/utils.go
@@ -566,8 +566,8 @@ func readLengthEncodedInteger(b []byte) (uint64, bool, int) {
 	if len(b) == 0 {
 		return 0, true, 1
 	}
-	switch b[0] {
 
+	switch b[0] {
 	// 251: NULL
 	case 0xfb:
 		return 0, true, 1


### PR DESCRIPTION
Apparently there were some changes to `gofmt` in `tip` and our builds start to fail because of formatting errors: https://travis-ci.org/go-sql-driver/mysql/jobs/301089722

This PR just applies 3 minor style fixes.
