### PR TITLE
travis: Test with Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
   - 1.7.x
   - 1.8.x
   - 1.9.x
+  - 1.10.x
   - master
 
 before_install:
@@ -21,7 +22,7 @@ matrix:
     - env: DB=MYSQL57
       sudo: required
       dist: trusty
-      go: 1.9.x
+      go: 1.10.x
       services:
         - docker
       before_install:
@@ -43,7 +44,7 @@ matrix:
     - env: DB=MARIA55
       sudo: required
       dist: trusty
-      go: 1.9.x
+      go: 1.10.x
       services:
         - docker
       before_install:
@@ -65,7 +66,7 @@ matrix:
     - env: DB=MARIA10_1
       sudo: required
       dist: trusty
-      go: 1.9.x
+      go: 1.10.x
       services:
         - docker
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,6 @@ matrix:
 script:
   - go test -v -covermode=count -coverprofile=coverage.out
   - go vet ./...
-  - test -z "$(gofmt -d -s . | tee /dev/stderr)"
+  - .travis/gofmt.sh
 after_script:
   - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci

--- a/.travis/gofmt.sh
+++ b/.travis/gofmt.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -ev
+
+# Only check for go1.10+ since the gofmt style changed
+if [[ $(go version) =~ go1\.([0-9]+) ]] && ((${BASH_REMATCH[1]} >= 10)); then
+    test -z "$(gofmt -d -s . | tee /dev/stderr)"
+fi


### PR DESCRIPTION
### Description
Adds Go 1.10 to the versions Travis tests against.
Although we agreed to only support the latest 3 Go versions, I didn't remove Go 1.7 yet.
Instead, I would postpone it until shortly after the v1.4.0 release.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
