### PR TITLE
Fix caching_sha2_password with empty password

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -241,7 +241,7 @@ func (mc *mysqlConn) auth(authData []byte, plugin string) ([]byte, bool, error) 
 	switch plugin {
 	case "caching_sha2_password":
 		authResp := scrambleSHA256Password(authData, mc.cfg.Passwd)
-		return authResp, (authResp == nil), nil
+		return authResp, false, nil
 
 	case "mysql_old_password":
 		if !mc.cfg.AllowOldPasswords {

--- a/auth_test.go
+++ b/auth_test.go
@@ -764,7 +764,7 @@ func TestAuthSwitchCachingSHA256PasswordEmpty(t *testing.T) {
 		t.Errorf("got error: %v", err)
 	}
 
-	expectedReply := []byte{1, 0, 0, 3, 0}
+	expectedReply := []byte{0, 0, 0, 3}
 	if !bytes.Equal(conn.written, expectedReply) {
 		t.Errorf("got unexpected data: %v", conn.written)
 	}


### PR DESCRIPTION
There shouldn't be trailing NUL byte for caching_sha2_password.

Fixes #825

---

### Description

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
