### PR TITLE
Use database/sql ConvertValue() except for uint64 with high bit set

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@
 
 Aaron Hopkins <go-sql-driver at die.net>
 Achille Roussel <achille.roussel at gmail.com>
+Andrew Reid <andrew.reid at tixtrack.com>
 Arne Hormann <arnehormann at gmail.com>
 Asta Xie <xiemengjun at gmail.com>
 Bulat Gaifullin <gaifullinbf at gmail.com>

--- a/driver_test.go
+++ b/driver_test.go
@@ -547,6 +547,7 @@ func TestValuerWithValidation(t *testing.T) {
 		var out string
 		var rows *sql.Rows
 
+		dbt.mustExec("DROP TABLE IF EXISTS testValuer")
 		dbt.mustExec("CREATE TABLE testValuer (value VARCHAR(255)) CHARACTER SET utf8")
 		dbt.mustExec("INSERT INTO testValuer VALUES (?)", in)
 
@@ -568,6 +569,10 @@ func TestValuerWithValidation(t *testing.T) {
 
 		if _, err := dbt.db.Exec("INSERT INTO testValuer VALUES (?)", nil); err != nil {
 			dbt.Errorf("Failed to check nil")
+		}
+
+		if _, err := dbt.db.Exec("INSERT INTO testValuer VALUES (?)", (*testValuerWithValidation)(nil)); err != nil {
+			dbt.Errorf("Failed to check typed nil")
 		}
 
 		if _, err := dbt.db.Exec("INSERT INTO testValuer VALUES (?)", map[string]bool{}); err == nil {

--- a/statement_test.go
+++ b/statement_test.go
@@ -9,118 +9,116 @@
 package mysql
 
 import (
-	"bytes"
+	"database/sql/driver"
 	"testing"
+	"time"
 )
 
-func TestConvertDerivedString(t *testing.T) {
-	type derived string
+func TestValueThatIsValue(t *testing.T) {
+	now := time.Now()
+	inputs := []interface{}{nil, float64(1.0), int64(17), "ABC", now}
 
-	output, err := converter{}.ConvertValue(derived("value"))
-	if err != nil {
-		t.Fatal("Derived string type not convertible", err)
-	}
-
-	if output != "value" {
-		t.Fatalf("Derived string type not converted, got %#v %T", output, output)
-	}
-}
-
-func TestConvertDerivedByteSlice(t *testing.T) {
-	type derived []uint8
-
-	output, err := converter{}.ConvertValue(derived("value"))
-	if err != nil {
-		t.Fatal("Byte slice not convertible", err)
-	}
-
-	if bytes.Compare(output.([]byte), []byte("value")) != 0 {
-		t.Fatalf("Byte slice not converted, got %#v %T", output, output)
-	}
-}
-
-func TestConvertDerivedUnsupportedSlice(t *testing.T) {
-	type derived []int
-
-	_, err := converter{}.ConvertValue(derived{1})
-	if err == nil || err.Error() != "unsupported type mysql.derived, a slice of int" {
-		t.Fatal("Unexpected error", err)
-	}
-}
-
-func TestConvertDerivedBool(t *testing.T) {
-	type derived bool
-
-	output, err := converter{}.ConvertValue(derived(true))
-	if err != nil {
-		t.Fatal("Derived bool type not convertible", err)
-	}
-
-	if output != true {
-		t.Fatalf("Derived bool type not converted, got %#v %T", output, output)
-	}
-}
-
-func TestConvertPointer(t *testing.T) {
-	str := "value"
-
-	output, err := converter{}.ConvertValue(&str)
-	if err != nil {
-		t.Fatal("Pointer type not convertible", err)
-	}
-
-	if output != "value" {
-		t.Fatalf("Pointer type not converted, got %#v %T", output, output)
-	}
-}
-
-func TestConvertSignedIntegers(t *testing.T) {
-	values := []interface{}{
-		int8(-42),
-		int16(-42),
-		int32(-42),
-		int64(-42),
-		int(-42),
-	}
-
-	for _, value := range values {
-		output, err := converter{}.ConvertValue(value)
+	for _, in := range inputs {
+		out, err := converter{}.ConvertValue(in)
 		if err != nil {
-			t.Fatalf("%T type not convertible %s", value, err)
+			t.Fatalf("Value %#v %T not needing conversion caused error: %s", in, in, err)
 		}
-
-		if output != int64(-42) {
-			t.Fatalf("%T type not converted, got %#v %T", value, output, output)
+		if out != in {
+			t.Fatalf("Value %#v %T altered in conversion got %#v %T", in, in, out, out)
 		}
 	}
 }
 
-func TestConvertUnsignedIntegers(t *testing.T) {
-	values := []interface{}{
-		uint8(42),
-		uint16(42),
-		uint32(42),
-		uint64(42),
-		uint(42),
-	}
+func TestValueThatIsPtrToValue(t *testing.T) {
+	w := "ABC"
+	x := &w
+	y := &x
+	inputs := []interface{}{x, y}
 
-	for _, value := range values {
-		output, err := converter{}.ConvertValue(value)
+	for _, in := range inputs {
+		out, err := converter{}.ConvertValue(in)
 		if err != nil {
-			t.Fatalf("%T type not convertible %s", value, err)
+			t.Fatalf("Pointer %#v %T to value not needing conversion caused error: %s", in, in, err)
 		}
-
-		if output != int64(42) {
-			t.Fatalf("%T type not converted, got %#v %T", value, output, output)
+		if out != w {
+			t.Fatalf("Value %#v %T not resolved to string in conversion (got %#v %T)", in, in, out, out)
 		}
 	}
+}
 
-	output, err := converter{}.ConvertValue(^uint64(0))
-	if err != nil {
-		t.Fatal("uint64 high-bit not convertible", err)
+func TestValueThatIsTypedPtrToNil(t *testing.T) {
+	var w *string
+	x := &w
+	y := &x
+	inputs := []interface{}{x, y}
+
+	for _, in := range inputs {
+		out, err := converter{}.ConvertValue(in)
+		if err != nil {
+			t.Fatalf("Pointer %#v %T to nil value caused error: %s", in, in, err)
+		}
+		if out != nil {
+			t.Fatalf("Pointer to nil did not Value as nil")
+		}
 	}
+}
 
-	if output != "18446744073709551615" {
-		t.Fatalf("uint64 high-bit not converted, got %#v %T", output, output)
+type implementsValuer uint64
+
+func (me implementsValuer) Value() (driver.Value, error) {
+	return string(me), nil
+}
+func TestTypesThatImplementValuerAreSkipped(t *testing.T) {
+	// Have to test on a uint64 with high bit set - as we skip everything else anyhow
+	x := implementsValuer(^uint64(0))
+	y := &x
+	z := &y
+	var a *implementsValuer
+	b := &a
+	c := &b
+	inputs := []interface{}{x, y, z, a, b, c}
+
+	for _, in := range inputs {
+		_, err := converter{}.ConvertValue(in)
+		if err != driver.ErrSkip {
+			t.Fatalf("Conversion of Valuer implementing type %T not skipped", in)
+		}
+	}
+}
+
+func TestTypesThatAreNotValuesAreSkipped(t *testing.T) {
+	type derived1 string  // convertable
+	type derived2 []uint8 // convertable
+	type derived3 []int   // not convertable
+	type derived4 uint64  // without the high bit set
+	inputs := []interface{}{derived1("ABC"), derived2([]uint8{'A', 'B'}), derived3([]int{17, 32}), derived3(nil), derived4(26)}
+
+	for _, in := range inputs {
+		_, err := converter{}.ConvertValue(in)
+		if err != driver.ErrSkip {
+			t.Fatalf("Conversion of non-value value %#v %T not skipped", in, in)
+		}
+	}
+}
+
+func TestConvertLargeUnsignedIntegers(t *testing.T) {
+	type derived uint64
+	type derived2 *uint64
+	v := ^uint64(0)
+	w := &v
+	x := derived(v)
+	y := &x
+	z := derived2(w)
+
+	inputs := []interface{}{v, w, x, y, z}
+
+	for _, in := range inputs {
+		out, err := converter{}.ConvertValue(in)
+		if err != nil {
+			t.Fatalf("uint64 high-bit not convertible for type %T", in)
+		}
+		if out != "18446744073709551615" {
+			t.Fatalf("uint64 high-bit not converted, got %#v %T", out, out)
+		}
 	}
 }


### PR DESCRIPTION
### Description
This address #739 in one of the two ways proposed in that discussion.

A combination of #690 and subsequent fixes #708, #709 & #710 left the behaviour of `ConvertValue()` unintentionally different from the reference `ConvertValue()` implementation in `database/sql/driver`.

Rather than patch up the difference by copying from `database/sql/driver` this PR proposes using `ErrSkip` to defer to the default `ConvertValue()` implementation in all cases except those needed to handle `uint64`, `*uint64` etc with their high bit set.

The test in `driver_test.go` is the test that fails without this change.  The remaining tests are substantially changed because `ConvertValue()` now returns `ErrSkip` in many cases 

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
