### PR TITLE
fix convert mysql TIME to time.Time

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -761,6 +761,15 @@ func (rows *textRows) readRow(dest []driver.Value) error {
 						if err == nil {
 							continue
 						}
+					case fieldTypeTime:
+						dest[i], err = time.ParseInLocation(
+							"15:04:05",
+							string(dest[i].([]byte)),
+							mc.cfg.Loc,
+						)
+						if err == nil {
+							continue
+						}
 					default:
 						continue
 					}


### PR DESCRIPTION
### Description
mysql has TIME type, build if I set the type to `fieldTypeTime`, it show me this error message:

```txt
unsupported Scan, storing driver.Value type []uint8 into type *time.Time) 
```

So, just fix this bug. ;-)

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
