### PR TITLE
Support for sending connection attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
   - sudo service mysql restart
   - .travis/wait_mysql.sh
   - mysql -e 'create database gotest;'
+  - mysql -e 'show databases;'
 
 matrix:
   include:

--- a/AUTHORS
+++ b/AUTHORS
@@ -72,6 +72,7 @@ Shuode Li <elemount at qq.com>
 Soroush Pour <me at soroushjp.com>
 Stan Putrya <root.vagner at gmail.com>
 Stanley Gunawan <gunawan.stanley at gmail.com>
+Vasily Fedoseyev <vasilyfedoseyev at gmail.com>
 Xiangyu Hu <xiangyu.hu at outlook.com>
 Xiaobing Jiang <s7v7nislands at gmail.com>
 Xiuming Chen <cc at cxm.cc>

--- a/README.md
+++ b/README.md
@@ -204,6 +204,16 @@ SELECT u.id FROM users as u
 
 will return `u.id` instead of just `id` if `columnsWithAlias=true`.
 
+##### `connectionAttributes`
+
+```
+Type:           map
+Valid Values:   comma-separated list of attribute:value pairs
+Default:        empty
+```
+
+Allows setting of connection attributes, for example `connectionAttributes=program_name:YourProgramName` will show `YourProgramName` in `Program` field of connections list of Mysql Workbench.
+
 ##### `interpolateParams`
 
 ```

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ SELECT u.id FROM users as u
 
 will return `u.id` instead of just `id` if `columnsWithAlias=true`.
 
-##### `connectionAttributes`
+##### `connectAttrs`
 
 ```
 Type:           map
