### PR TITLE
Travis: Add  MySQL 8.0 test enviornment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ matrix:
         - docker pull mysql:8.0
         - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
           mysql:8.0 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB --local-infile=1
-        - sleep 10
         - cp .travis/docker.cnf ~/.my.cnf
         - .travis/wait_mysql.sh
       before_script:
@@ -52,7 +51,6 @@ matrix:
         - docker pull mysql:5.7
         - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
           mysql:5.7 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB --local-infile=1
-        - sleep 10
         - cp .travis/docker.cnf ~/.my.cnf
         - .travis/wait_mysql.sh
       before_script:
@@ -73,7 +71,6 @@ matrix:
         - docker pull mariadb:5.5
         - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
           mariadb:5.5 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB --local-infile=1
-        - sleep 10
         - cp .travis/docker.cnf ~/.my.cnf
         - .travis/wait_mysql.sh
       before_script:
@@ -94,7 +91,6 @@ matrix:
         - docker pull mariadb:10.1
         - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
           mariadb:10.1 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB --local-infile=1
-        - sleep 10
         - cp .travis/docker.cnf ~/.my.cnf
         - .travis/wait_mysql.sh
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,9 @@ matrix:
         - docker pull mysql:8.0
         - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
           mysql:8.0 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB --local-infile=1
-        - sleep 30
+        - sleep 10
         - cp .travis/docker.cnf ~/.my.cnf
-        - mysql --print-defaults
-        # - .travis/wait_mysql.sh
+        - .travis/wait_mysql.sh
       before_script:
         - export MYSQL_TEST_USER=gotest
         - export MYSQL_TEST_PASS=secret
@@ -53,9 +52,8 @@ matrix:
         - docker pull mysql:5.7
         - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
           mysql:5.7 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB --local-infile=1
-        - sleep 30
+        - sleep 10
         - cp .travis/docker.cnf ~/.my.cnf
-        - mysql --print-defaults
         - .travis/wait_mysql.sh
       before_script:
         - export MYSQL_TEST_USER=gotest
@@ -75,9 +73,8 @@ matrix:
         - docker pull mariadb:5.5
         - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
           mariadb:5.5 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB --local-infile=1
-        - sleep 30
+        - sleep 10
         - cp .travis/docker.cnf ~/.my.cnf
-        - mysql --print-defaults
         - .travis/wait_mysql.sh
       before_script:
         - export MYSQL_TEST_USER=gotest
@@ -97,9 +94,8 @@ matrix:
         - docker pull mariadb:10.1
         - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
           mariadb:10.1 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB --local-infile=1
-        - sleep 30
+        - sleep 10
         - cp .travis/docker.cnf ~/.my.cnf
-        - mysql --print-defaults
         - .travis/wait_mysql.sh
       before_script:
         - export MYSQL_TEST_USER=gotest

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
         - go get github.com/mattn/goveralls
         - docker pull mysql:8.0
         - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
-          mysql:8.0 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB
+          mysql:8.0 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB --local-infile=1
         - sleep 30
         - cp .travis/docker.cnf ~/.my.cnf
         - mysql --print-defaults
@@ -52,7 +52,7 @@ matrix:
         - go get github.com/mattn/goveralls
         - docker pull mysql:5.7
         - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
-          mysql:5.7 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB
+          mysql:5.7 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB --local-infile=1
         - sleep 30
         - cp .travis/docker.cnf ~/.my.cnf
         - mysql --print-defaults
@@ -74,7 +74,7 @@ matrix:
         - go get github.com/mattn/goveralls
         - docker pull mariadb:5.5
         - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
-          mariadb:5.5 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB
+          mariadb:5.5 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB --local-infile=1
         - sleep 30
         - cp .travis/docker.cnf ~/.my.cnf
         - mysql --print-defaults
@@ -96,7 +96,7 @@ matrix:
         - go get github.com/mattn/goveralls
         - docker pull mariadb:10.1
         - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
-          mariadb:10.1 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB
+          mariadb:10.1 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB --local-infile=1
         - sleep 30
         - cp .travis/docker.cnf ~/.my.cnf
         - mysql --print-defaults

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         - sleep 30
         - cp .travis/docker.cnf ~/.my.cnf
         - mysql --print-defaults
-        - .travis/wait_mysql.sh
+        # - .travis/wait_mysql.sh
       before_script:
         - export MYSQL_TEST_USER=gotest
         - export MYSQL_TEST_PASS=secret

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,28 @@ before_script:
 
 matrix:
   include:
+    - env: DB=MYSQL8
+      sudo: required
+      dist: trusty
+      go: 1.10.x
+      services:
+        - docker
+      before_install:
+        - go get golang.org/x/tools/cmd/cover
+        - go get github.com/mattn/goveralls
+        - docker pull mysql:8.0
+        - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
+          mysql:8.0 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB
+        - sleep 30
+        - cp .travis/docker.cnf ~/.my.cnf
+        - mysql --print-defaults
+        - .travis/wait_mysql.sh
+      before_script:
+        - export MYSQL_TEST_USER=gotest
+        - export MYSQL_TEST_PASS=secret
+        - export MYSQL_TEST_ADDR=127.0.0.1:3307
+        - export MYSQL_TEST_CONCURRENT=1
+
     - env: DB=MYSQL57
       sudo: required
       dist: trusty

--- a/.travis/wait_mysql.sh
+++ b/.travis/wait_mysql.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 while :
 do
-    sleep 3
-    if mysql -e 'select version()'; then
+    if mysql -e 'select version()' 2>&1 | grep 'ERROR 1045 (28000):\|ERROR 2059 (HY000):'; then
         break
     fi
+    sleep 3
 done

--- a/.travis/wait_mysql.sh
+++ b/.travis/wait_mysql.sh
@@ -2,7 +2,7 @@
 set -v
 while :
 do
-    if mysql -e 'select version()' 2>&1 | grep 'ERROR 1045 (28000):\|ERROR 2059 (HY000):'; then
+    if mysql -e 'select version()' 2>&1 | grep 'version()\|ERROR 2059 (HY000):'; then
         break
     fi
     sleep 3

--- a/.travis/wait_mysql.sh
+++ b/.travis/wait_mysql.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -v
 while :
 do
     if mysql -e 'select version()' 2>&1 | grep 'ERROR 1045 (28000):\|ERROR 2059 (HY000):'; then

--- a/.travis/wait_mysql.sh
+++ b/.travis/wait_mysql.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -v
 while :
 do
     if mysql -e 'select version()' 2>&1 | grep 'version()\|ERROR 2059 (HY000):'; then


### PR DESCRIPTION
### Description
* added a test environment using a docker container with MySQL 8.0
* set `local-infile=1` via command args (defaults to `0` in MySQL 8)
* changed the wait script to grep the output, since the mysql client does not support all the required auth plugins (such as MySQL 8.0's default auth plugin).
* removed the `sleep ` command and poll the status more aggressively instead, potentially reducing the wait time

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
