### PR TITLE
Avoid potential double driver registration

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -161,5 +161,10 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 }
 
 func init() {
+	for _, driver := range sql.Drivers() {
+		if driver == "mysql" {
+			return
+		}
+	}
 	sql.Register("mysql", &MySQLDriver{})
 }


### PR DESCRIPTION
When used with migration goose tool, for golang-based migrations, it imports this driver itself and the migration code tries to import it as well which causes an exception.