@@ -212,7 +212,7 @@ Valid Values:   comma-separated list of attribute:value pairs
 Default:        empty
 ```
 
-Allows setting of connection attributes, for example `connectionAttributes=program_name:YourProgramName` will show `YourProgramName` in `Program` field of connections list of Mysql Workbench.
+Allows setting of connection attributes, for example `connectAttrs=program_name:YourProgramName` will show `YourProgramName` in `Program` field of connections list of Mysql Workbench, if your server supports it (requires `performance_schema` to be supported and enabled).
 
 ##### `interpolateParams`
 
@@ -497,4 +497,3 @@ Please read the [MPL 2.0 FAQ](https://www.mozilla.org/en-US/MPL/2.0/FAQ/) if you
 You can read the full terms here: [LICENSE](https://raw.github.com/go-sql-driver/mysql/master/LICENSE).
 
 ![Go Gopher and MySQL Dolphin](https://raw.github.com/wiki/go-sql-driver/mysql/go-mysql-driver_m.jpg "Golang Gopher transporting the MySQL Dolphin in a wheelbarrow")
-

--- a/const.go
+++ b/const.go
@@ -46,7 +46,7 @@ const (
 	clientIgnoreSIGPIPE
 	clientTransactions
 	clientReserved
-	clientSecureConn
+	clientSecureConn // reserved2 in 8.0
 	clientMultiStatements
 	clientMultiResults
 	clientPSMultiResults
@@ -56,6 +56,8 @@ const (
 	clientCanHandleExpiredPasswords
 	clientSessionTrack
 	clientDeprecateEOF
+	clientSslVerifyServerCert clientFlag = 1 << 30
+	clientRememberOptions     clientFlag = 1 << 31
 )
 
 const (

--- a/driver_test.go
+++ b/driver_test.go
@@ -2074,7 +2074,7 @@ func TestEmptyPassword(t *testing.T) {
 		if !strings.HasPrefix(err.Error(), "Error 1045") {
 			t.Fatal(err.Error())
 		}
-  }
+	}
 }
 
 func TestConnectAttrs(t *testing.T) {
@@ -2089,16 +2089,16 @@ func TestConnectAttrs(t *testing.T) {
 	defer db.Close()
 	dbt := &DBTest{t, db}
 
-  // performance_schema seems to be updated with a delay in some conditions, so first see if we are in list:
-  rows := dbt.mustQuery("SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST where ID=CONNECTION_ID()")
-  if rows.Next() {
-  } else {
-    dbt.Error("no data in processlist")
-  }
+	// performance_schema seems to be updated with a delay in some conditions, so first see if we are in list:
+	rows := dbt.mustQuery("SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST where ID=CONNECTION_ID()")
+	if rows.Next() {
+	} else {
+		dbt.Error("no data in processlist")
+	}
 
 	rows, err = dbt.db.Query("select attr_value from performance_schema.session_account_connect_attrs where processlist_id=CONNECTION_ID() and attr_name='program_name'")
 	if err != nil {
-    fmt.Println(err)
+		fmt.Println(err)
 		dbt.Skip("server probably does not support performance_schema.session_account_connect_attrs")
 	}
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -2096,10 +2096,10 @@ func TestConnectAttrs(t *testing.T) {
 		dbt.Error("no data in processlist")
 	}
 
-	rows, err = dbt.db.Query("select attr_value from performance_schema.session_account_connect_attrs where processlist_id=CONNECTION_ID() and attr_name='program_name'")
+	rows, err = dbt.db.Query("select attr_value from performance_schema.session_connect_attrs where processlist_id=CONNECTION_ID() and attr_name='program_name'")
 	if err != nil {
 		fmt.Println(err)
-		dbt.Skip("server probably does not support performance_schema.session_account_connect_attrs")
+		dbt.Skip("server probably does not support performance_schema.session_connect_attrs")
 	}
 
 	if rows.Next() {
@@ -2112,7 +2112,7 @@ func TestConnectAttrs(t *testing.T) {
 		dbt.Error("no data for program_name")
 	}
 
-	rows = dbt.mustQuery("select attr_value from performance_schema.session_account_connect_attrs where processlist_id=CONNECTION_ID() and attr_name='foo'")
+	rows = dbt.mustQuery("select attr_value from performance_schema.session_connect_attrs where processlist_id=CONNECTION_ID() and attr_name='foo'")
 	if rows.Next() {
 		var str string
 		rows.Scan(&str)

--- a/dsn.go
+++ b/dsn.go
@@ -39,7 +39,7 @@ type Config struct {
 	Addr             string            // Network address (requires Net)
 	DBName           string            // Database name
 	Params           map[string]string // Connection parameters
-	Attributes       map[string]string // Connection attributes
+	ConnectAttrs     map[string]string // Connection attributes
 	Collation        string            // Connection collation
 	Loc              *time.Location    // Location for time.Time values
 	MaxAllowedPacket int               // Max packet size allowed
@@ -309,17 +309,17 @@ func (cfg *Config) FormatDSN() string {
 
 	}
 
-	if len(cfg.Attributes) > 0 {
-		// connectionAttributes=program_name:Login Server,other_name:other
+	if len(cfg.ConnectAttrs) > 0 {
+		// connectAttrs=program_name:Login Server,other_name:other
 		if hasParam {
-			buf.WriteString("&connectionAttributes=")
+			buf.WriteString("&connectAttrs=")
 		} else {
 			hasParam = true
-			buf.WriteString("?connectionAttributes=")
+			buf.WriteString("?connectAttrs=")
 		}
 
 		var attr_names []string
-		for attr_name := range cfg.Attributes {
+		for attr_name := range cfg.ConnectAttrs {
 			attr_names = append(attr_names, attr_name)
 		}
 		sort.Strings(attr_names)
@@ -329,7 +329,7 @@ func (cfg *Config) FormatDSN() string {
 			}
 			buf.WriteString(attr_name)
 			buf.WriteByte(':')
-			buf.WriteString(url.QueryEscape(cfg.Attributes[attr_name]))
+			buf.WriteString(url.QueryEscape(cfg.ConnectAttrs[attr_name]))
 		}
 	}
 
@@ -613,23 +613,23 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			if err != nil {
 				return
 			}
-		case "connectionAttributes":
-			if cfg.Attributes == nil {
-				cfg.Attributes = make(map[string]string)
+		case "connectAttrs":
+			if cfg.ConnectAttrs == nil {
+				cfg.ConnectAttrs = make(map[string]string)
 			}
 
-			var attributes string
-			if attributes, err = url.QueryUnescape(value); err != nil {
+			var ConnectAttrs string
+			if ConnectAttrs, err = url.QueryUnescape(value); err != nil {
 				return
 			}
 
 			// program_name:Name,foo:bar
-			for _, attr_str := range strings.Split(attributes, ",") {
+			for _, attr_str := range strings.Split(ConnectAttrs, ",") {
 				attr := strings.SplitN(attr_str, ":", 2)
 				if len(attr) != 2 {
 					continue
 				}
-				cfg.Attributes[attr[0]] = attr[1]
+				cfg.ConnectAttrs[attr[0]] = attr[1]
 			}
 		default:
 			// lazy init

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -71,6 +71,9 @@ var testDSNs = []struct {
 }, {
 	"tcp(de:ad:be:ef::ca:fe)/dbname",
 	&Config{Net: "tcp", Addr: "[de:ad:be:ef::ca:fe]:3306", DBName: "dbname", Collation: "utf8_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true},
+}, {
+	"tcp(127.0.0.1)/dbname?connectionAttributes=program_name:SomeService",
+	&Config{Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Attributes: map[string]string{"program_name": "SomeService"}, Collation: "utf8_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true},
 },
 }
 
@@ -315,6 +318,20 @@ func TestParamsAreSorted(t *testing.T) {
 	actual := cfg.FormatDSN()
 	if actual != expected {
 		t.Errorf("generic Config.Params were not sorted: want %#v, got %#v", expected, actual)
+	}
+}
+
+func TestAttributesAreSorted(t *testing.T) {
+	expected := "/dbname?connectionAttributes=p1:v1,p2:v2"
+	cfg := NewConfig()
+	cfg.DBName = "dbname"
+	cfg.Attributes = map[string]string{
+		"p2": "v2",
+		"p1": "v1",
+	}
+	actual := cfg.FormatDSN()
+	if actual != expected {
+		t.Errorf("generic Config.Attributes were not sorted: want %#v, got %#v", expected, actual)
 	}
 }
 

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -72,8 +72,8 @@ var testDSNs = []struct {
 	"tcp(de:ad:be:ef::ca:fe)/dbname",
 	&Config{Net: "tcp", Addr: "[de:ad:be:ef::ca:fe]:3306", DBName: "dbname", Collation: "utf8_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true},
 }, {
-	"tcp(127.0.0.1)/dbname?connectionAttributes=program_name:SomeService",
-	&Config{Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Attributes: map[string]string{"program_name": "SomeService"}, Collation: "utf8_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true},
+	"tcp(127.0.0.1)/dbname?connectAttrs=program_name:SomeService",
+	&Config{Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", ConnectAttrs: map[string]string{"program_name": "SomeService"}, Collation: "utf8_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true},
 },
 }
 
@@ -322,16 +322,16 @@ func TestParamsAreSorted(t *testing.T) {
 }
 
 func TestAttributesAreSorted(t *testing.T) {
-	expected := "/dbname?connectionAttributes=p1:v1,p2:v2"
+	expected := "/dbname?connectAttrs=p1:v1,p2:v2"
 	cfg := NewConfig()
 	cfg.DBName = "dbname"
-	cfg.Attributes = map[string]string{
+	cfg.ConnectAttrs = map[string]string{
 		"p2": "v2",
 		"p1": "v1",
 	}
 	actual := cfg.FormatDSN()
 	if actual != expected {
-		t.Errorf("generic Config.Attributes were not sorted: want %#v, got %#v", expected, actual)
+		t.Errorf("generic Config.ConnectAttrs were not sorted: want %#v, got %#v", expected, actual)
 	}
 }
 

--- a/packets.go
+++ b/packets.go
@@ -202,10 +202,15 @@ func (mc *mysqlConn) readHandshakePacket() ([]byte, string, error) {
 	if len(data) > pos {
 		// character set [1 byte]
 		// status flags [2 bytes]
+		pos += 1 + 2
+
 		// capability flags (upper 2 bytes) [2 bytes]
+		mc.flags |= clientFlag(uint32(binary.LittleEndian.Uint16(data[pos:pos+2])) << 16)
+		pos += 2
+
 		// length of auth-plugin-data [1 byte]
 		// reserved (all [00]) [10 bytes]
-		pos += 1 + 2 + 2 + 1 + 10
+		pos += 1 + 10
 
 		// second part of the password cipher [mininum 13 bytes],
 		// where len=MAX(13, length of auth-plugin-data - 8)
@@ -282,6 +287,24 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, addNUL bool, 
 	pktLen := 4 + 4 + 1 + 23 + len(mc.cfg.User) + 1 + len(authRespLEI) + len(authResp) + 21 + 1
 	if addNUL {
 		pktLen++
+	}
+
+	connectAttrsBuf := make([]byte, 0, 100)
+	if mc.flags&clientConnectAttrs != 0 {
+		clientFlags |= clientConnectAttrs
+		connectAttrsBuf = appendLengthEncodedString(connectAttrsBuf, []byte("_client_name"))
+		connectAttrsBuf = appendLengthEncodedString(connectAttrsBuf, []byte("go-mysql-driver"))
+
+		for k, v := range mc.cfg.Attributes {
+			if k == "_client_name" {
+				// do not allow overwriting reserved values
+				continue
+			}
+			connectAttrsBuf = appendLengthEncodedString(connectAttrsBuf, []byte(k))
+			connectAttrsBuf = appendLengthEncodedString(connectAttrsBuf, []byte(v))
+		}
+		connectAttrsBuf = appendLengthEncodedString(make([]byte, 0, 100), connectAttrsBuf)
+		pktLen += len(connectAttrsBuf)
 	}
 
 	// To specify a db name
@@ -367,6 +390,11 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, addNUL bool, 
 
 	pos += copy(data[pos:], plugin)
 	data[pos] = 0x00
+	pos++
+
+	if clientFlags&clientConnectAttrs != 0 {
+		pos += copy(data[pos:], connectAttrsBuf)
+	}
 
 	// Send Auth packet
 	return mc.writePacket(data)

--- a/packets.go
+++ b/packets.go
@@ -295,7 +295,7 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, addNUL bool, 
 		connectAttrsBuf = appendLengthEncodedString(connectAttrsBuf, []byte("_client_name"))
 		connectAttrsBuf = appendLengthEncodedString(connectAttrsBuf, []byte("go-mysql-driver"))
 
-		for k, v := range mc.cfg.Attributes {
+		for k, v := range mc.cfg.ConnectAttrs {
 			if k == "_client_name" {
 				// do not allow overwriting reserved values
 				continue

--- a/utils.go
+++ b/utils.go
@@ -466,6 +466,12 @@ func skipLengthEncodedString(b []byte) (int, error) {
 	return n, io.EOF
 }
 
+// encodes a bytes slice with prepended length-encoded size and appends it to the given bytes slice
+func appendLengthEncodedString(b []byte, str []byte) []byte {
+	b = appendLengthEncodedInteger(b, uint64(len(str)))
+	return append(b, str...)
+}
+
 // returns the number read, whether the value is NULL and the number of bytes read
 func readLengthEncodedInteger(b []byte) (uint64, bool, int) {
 	// See issue #349


### PR DESCRIPTION
### Description
This PR adds support for sending connection attributes, which are used for identifying individual connections in mysql. (https://dev.mysql.com/doc/refman/5.7/en/performance-schema-connection-attribute-tables.html)
For example libmysql sets attributes `_client_name`, `_pid`, `_client_version`, `_os`, `_platform`. This adds default `_client_name=go-mysql-driver`

### Checklist
- [+] Code compiles correctly
- [+] Created tests which fail without the change (if possible)
- [+] All tests passing
- [+] Extended the README / documentation, if necessary
- [+] Added myself / the copyright holder to the AUTHORS file
