### PR TITLE
Flag for disabling microseconds time resolution support

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -41,6 +41,8 @@ type mysqlConn struct {
 	sequence         uint8
 	parseTime        bool
 
+	disableMilliseconds bool
+
 	// for context support (Go 1.8+)
 	watching bool
 	watcher  chan<- mysqlContext
@@ -231,6 +233,9 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 			if v.IsZero() {
 				buf = append(buf, "'0000-00-00'"...)
 			} else {
+				if mc.disableMilliseconds {
+					v = v.Round(time.Second)
+				}
 				v := v.In(mc.cfg.Loc)
 				v = v.Add(time.Nanosecond * 500) // To round under microsecond
 				year := v.Year()

--- a/driver.go
+++ b/driver.go
@@ -64,6 +64,7 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 		return nil, err
 	}
 	mc.parseTime = mc.cfg.ParseTime
+	mc.disableMilliseconds = mc.cfg.DisableMilliseconds
 
 	// Connect to Server
 	if dial, ok := dials[mc.cfg.Net]; ok {

--- a/dsn.go
+++ b/dsn.go
@@ -56,6 +56,7 @@ type Config struct {
 	InterpolateParams       bool // Interpolate placeholders into query string
 	MultiStatements         bool // Allow multiple statements in one query
 	ParseTime               bool // Parse time values to time.Time
+	DisableMilliseconds     bool // Disable DATETIME sub-second precision and round time.Time down.
 	RejectReadOnly          bool // Reject read-only connections
 }
 
@@ -223,6 +224,15 @@ func (cfg *Config) FormatDSN() string {
 		} else {
 			hasParam = true
 			buf.WriteString("?parseTime=true")
+		}
+	}
+
+	if cfg.DisableMilliseconds {
+		if hasParam {
+			buf.WriteString("&disableMilliseconds=true")
+		} else {
+			hasParam = true
+			buf.WriteString("?disableMilliseconds=true")
 		}
 	}
 
@@ -484,6 +494,13 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 		case "parseTime":
 			var isBool bool
 			cfg.ParseTime, isBool = readBool(value)
+			if !isBool {
+				return errors.New("invalid bool value: " + value)
+			}
+
+		case "disableMilliseconds":
+			var isBool bool
+			cfg.DisableMilliseconds, isBool = readBool(value)
 			if !isBool {
 				return errors.New("invalid bool value: " + value)
 			}


### PR DESCRIPTION
This change allows to restore v1.2 behavior of
dealing with time.Time values.

When connection is open with `disableMilliseconds=true`
time.Time values will be rounded DOWN to second resolution
before insert into database.

Related issue #713 

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
