### PR TITLE
[WIP] add parseNull option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -76,6 +76,7 @@ Xiangyu Hu <xiangyu.hu at outlook.com>
 Xiaobing Jiang <s7v7nislands at gmail.com>
 Xiuming Chen <cc at cxm.cc>
 Zhenye Xie <xiezhenye at gmail.com>
+Haitao Lv <git@lvht.net>
 
 # Organizations
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,17 @@ Default:        false
 The date or datetime like `0000-00-00 00:00:00` is converted into zero value of `time.Time`.
 
 
+##### `parseNull`
+
+```
+Type:           bool
+Valid Values:   true, false
+Default:        false
+```
+
+`parseNull=true` changes the output type of `null` to its golang default value.
+
+
 ##### `readTimeout`
 
 ```

--- a/connection.go
+++ b/connection.go
@@ -42,6 +42,7 @@ type mysqlConn struct {
 	status           statusFlag
 	sequence         uint8
 	parseTime        bool
+	parseNull        bool
 
 	// for context support (Go 1.8+)
 	watching bool

--- a/driver.go
+++ b/driver.go
@@ -65,6 +65,7 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 		return nil, err
 	}
 	mc.parseTime = mc.cfg.ParseTime
+	mc.parseNull = mc.cfg.ParseNull
 
 	// Connect to Server
 	dialsLock.RLock()

--- a/driver_test.go
+++ b/driver_test.go
@@ -294,6 +294,41 @@ func TestCRUD(t *testing.T) {
 	})
 }
 
+func TestParseNull(t *testing.T) {
+	dsn += "&parseNull=true&parseTime=true"
+
+	runTests(t, dsn, func(dbt *DBTest) {
+		// Create Table
+		dbt.mustExec("CREATE TABLE test (id int, a int, b float, c double, d varchar(1), e timestamp, f decimal(3,1))")
+		dbt.mustExec("INSERT INTO test (id) VALUES (1)")
+
+		a := int32(1)
+		b := float32(1.0)
+		c := float64(1.0)
+		d := "non-empty"
+		e := time.Now()
+		f := "1.1"
+		t := time.Time{}
+
+		err := dbt.db.QueryRow("SELECT a,b,c,d,e,f FROM test WHERE id = 1").Scan(&a, &b, &c, &d, &e, &f)
+		if err != nil {
+			dbt.Fatalf("Error on ParseNull-Query: %s", err.Error())
+		} else if a != 0 {
+			dbt.Errorf("ParseNull: a is not empty")
+		} else if b != 0 {
+			dbt.Errorf("ParseNull: b is not empty")
+		} else if c != 0 {
+			dbt.Errorf("ParseNull: c is not empty")
+		} else if d != "" {
+			dbt.Errorf("ParseNull: d is not empty")
+		} else if e != t {
+			dbt.Errorf("ParseNull: e is not empty")
+		} else if f != "" {
+			dbt.Errorf("ParseNull: e is not empty")
+		}
+	})
+}
+
 func TestMultiQuery(t *testing.T) {
 	runTestsWithMultiStatement(t, dsn, func(dbt *DBTest) {
 		// Create Table

--- a/dsn.go
+++ b/dsn.go
@@ -60,6 +60,7 @@ type Config struct {
 	MultiStatements         bool // Allow multiple statements in one query
 	ParseTime               bool // Parse time values to time.Time
 	RejectReadOnly          bool // Reject read-only connections
+	ParseNull               bool // Convert null to go default value
 }
 
 // NewConfig creates a new Config and sets default values.
@@ -235,6 +236,15 @@ func (cfg *Config) FormatDSN() string {
 		} else {
 			hasParam = true
 			buf.WriteString("?parseTime=true")
+		}
+	}
+
+	if cfg.ParseNull {
+		if hasParam {
+			buf.WriteString("&parseNull=true")
+		} else {
+			hasParam = true
+			buf.WriteString("?parseNull=true")
 		}
 	}
 
@@ -506,6 +516,14 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 		case "parseTime":
 			var isBool bool
 			cfg.ParseTime, isBool = readBool(value)
+			if !isBool {
+				return errors.New("invalid bool value: " + value)
+			}
+
+		// null parsing
+		case "parseNull":
+			var isBool bool
+			cfg.ParseNull, isBool = readBool(value)
 			if !isBool {
 				return errors.New("invalid bool value: " + value)
 			}


### PR DESCRIPTION
### Description
Scanning `null` will triger an error. However, a `null` value is not always an fatal error. If we want to work around with the `null` value, we have to use the `sql.NullXxx` and check wether is null.

Here I propose another simple solution. Let the db driver convert to null value to the golang default value if needed.

Please make your comments on whether this solution make sense.

Thanks.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
