### PR TITLE
Implement Connector interface

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@
 
 Aaron Hopkins <go-sql-driver at die.net>
 Achille Roussel <achille.roussel at gmail.com>
+Anthony Gruetzmacher <anthony at thegruetzmachergroup.com>
 Arne Hormann <arnehormann at gmail.com>
 Asta Xie <xiemengjun at gmail.com>
 Bulat Gaifullin <gaifullinbf at gmail.com>

--- a/driver.go
+++ b/driver.go
@@ -184,9 +184,8 @@ func (c MySQLConnector) Connect(cxt context.Context) (driver.Conn, error) {
 		if err != nil {
 			return nil, err
 		}
-
-		return mc, nil
 	}
+	return mc, nil
 }
 
 //Driver returns a driver interface

--- a/driver_go110_test.go
+++ b/driver_go110_test.go
@@ -1,0 +1,82 @@
+// Go MySQL Driver - A MySQL-Driver for Go's database/sql package
+//
+// Copyright 2018 The Go-MySQL-Driver Authors. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build go1.10
+
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"sync"
+	"testing"
+)
+
+type Connector struct {
+	m     sync.Mutex
+	mysql *MySQLConnector
+}
+
+func (c *Connector) Connect(cxt context.Context) (driver.Conn, error) {
+	var err error
+
+	if c.mysql == nil {
+		c.mysql = c.init()
+	}
+
+	//Just use the global DSN because we just want to test the connector
+	//interface and we do not care about any custom functionality in the Connector
+	c.m.Lock()
+	c.mysql.Cfg, err = ParseDSN(dsn)
+	c.m.Unlock()
+	if err != nil {
+		println(err)
+		return nil, err
+	}
+
+	return c.mysql.Connect(cxt)
+}
+
+func (c *Connector) Driver() driver.Driver {
+	return c.mysql.Driver()
+}
+
+func (c *Connector) init() *MySQLConnector {
+	return &MySQLConnector{}
+}
+
+func runtestsWithConnector(t *testing.T, tests ...func(dbt *DBTest)) {
+	if !available {
+		t.Skipf("MySQL server not running on %s", netAddr)
+	}
+
+	connector := &Connector{}
+
+	db := sql.OpenDB(connector)
+	if err := db.Ping(); err != nil {
+		db.Close()
+		t.Fatalf("error connecting: %s", err.Error())
+	}
+	defer db.Close()
+
+	dbt := &DBTest{t, db}
+	for _, test := range tests {
+		test(dbt)
+		dbt.db.Exec("DROP TABLE IF EXISTS test")
+	}
+
+}
+
+func TestPingWithConnector(t *testing.T) {
+	runtestsWithConnector(t, func(dbt *DBTest) {
+		if err := dbt.db.Ping(); err != nil {
+			dbt.fail("Ping With Connector", "Ping With Connector", err)
+		}
+	})
+}


### PR DESCRIPTION
### Description
Implemented the connector interface support that is coming out in go 1.10. Moved the connection code in the Open interface to a connectServer method that can be shared while still maintaining the differences between the Open interface that accepts a DSN and the Connect interface that allows for other types of configuration options.

All existing tests are passing. I wanted to get feed back before writing the tests for this. Unsure where/how documentation should change.

fixes #671

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file