### PR TITLE
statement: Fix conversion of Valuer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -46,6 +46,7 @@ Kamil Dziedzic <kamil at klecza.pl>
 Kevin Malachowski <kevin at chowski.com>
 Lennart Rudolph <lrudolph at hmc.edu>
 Leonardo YongUk Kim <dalinaum at gmail.com>
+Linh Tran Tuan <linhduonggnu at gmail.com>
 Lion Yang <lion at aosc.xyz>
 Luca Looz <luca.looz92 at gmail.com>
 Lucas Liu <extrafliu at gmail.com>
@@ -72,6 +73,7 @@ Zhenye Xie <xiezhenye at gmail.com>
 
 Barracuda Networks, Inc.
 Counting Ltd.
+CIS Viet Nam JSC
 Google Inc.
 Keybase Inc.
 Pivotal Inc.

--- a/AUTHORS
+++ b/AUTHORS
@@ -73,7 +73,6 @@ Zhenye Xie <xiezhenye at gmail.com>
 
 Barracuda Networks, Inc.
 Counting Ltd.
-CIS Viet Nam JSC
 Google Inc.
 Keybase Inc.
 Pivotal Inc.

--- a/connection_go18.go
+++ b/connection_go18.go
@@ -197,10 +197,6 @@ func (mc *mysqlConn) startWatcher() {
 }
 
 func (mc *mysqlConn) CheckNamedValue(nv *driver.NamedValue) (err error) {
-	value, err := converter{}.ConvertValue(nv.Value)
-	if err != nil {
-		return driver.ErrSkip
-	}
-	nv.Value = value
+	nv.Value, err = converter{}.ConvertValue(nv.Value)
 	return
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -547,10 +547,10 @@ func TestValuerWithValidation(t *testing.T) {
 		var out string
 		var rows *sql.Rows
 
-		dbt.mustExec("CREATE TABLE testValuer (value VARCHAR(255)) CHARACTER SET utf8")
-		dbt.mustExec("INSERT INTO testValuer VALUES (?)", in)
+		dbt.mustExec("CREATE TABLE test (value VARCHAR(255)) CHARACTER SET utf8")
+		dbt.mustExec("INSERT INTO test VALUES (?)", in)
 
-		rows = dbt.mustQuery("SELECT value FROM testValuer")
+		rows = dbt.mustQuery("SELECT value FROM test")
 		defer rows.Close()
 
 		if rows.Next() {
@@ -562,19 +562,11 @@ func TestValuerWithValidation(t *testing.T) {
 			dbt.Errorf("Valuer: no data")
 		}
 
-		if _, err := dbt.db.Exec("INSERT INTO testValuer VALUES (?)", testValuerWithValidation{""}); err == nil {
+		if _, err := dbt.db.Exec("INSERT INTO test VALUES (?)", testValuerWithValidation{""}); err == nil {
 			dbt.Errorf("Failed to check valuer error")
 		}
 
-		if _, err := dbt.db.Exec("INSERT INTO testValuer VALUES (?)", nil); err == nil {
-			dbt.Errorf("Failed to check nil")
-		}
-
-		if _, err := dbt.db.Exec("INSERT INTO testValuer VALUES (?)", map[string]bool{}); err == nil {
-			dbt.Errorf("Failed to check not valuer")
-		}
-
-		dbt.mustExec("DROP TABLE IF EXISTS testValuer")
+		dbt.mustExec("DROP TABLE IF EXISTS test")
 	})
 }
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -547,10 +547,10 @@ func TestValuerWithValidation(t *testing.T) {
 		var out string
 		var rows *sql.Rows
 
-		dbt.mustExec("CREATE TABLE test (value VARCHAR(255)) CHARACTER SET utf8")
-		dbt.mustExec("INSERT INTO test VALUES (?)", in)
+		dbt.mustExec("CREATE TABLE testValuer (value VARCHAR(255)) CHARACTER SET utf8")
+		dbt.mustExec("INSERT INTO testValuer VALUES (?)", in)
 
-		rows = dbt.mustQuery("SELECT value FROM test")
+		rows = dbt.mustQuery("SELECT value FROM testValuer")
 		defer rows.Close()
 
 		if rows.Next() {
@@ -562,11 +562,19 @@ func TestValuerWithValidation(t *testing.T) {
 			dbt.Errorf("Valuer: no data")
 		}
 
-		if _, err := dbt.db.Exec("INSERT INTO test VALUES (?)", testValuerWithValidation{""}); err == nil {
+		if _, err := dbt.db.Exec("INSERT INTO testValuer VALUES (?)", testValuerWithValidation{""}); err == nil {
 			dbt.Errorf("Failed to check valuer error")
 		}
 
-		dbt.mustExec("DROP TABLE IF EXISTS test")
+		if _, err := dbt.db.Exec("INSERT INTO testValuer VALUES (?)", nil); err == nil {
+			dbt.Errorf("Failed to check nil")
+		}
+
+		if _, err := dbt.db.Exec("INSERT INTO testValuer VALUES (?)", map[string]bool{}); err == nil {
+			dbt.Errorf("Failed to check not valuer")
+		}
+
+		dbt.mustExec("DROP TABLE IF EXISTS testValuer")
 	})
 }
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -547,10 +547,10 @@ func TestValuerWithValidation(t *testing.T) {
 		var out string
 		var rows *sql.Rows
 
-		dbt.mustExec("CREATE TABLE test (value VARCHAR(255)) CHARACTER SET utf8")
-		dbt.mustExec("INSERT INTO test VALUES (?)", in)
+		dbt.mustExec("CREATE TABLE testValuer (value VARCHAR(255)) CHARACTER SET utf8")
+		dbt.mustExec("INSERT INTO testValuer VALUES (?)", in)
 
-		rows = dbt.mustQuery("SELECT value FROM test")
+		rows = dbt.mustQuery("SELECT value FROM testValuer")
 		defer rows.Close()
 
 		if rows.Next() {
@@ -562,11 +562,19 @@ func TestValuerWithValidation(t *testing.T) {
 			dbt.Errorf("Valuer: no data")
 		}
 
-		if _, err := dbt.db.Exec("INSERT INTO test VALUES (?)", testValuerWithValidation{""}); err == nil {
+		if _, err := dbt.db.Exec("INSERT INTO testValuer VALUES (?)", testValuerWithValidation{""}); err == nil {
 			dbt.Errorf("Failed to check valuer error")
 		}
 
-		dbt.mustExec("DROP TABLE IF EXISTS test")
+		if _, err := dbt.db.Exec("INSERT INTO testValuer VALUES (?)", nil); err != nil {
+			dbt.Errorf("Failed to check nil")
+		}
+
+		if _, err := dbt.db.Exec("INSERT INTO testValuer VALUES (?)", map[string]bool{}); err == nil {
+			dbt.Errorf("Failed to check not valuer")
+		}
+
+		dbt.mustExec("DROP TABLE IF EXISTS testValuer")
 	})
 }
 

--- a/statement.go
+++ b/statement.go
@@ -137,6 +137,12 @@ func (c converter) ConvertValue(v interface{}) (driver.Value, error) {
 		return v, nil
 	}
 
+	if v != nil {
+		if valuer, ok := v.(driver.Valuer); ok {
+			return valuer.Value()
+		}
+	}
+
 	rv := reflect.ValueOf(v)
 	switch rv.Kind() {
 	case reflect.Ptr:


### PR DESCRIPTION
### Description
Current fix is returning `driver.ErrSkip` when converter failed to convert valuer. 
It should be right to give error validation to valuer instead of skipping like this. In this update, I also give a check to valuer interface and call for it to convert, fix error #708 #706 

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file