### PR TITLE
Fix prepared statement

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -1671,38 +1671,33 @@ func TestStmtMultiRows(t *testing.T) {
 // * more parameters than fit into the buffer (issue 201)
 // * parameters * 64 > max_allowed_packet (issue 734)
 func TestPreparedManyCols(t *testing.T) {
-	numParams := []int{32, int(defaultBufSize), 65535}
+	numParams := 65535
 	runTests(t, dsn, func(dbt *DBTest) {
-		for _, np := range numParams {
-			query := "SELECT ?" + strings.Repeat(",?", np-1)
-			stmt, err := dbt.db.Prepare(query)
-			if err != nil {
-				dbt.Fatal(err)
-			}
-
-			// create more parameters than fit into the buffer
-			// which will take nil-values
-			params := make([]interface{}, np)
-			rows, err := stmt.Query(params...)
-			if err != nil {
-				stmt.Close()
-				dbt.Fatal(err)
-			}
-			rows.Close()
-
-			// Create 0byte string which we can't send via STMT_LONG_DATA.
-			for i := 0; i < np; i++ {
-				params[i] = ""
-			}
-			rows, err = stmt.Query(params...)
-			if err != nil {
-				stmt.Close()
-				dbt.Fatal(err)
-			}
-			rows.Close()
-
-			stmt.Close()
+		query := "SELECT ?" + strings.Repeat(",?", numParams-1)
+		stmt, err := dbt.db.Prepare(query)
+		if err != nil {
+			dbt.Fatal(err)
 		}
+		defer stmt.Close()
+
+		// create more parameters than fit into the buffer
+		// which will take nil-values
+		params := make([]interface{}, numParams)
+		rows, err := stmt.Query(params...)
+		if err != nil {
+			dbt.Fatal(err)
+		}
+		rows.Close()
+
+		// Create 0byte string which we can't send via STMT_LONG_DATA.
+		for i := 0; i < numParams; i++ {
+			params[i] = ""
+		}
+		rows, err = stmt.Query(params...)
+		if err != nil {
+			dbt.Fatal(err)
+		}
+		rows.Close()
 	})
 }
 

--- a/packets.go
+++ b/packets.go
@@ -912,7 +912,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 	const minPktLen = 4 + 1 + 4 + 1 + 4
 	mc := stmt.mc
 
-	// Determine threshould dynamically to avoid packet size shortage as possible.
+	// Determine threshould dynamically to avoid packet size shortage.
 	longDataSize := mc.maxAllowedPacket / (stmt.paramCount + 1)
 	if longDataSize < 64 {
 		longDataSize = 64

--- a/packets.go
+++ b/packets.go
@@ -912,9 +912,10 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 	const minPktLen = 4 + 1 + 4 + 1 + 4
 	mc := stmt.mc
 
-	longDataSize := mc.maxAllowedPacket / stmt.paramCount
-	if longDataSize < 16 {
-		longDataSize = 16
+	// Determine threshould dynamically to avoid packet size shortage as possible.
+	longDataSize := mc.maxAllowedPacket / (stmt.paramCount + 1)
+	if longDataSize < 64 {
+		longDataSize = 64
 	}
 
 	// Reset packet-sequence

--- a/packets.go
+++ b/packets.go
@@ -912,6 +912,11 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 	const minPktLen = 4 + 1 + 4 + 1 + 4
 	mc := stmt.mc
 
+	longDataSize := mc.maxAllowedPacket / stmt.paramCount
+	if longDataSize < 16 {
+		longDataSize = 16
+	}
+
 	// Reset packet-sequence
 	mc.sequence = 0
 
@@ -1039,7 +1044,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 					paramTypes[i+i] = byte(fieldTypeString)
 					paramTypes[i+i+1] = 0x00
 
-					if len(v) < mc.maxAllowedPacket-pos-len(paramValues)-(len(args)-(i+1))*64 {
+					if len(v) < longDataSize {
 						paramValues = appendLengthEncodedInteger(paramValues,
 							uint64(len(v)),
 						)
@@ -1061,7 +1066,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 				paramTypes[i+i] = byte(fieldTypeString)
 				paramTypes[i+i+1] = 0x00
 
-				if len(v) < mc.maxAllowedPacket-pos-len(paramValues)-(len(args)-(i+1))*64 {
+				if len(v) < longDataSize {
 					paramValues = appendLengthEncodedInteger(paramValues,
 						uint64(len(v)),
 					)


### PR DESCRIPTION
When there are many args and maxAllowedPacket is not enough,
writeExecutePacket() attempted to use STMT_LONG_DATA even for
0byte string.
But writeCommandLongData() doesn't support 0byte data. So it
caused to send malfold packet.

This commit loosen threshold for using STMT_LONG_DATA.

fixes #730

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
