### PR TITLE
Change ErrUnknownPlugin to a func which can take the plugin name

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -46,6 +46,7 @@ Olivier Mengué <dolmen at cpan.org>
 Paul Bonser <misterpib at gmail.com>
 Peter Schultz <peter.schultz at classmarkets.com>
 Runrioter Wung <runrioter at gmail.com>
+Simon J Mudd <sjmudd at pobox.com>
 Soroush Pour <me at soroushjp.com>
 Stan Putrya <root.vagner at gmail.com>
 Stanley Gunawan <gunawan.stanley at gmail.com>

--- a/errors.go
+++ b/errors.go
@@ -25,13 +25,17 @@ var (
 	ErrCleartextPassword = errors.New("this user requires clear text authentication. If you still want to use it, please add 'allowCleartextPasswords=1' to your DSN")
 	ErrNativePassword    = errors.New("this user requires mysql native password authentication.")
 	ErrOldPassword       = errors.New("this user requires old password authentication. If you still want to use it, please add 'allowOldPasswords=1' to your DSN. See also https://github.com/go-sql-driver/mysql/wiki/old_passwords")
-	ErrUnknownPlugin     = errors.New("this authentication plugin is not supported")
 	ErrOldProtocol       = errors.New("MySQL server does not support required protocol 41+")
 	ErrPktSync           = errors.New("commands out of sync. You can't run this command now")
 	ErrPktSyncMul        = errors.New("commands out of sync. Did you run multiple statements at once?")
 	ErrPktTooLarge       = errors.New("packet for query is too large. Try adjusting the 'max_allowed_packet' variable on the server")
 	ErrBusyBuffer        = errors.New("busy buffer")
 )
+
+// ErrUnknownPlugin returns an error with the name of the plugin that is not supported
+func ErrUnknownPlugin(name string) error {
+	return fmt.Errorf("authentication plugin %q is not supported", name)
+}
 
 var errLog = Logger(log.New(os.Stderr, "[mysql] ", log.Ldate|log.Ltime|log.Lshortfile))
 

--- a/packets.go
+++ b/packets.go
@@ -496,7 +496,7 @@ func (mc *mysqlConn) readResultOK() ([]byte, error) {
 					// using mysql default authentication method
 					return cipher, ErrNativePassword
 				} else {
-					return cipher, ErrUnknownPlugin
+					return cipher, ErrUnknownPlugin(plugin)
 				}
 			} else {
 				// https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::OldAuthSwitchRequest


### PR DESCRIPTION
### Description

Change `ErrUnknownPlugin` to a func which can take the plugin name

MySQL 8.0 brings a new authentication plugin which is enabled by default. This plugin is not yet handled by the go driver.

The error message which is returned is somewhat vague and this is likely to cause confusion.

The change provides the same error message but includes the plugin name which will be easier for people to lookup. So rather than returning the error:

`this authentication plugin is not supported`

we return something like:

`authentication plugin "caching_sha2_password" is not supported`

### Checklist
- [x] Code compiles correctly
- [x] Added myself / the copyright holder to the AUTHORS file
