### PR TITLE
Use of the multiple statement with prepared statements is not support…

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -312,7 +312,7 @@ func (mc *mysqlConn) Exec(query string, args []driver.Value) (driver.Result, err
 		return nil, driver.ErrBadConn
 	}
 	if len(args) != 0 {
-		if !mc.cfg.InterpolateParams {
+		if !mc.cfg.InterpolateParams && !mc.cfg.MultiStatements {
 			return nil, driver.ErrSkip
 		}
 		// try to interpolate the parameters to save extra roundtrips for preparing and closing a statement
@@ -373,7 +373,7 @@ func (mc *mysqlConn) query(query string, args []driver.Value) (*textRows, error)
 		return nil, driver.ErrBadConn
 	}
 	if len(args) != 0 {
-		if !mc.cfg.InterpolateParams {
+		if !mc.cfg.InterpolateParams && !mc.cfg.MultiStatements {
 			return nil, driver.ErrSkip
 		}
 		// try client-side prepare to reduce roundtrip


### PR DESCRIPTION
…ed in MySQL, query and exec with args should be interpolated into a single query string

When multiStatements is used and interpolateParams is default, query or exec with args will send prepared query statement to MySQL, which is not supported by MySQL.  Interpolating args  into a single query string
can make it work fine.


