### PR TITLE
Truncate internal buffer when rows.Close() is called

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -37,6 +37,12 @@ func newBuffer(nc net.Conn) buffer {
 	}
 }
 
+func (b *buffer) reset() {
+	b.buf = make([]byte, defaultBufSize)
+	b.idx = 0
+	b.length = 0
+}
+
 // fill reads into the buffer until at least _need_ bytes are in it
 func (b *buffer) fill(need int) error {
 	n := b.length

--- a/rows.go
+++ b/rows.go
@@ -111,6 +111,10 @@ func (rows *mysqlRows) Close() (err error) {
 		return err
 	}
 
+	// We can't reuse receive buffer when rows.Close() is called.
+	// See https://github.com/golang/go/commit/651ddbdb5056ded455f47f9c494c67b389622a47
+	mc.buf.reset()
+
 	// Remove unread packets from stream
 	if !rows.rs.done {
 		err = mc.readUntilEOF()

--- a/rows.go
+++ b/rows.go
@@ -113,7 +113,7 @@ func (rows *mysqlRows) Close() (err error) {
 
 	// We can't reuse receive buffer when rows.Close() is called.
 	// See https://github.com/golang/go/commit/651ddbdb5056ded455f47f9c494c67b389622a47
-	mc.buf.reset()
+	mc.buf.discard()
 
 	// Remove unread packets from stream
 	if !rows.rs.done {


### PR DESCRIPTION
### Description
Fixes #903

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
