### PR TITLE
AllowNativePasswords, if using the requested plugin failed

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -115,6 +115,7 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 		// try the default auth plugin, if using the requested plugin failed
 		errLog.Print("could not use requested auth plugin '"+plugin+"': ", err.Error())
 		plugin = defaultAuthPlugin
+		mc.cfg.AllowNativePasswords = true
 		authResp, addNUL, err = mc.auth(authData, plugin)
 		if err != nil {
 			mc.cleanup()


### PR DESCRIPTION
### Description
//try the default auth plugin, if using the requested plugin failed
driver.go#117:  plugin = defaultAuthPlugin
Also need AllowNativePasswords = true

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
