### PR TITLE
buffer: Improve len(buf)==cap(buf) consistency

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -1076,7 +1076,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 		// In that case we must build the data packet with the new values buffer
 		if valuesCap != cap(paramValues) {
 			data = append(data[:pos], paramValues...)
-			mc.buf.buf = data
+			mc.buf.setGrownBuffer(data)
 		}
 
 		pos += len(paramValues)


### PR DESCRIPTION
### Description

Fix `writeExecutePacket` may set buf such that `len(buf) < cap(buf)`.
And buffer.go keeps `len(b.buf) == cap(b.buf)` more explicitly.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
