### PR TITLE
Update ConvertValue() to match the database/sql/driver implementation except for uint64

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@
 Aaron Hopkins <go-sql-driver at die.net>
 Achille Roussel <achille.roussel at gmail.com>
 Alexey Palazhchenko <alexey.palazhchenko at gmail.com>
+Andrew Reid <andrew.reid at tixtrack.com>
 Arne Hormann <arnehormann at gmail.com>
 Asta Xie <xiemengjun at gmail.com>
 Bulat Gaifullin <gaifullinbf at gmail.com>

--- a/driver_go18_test.go
+++ b/driver_go18_test.go
@@ -800,13 +800,7 @@ func TestRowsColumnTypes(t *testing.T) {
 func TestValuerWithValueReceiverGivenNilValue(t *testing.T) {
 	runTests(t, dsn, func(dbt *DBTest) {
 		dbt.mustExec("CREATE TABLE test (value VARCHAR(255))")
-
-		defer func() {
-			if r := recover(); r != nil {
-				dbt.Errorf("Failed to check typed nil before calling valuer with value receiver")
-			}
-		}()
-
 		dbt.db.Exec("INSERT INTO test VALUES (?)", (*testValuer)(nil))
+		// This test will panic on the INSERT if ConvertValue() does not check for typed nil before calling Value()
 	})
 }

--- a/driver_go18_test.go
+++ b/driver_go18_test.go
@@ -796,3 +796,17 @@ func TestRowsColumnTypes(t *testing.T) {
 		})
 	}
 }
+
+func TestValuerWithValueReceiverGivenNilValue(t *testing.T) {
+	runTests(t, dsn, func(dbt *DBTest) {
+		dbt.mustExec("CREATE TABLE test (value VARCHAR(255))")
+
+		defer func() {
+			if r := recover(); r != nil {
+				dbt.Errorf("Failed to check typed nil before calling valuer with value receiver")
+			}
+		}()
+
+		dbt.db.Exec("INSERT INTO test VALUES (?)", (*testValuer)(nil))
+	})
+}

--- a/statement.go
+++ b/statement.go
@@ -132,6 +132,11 @@ func (stmt *mysqlStmt) query(args []driver.Value) (*binaryRows, error) {
 
 type converter struct{}
 
+// ConvertValue mirrors the reference/default converter in database/sql/driver
+// with _one_ exception.  We support uint64 with their high bit and the default
+// implementation does not.  This function should be kept in sync with
+// database/sql/driver defaultConverter.ConvertValue() except for that
+// deliberate difference.
 func (c converter) ConvertValue(v interface{}) (driver.Value, error) {
 	if driver.IsValue(v) {
 		return v, nil
@@ -194,7 +199,8 @@ var valuerReflectType = reflect.TypeOf((*driver.Valuer)(nil)).Elem()
 // still use nil pointers to those types to mean nil/NULL, just like
 // string/*string.
 //
-// This function is copied from the database/sql package.
+// This is an exact copy of the same-named unexported function from the
+// database/sql package.
 func callValuerValue(vr driver.Valuer) (v driver.Value, err error) {
 	if rv := reflect.ValueOf(vr); rv.Kind() == reflect.Ptr &&
 		rv.IsNil() &&


### PR DESCRIPTION
### Description
This addresses #739 by copying across more recent changes to `ConvertValue()` from the reference implementation in `database/sql/driver` [here](https://github.com/golang/go/blob/master/src/database/sql/driver/types.go#L233).  The important change is the use of `callValuerValue` which checks for `nil` before calling a Valuer implemented with value receiver.  This was added to `database/sql/driver` for go 1.8 in [this commit](https://github.com/golang/go/commit/0ce1d79a6a771f7449ec493b993ed2a720917870)

This PR leaves the only difference from the reference implementation being the handling of `uint64` with their high bit set.

The test added to `driver_go18_test.go` will fail for go 1.9 and 1.10 without this change.  The code is not exercised for go 1.8 as it pre-dates #690.  The test cannot pass for go 1.7 as that pre-dates the relevant changes in `database/sql` - which is why the test is added to `driver_go18_test.go`.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
