### PR TITLE
Fix Valuers by returning driver.ErrSkip if couldn't convert type internally

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -71,6 +71,7 @@ Zhenye Xie <xiezhenye at gmail.com>
 # Organizations
 
 Barracuda Networks, Inc.
+Counting Ltd.
 Google Inc.
 Keybase Inc.
 Pivotal Inc.

--- a/connection_go18.go
+++ b/connection_go18.go
@@ -197,6 +197,10 @@ func (mc *mysqlConn) startWatcher() {
 }
 
 func (mc *mysqlConn) CheckNamedValue(nv *driver.NamedValue) (err error) {
-	nv.Value, err = converter{}.ConvertValue(nv.Value)
+	value, err := converter{}.ConvertValue(nv.Value)
+	if err != nil {
+		return driver.ErrSkip
+	}
+	nv.Value = value
 	return
 }


### PR DESCRIPTION
### Description
CheckNamedValue was returning a hard error instead of driver.ErrSkip if it couldn't convert the type. This commit intercepts the error and returns driver.ErrSkip to fix the use of Valuers.

Added a test that Valuer types are handled correctly. This test fails without the fix.

CheckNamedValue code was included recently:
https://github.com/go-sql-driver/mysql/pull/690

Issue was reported in:
https://github.com/go-sql-driver/mysql/issues/708

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [-] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
