### PR TITLE
Fix 'panic: runtime error: slice bounds out of range'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -64,6 +64,7 @@ Paul Bonser <misterpib at gmail.com>
 Peter Schultz <peter.schultz at classmarkets.com>
 Rebecca Chin <rchin at pivotal.io>
 Reed Allman <rdallman10 at gmail.com>
+Richard Wilkes <wilkes at me.com>
 Robert Russell <robert at rrbrussell.com>
 Runrioter Wung <runrioter at gmail.com>
 Shuode Li <elemount at qq.com>

--- a/packets.go
+++ b/packets.go
@@ -228,6 +228,8 @@ func (mc *mysqlConn) readInitPacket() ([]byte, string, error) {
 		pos += 13
 		if end := bytes.IndexByte(data[pos:], 0x00); end != -1 {
 			pluginName = string(data[pos : pos+end])
+		} else {
+			pluginName = string(data[pos:])
 		}
 
 		// TODO: Verify string termination

--- a/packets.go
+++ b/packets.go
@@ -203,6 +203,8 @@ func (mc *mysqlConn) readInitPacket() ([]byte, string, error) {
 	}
 	pos += 2
 
+	// EOF if version (>= 5.5.7 and < 5.5.10) or (>= 5.6.0 and < 5.6.2)
+	// \NUL otherwise
 	pluginName := ""
 	if len(data) > pos {
 		// character set [1 byte]
@@ -231,15 +233,6 @@ func (mc *mysqlConn) readInitPacket() ([]byte, string, error) {
 		} else {
 			pluginName = string(data[pos:])
 		}
-
-		// TODO: Verify string termination
-		// EOF if version (>= 5.5.7 and < 5.5.10) or (>= 5.6.0 and < 5.6.2)
-		// \NUL otherwise
-		//
-		//if data[len(data)-1] == 0 {
-		//	return
-		//}
-		//return ErrMalformPkt
 
 		// make a memory safe copy of the cipher slice
 		var b [20]byte

--- a/packets.go
+++ b/packets.go
@@ -226,7 +226,9 @@ func (mc *mysqlConn) readInitPacket() ([]byte, string, error) {
 		// which seems to work but technically could have a hidden bug.
 		cipher = append(cipher, data[pos:pos+12]...)
 		pos += 13
-		pluginName = string(data[pos : pos+bytes.IndexByte(data[pos:], 0x00)])
+		if end := bytes.IndexByte(data[pos:], 0x00); end != -1 {
+			pluginName = string(data[pos : pos+end])
+		}
 
 		// TODO: Verify string termination
 		// EOF if version (>= 5.5.7 and < 5.5.10) or (>= 5.6.0 and < 5.6.2)

--- a/packets.go
+++ b/packets.go
@@ -203,8 +203,6 @@ func (mc *mysqlConn) readInitPacket() ([]byte, string, error) {
 	}
 	pos += 2
 
-	// EOF if version (>= 5.5.7 and < 5.5.10) or (>= 5.6.0 and < 5.6.2)
-	// \NUL otherwise
 	pluginName := ""
 	if len(data) > pos {
 		// character set [1 byte]
@@ -228,6 +226,9 @@ func (mc *mysqlConn) readInitPacket() ([]byte, string, error) {
 		// which seems to work but technically could have a hidden bug.
 		cipher = append(cipher, data[pos:pos+12]...)
 		pos += 13
+
+		// EOF if version (>= 5.5.7 and < 5.5.10) or (>= 5.6.0 and < 5.6.2)
+		// \NUL otherwise
 		if end := bytes.IndexByte(data[pos:], 0x00); end != -1 {
 			pluginName = string(data[pos : pos+end])
 		} else {


### PR DESCRIPTION
### Description
The code added in commit f55773078414cbe0891269c87d7963181b54e174 introduced a bug that prevents access to some databases by failing to check to see if the data it is looking for was actually present. This corrects that.

Discovered using MemSQL 5.5.8.

The data in the packet that was received in the `readInitPacket()` function was:
```
[10 53 46 53 46 56 0 165 0 0 0 60 70 63 58 68 104 34 97 0 223 247 33 2 0 15 128 21 0 0 0 0 0 0 0 0 0 0 98 120 114 47 85 75 109 99 51 77 50 64 0 109 121 115 113 108 95 110 97 116 105 118 101 95 112 97 115 115 119 111 114 100]
```

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file