### PR TITLE
Update README.md to remove 1.7 support doc

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -72,6 +72,7 @@ Shuode Li <elemount at qq.com>
 Soroush Pour <me at soroushjp.com>
 Stan Putrya <root.vagner at gmail.com>
 Stanley Gunawan <gunawan.stanley at gmail.com>
+Thomas Wodarek <wodarekwebpage at gmail.com>
 Xiangyu Hu <xiangyu.hu at outlook.com>
 Xiaobing Jiang <s7v7nislands at gmail.com>
 Xiuming Chen <cc at cxm.cc>

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A MySQL-Driver for Go's [database/sql](https://golang.org/pkg/database/sql/) pac
   * Optional placeholder interpolation
 
 ## Requirements
-  * Go 1.7 or higher. We aim to support the 3 latest versions of Go.
+  * Go 1.8 or higher. We aim to support the 3 latest versions of Go.
   * MySQL (4.1+), MariaDB, Percona Server, Google CloudSQL or Sphinx (2.2.3+)
 
 ---------------------------------------


### PR DESCRIPTION
### Description
Per commit https://github.com/go-sql-driver/mysql/commit/749ddf1598b47e3cd909414bda735fe790ef3d30, 1.7 support was removed, so this will fix the docs to reflect that change.

### Checklist
- [X] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [X] All tests passing
- [X] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
