### PR TITLE
Treat dial error as driver.ErrBadConn

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -73,6 +73,7 @@ Soroush Pour <me at soroushjp.com>
 Stan Putrya <root.vagner at gmail.com>
 Stanley Gunawan <gunawan.stanley at gmail.com>
 Thomas Wodarek <wodarekwebpage at gmail.com>
+Tom Jenkinson <tom at tjenkinson.me>
 Xiangyu Hu <xiangyu.hu at outlook.com>
 Xiaobing Jiang <s7v7nislands at gmail.com>
 Xiuming Chen <cc at cxm.cc>

--- a/driver.go
+++ b/driver.go
@@ -77,7 +77,7 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 		mc.netConn, err = nd.Dial(mc.cfg.Net, mc.cfg.Addr)
 	}
 	if err != nil {
-		if nerr, ok := err.(net.Error); ok && (nerr.Temporary() || nerr.Timeout()) {
+		if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
 			errLog.Print("net.Error from Dial()': ", nerr.Error())
 			return nil, driver.ErrBadConn
 		}

--- a/driver.go
+++ b/driver.go
@@ -77,6 +77,7 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 		mc.netConn, err = nd.Dial(mc.cfg.Net, mc.cfg.Addr)
 	}
 	if err != nil {
+		errLog.Print("err from Dial()': ", err.Error())
 		return nil, driver.ErrBadConn
 	}
 

--- a/driver.go
+++ b/driver.go
@@ -77,8 +77,11 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 		mc.netConn, err = nd.Dial(mc.cfg.Net, mc.cfg.Addr)
 	}
 	if err != nil {
-		errLog.Print("err from Dial()': ", err.Error())
-		return nil, driver.ErrBadConn
+		if nerr, ok := err.(net.Error); ok && (nerr.Temporary() || nerr.Timeout()) {
+			errLog.Print("net.Error from Dial()': ", nerr.Error())
+			return nil, driver.ErrBadConn
+		}
+		return nil, err
 	}
 
 	// Enable TCP Keepalives on TCP connections

--- a/driver.go
+++ b/driver.go
@@ -77,7 +77,7 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 		mc.netConn, err = nd.Dial(mc.cfg.Net, mc.cfg.Addr)
 	}
 	if err != nil {
-		return nil, err
+		return nil, driver.ErrBadConn
 	}
 
 	// Enable TCP Keepalives on TCP connections

--- a/driver_test.go
+++ b/driver_test.go
@@ -1801,6 +1801,23 @@ func TestConcurrent(t *testing.T) {
 	})
 }
 
+func TestDialErrBadConn(t *testing.T) {
+	RegisterDial("mydial", func(addr string) (net.Conn, error) {
+		return nil, fmt.Errorf("test")
+	})
+
+	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@mydial(%s)/%s?timeout=30s", user, pass, addr, dbname))
+	if err != nil {
+		t.Fatalf("error connecting: %s", err.Error())
+	}
+	defer db.Close()
+
+	_, err = db.Exec("DO 1")
+	if err != driver.ErrBadConn {
+		t.Fatalf("was expecting ErrBadConn. Got: %s", err)
+	}
+}
+
 // Tests custom dial functions
 func TestCustomDial(t *testing.T) {
 	if !available {

--- a/driver_test.go
+++ b/driver_test.go
@@ -1845,11 +1845,6 @@ func TestDialNonRetryableNetErr(t *testing.T) {
 	testDialError(t, testErr, testErr)
 }
 
-func TestDialTimeoutNetErr(t *testing.T) {
-	testErr := netErrorMock{timeout: true}
-	testDialError(t, testErr, driver.ErrBadConn)
-}
-
 func TestDialTemporaryNetErr(t *testing.T) {
 	testErr := netErrorMock{temporary: true}
 	testDialError(t, testErr, driver.ErrBadConn)


### PR DESCRIPTION
### Description
Currently if an error happens from the `Dial()` call, there  are no retries. The go sql driver will only retry on a [`driver.ErrBadConn`](https://github.com/golang/go/blob/a0d6420d8be2ae7164797051ec74fa2a2df466a1/src/database/sql/driver/driver.go#L111-L119) error.

The following is the doc for this error:

```
// ErrBadConn should be returned by a driver to signal to the sql
// package that a driver.Conn is in a bad state (such as the server
// having earlier closed the connection) and the sql package should
// retry on a new connection.
//
// To prevent duplicate operations, ErrBadConn should NOT be returned
// if there's a possibility that the database server might have
// performed the operation. Even if the server sends back an error,
// you shouldn't return ErrBadConn.
```

I noticed that other functions in `MySQLDriver.Open()` already return this error, so I wonder if this was an oversight?

One concern with this change is that users might be expecting and handling a `net.Error` from `dial()`, which with this PR would only be logged now.

It would also be possible to handle this without changes to the lib, by using `RegisterDial()`. If we are not concerned that users might be expecting  `net.Error`, I feel that `driver.ErrBadConn` is a more appropriate error and users should't be required to use `RegisterDial()` if they want retries.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
