### PR TITLE
Fix error message for unsupported isolation level.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@
 
 Aaron Hopkins <go-sql-driver at die.net>
 Achille Roussel <achille.roussel at gmail.com>
+Alexey Palazhchenko <alexey.palazhchenko at gmail.com>
 Arne Hormann <arnehormann at gmail.com>
 Asta Xie <xiemengjun at gmail.com>
 Bulat Gaifullin <gaifullinbf at gmail.com>
@@ -61,8 +62,8 @@ Paul Bonser <misterpib at gmail.com>
 Peter Schultz <peter.schultz at classmarkets.com>
 Rebecca Chin <rchin at pivotal.io>
 Reed Allman <rdallman10 at gmail.com>
-Runrioter Wung <runrioter at gmail.com>
 Robert Russell <robert at rrbrussell.com>
+Runrioter Wung <runrioter at gmail.com>
 Shuode Li <elemount at qq.com>
 Soroush Pour <me at soroushjp.com>
 Stan Putrya <root.vagner at gmail.com>
@@ -79,5 +80,6 @@ Counting Ltd.
 Google Inc.
 InfoSum Ltd.
 Keybase Inc.
+Percona LLC
 Pivotal Inc.
 Stripe Inc.

--- a/utils_go18.go
+++ b/utils_go18.go
@@ -15,6 +15,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 )
 
 func cloneTLSConfig(c *tls.Config) *tls.Config {
@@ -44,6 +45,6 @@ func mapIsolationLevel(level driver.IsolationLevel) (string, error) {
 	case sql.LevelSerializable:
 		return "SERIALIZABLE", nil
 	default:
-		return "", errors.New("mysql: unsupported isolation level: " + string(level))
+		return "", fmt.Errorf("mysql: unsupported isolation level: %v", level)
 	}
 }

--- a/utils_go18_test.go
+++ b/utils_go18_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestIsolationLevelMapping(t *testing.T) {
-
 	data := []struct {
 		level    driver.IsolationLevel
 		expected string
@@ -47,8 +46,12 @@ func TestIsolationLevelMapping(t *testing.T) {
 	}
 
 	// check unsupported mapping
-	if actual, err := mapIsolationLevel(driver.IsolationLevel(sql.LevelLinearizable)); actual != "" || err == nil {
+	expectedErr := "mysql: unsupported isolation level: 7"
+	actual, err := mapIsolationLevel(driver.IsolationLevel(sql.LevelLinearizable))
+	if actual != "" || err == nil {
 		t.Fatal("Expected error on unsupported isolation level")
 	}
-
+	if err.Error() != expectedErr {
+		t.Fatalf("Expected error to be %q, got %q", expectedErr, err)
+	}
 }


### PR DESCRIPTION
### Description

It was "mysql: unsupported isolation level: \a" due to wrong conversion from int to string.

See also https://github.com/golang/go/issues/23632

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
