### PR TITLE
kill queries on timeout

### DIFF
--- a/connection_go18.go
+++ b/connection_go18.go
@@ -160,6 +160,10 @@ func (mc *mysqlConn) watchCancel(ctx context.Context) error {
 	select {
 	default:
 	case <-ctx.Done():
+		killErr := mc.kill()
+		if killErr != nil {
+			errLog.Print("failed to kill query: ", killErr)
+		}
 		return ctx.Err()
 	}
 	if mc.watcher == nil {

--- a/connection_go18.go
+++ b/connection_go18.go
@@ -160,10 +160,6 @@ func (mc *mysqlConn) watchCancel(ctx context.Context) error {
 	select {
 	default:
 	case <-ctx.Done():
-		killErr := mc.kill()
-		if killErr != nil {
-			errLog.Print("failed to kill query: ", killErr)
-		}
 		return ctx.Err()
 	}
 	if mc.watcher == nil {

--- a/driver.go
+++ b/driver.go
@@ -150,6 +150,9 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 		return nil, err
 	}
 
+	mc.d = d
+	mc.dsn = dsn
+
 	return mc, nil
 }
 

--- a/driver.go
+++ b/driver.go
@@ -151,8 +151,6 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 	}
 
 	mc.d = d
-	mc.dsn = dsn
-
 	return mc, nil
 }
 

--- a/dsn.go
+++ b/dsn.go
@@ -57,6 +57,7 @@ type Config struct {
 	MultiStatements         bool // Allow multiple statements in one query
 	ParseTime               bool // Parse time values to time.Time
 	RejectReadOnly          bool // Reject read-only connections
+	KillQueryOnTimeout      bool // kill query on the server side if context timed out
 }
 
 // NewConfig creates a new Config and sets default values.
@@ -251,6 +252,15 @@ func (cfg *Config) FormatDSN() string {
 		} else {
 			hasParam = true
 			buf.WriteString("?rejectReadOnly=true")
+		}
+	}
+
+	if cfg.KillQueryOnTimeout {
+		if hasParam {
+			buf.WriteString("&killQueryOnTimeout=true")
+		} else {
+			hasParam = true
+			buf.WriteString("?killQueryOnTimeout=true")
 		}
 	}
 
@@ -508,6 +518,14 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 		case "rejectReadOnly":
 			var isBool bool
 			cfg.RejectReadOnly, isBool = readBool(value)
+			if !isBool {
+				return errors.New("invalid bool value: " + value)
+			}
+
+		// Kill queries on context timeout
+		case "killQueryOnTimeout":
+			var isBool bool
+			cfg.KillQueryOnTimeout, isBool = readBool(value)
 			if !isBool {
 				return errors.New("invalid bool value: " + value)
 			}

--- a/packets.go
+++ b/packets.go
@@ -179,8 +179,11 @@ func (mc *mysqlConn) readInitPacket() ([]byte, error) {
 	}
 
 	// server version [null terminated string]
+	idPos := 1 + bytes.IndexByte(data[1:], 0x00) + 1
+	mc.id = int(binary.LittleEndian.Uint32(data[idPos : idPos+4]))
+
 	// connection id [4 bytes]
-	pos := 1 + bytes.IndexByte(data[1:], 0x00) + 1 + 4
+	pos := idPos + 4
 
 	// first part of the password cipher [8 bytes]
 	cipher := data[pos : pos+8]

--- a/packets.go
+++ b/packets.go
@@ -179,10 +179,9 @@ func (mc *mysqlConn) readInitPacket() ([]byte, error) {
 	}
 
 	// server version [null terminated string]
+	// connection id [4 bytes]
 	idPos := 1 + bytes.IndexByte(data[1:], 0x00) + 1
 	mc.id = int(binary.LittleEndian.Uint32(data[idPos : idPos+4]))
-
-	// connection id [4 bytes]
 	pos := idPos + 4
 
 	// first part of the password cipher [8 bytes]


### PR DESCRIPTION
### Description
Added mechanism to kill orphan queries after context timeout.
Used approach is similar to one used in postgres driver: if context is cancelled, new connection is opened and than KILL query is executed.
Query is killed using id of corresponding connection which is saved on initial handshake. 

Related issues: [#731](https://github.com/go-sql-driver/mysql/issues/731), [#496](https://github.com/go-sql-driver/mysql/issues/496)

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
