### PR TITLE
in function MySQLDriver.Open: replace errBadConnNoWrite with driver.ErrBadConn for resend while 'bad connection' happenning

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -123,7 +123,7 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 	}
 	if err = mc.writeHandshakeResponsePacket(authResp, addNUL, plugin); err != nil {
 		mc.cleanup()
-		return nil, err
+		return nil, mc.markBadConn(err)
 	}
 
 	// Handle response to auth packet, switch methods if possible

--- a/driver_test.go
+++ b/driver_test.go
@@ -2860,3 +2860,19 @@ func TestValuerWithValueReceiverGivenNilValue(t *testing.T) {
 		// This test will panic on the INSERT if ConvertValue() does not check for typed nil before calling Value()
 	})
 }
+
+func TestWriteHandshakeResponseErr(t *testing.T) {
+	oldWritter := connWritter
+	defer func() {
+		connWritter = oldWritter
+	}()
+	connWritter = func(conn net.Conn, data []byte) (int, error) {
+		return 0, fmt.Errorf("network error")
+	}
+
+	md := MySQLDriver{}
+	_, err := md.Open(dsn)
+	if err != driver.ErrBadConn {
+		t.Fatalf("error is not driver.ErrBadConn: %v", err)
+	}
+}

--- a/packets.go
+++ b/packets.go
@@ -17,8 +17,14 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"time"
 )
+
+// connWritter write data with net.Conn, for test mocking
+var connWritter = func(conn net.Conn, data []byte) (int, error) {
+	return conn.Write(data)
+}
 
 // Packets documentation:
 // http://dev.mysql.com/doc/internals/en/client-server-protocol.html
@@ -118,7 +124,7 @@ func (mc *mysqlConn) writePacket(data []byte) error {
 			}
 		}
 
-		n, err := mc.netConn.Write(data[:4+size])
+		n, err := connWritter(mc.netConn, data[:4+size])
 		if err == nil && n == 4+size {
 			mc.sequence++
 			if size != maxPacketSize {


### PR DESCRIPTION
### Description
in function MySQLDriver.Open: replace errBadConnNoWrite with driver.ErrBadConn for resend while 'bad connection' happenning

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
