### PR TITLE
fix race on cancelling context passed to QueryContext

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -37,6 +37,27 @@ func newBuffer(nc net.Conn) buffer {
 	}
 }
 
+// discard trims b.buf[:b.idx] to prohibit it reused.
+//
+// This is required by Rows.Close().
+// See https://github.com/golang/go/commit/651ddbdb5056ded455f47f9c494c67b389622a47
+func (b *buffer) discard() {
+	if len(b.buf)-b.idx >= defaultBufSize {
+		b.buf = b.buf[b.idx:]
+		b.idx = 0
+		return
+	}
+
+	bufSize := defaultBufSize
+	if bufSize < b.length {
+		bufSize = b.length
+	}
+	newBuf := make([]byte, bufSize)
+	copy(newBuf, b.buf[b.idx:b.idx+b.length])
+	b.buf = newBuf
+	b.idx = 0
+}
+
 // fill reads into the buffer until at least _need_ bytes are in it
 func (b *buffer) fill(need int) error {
 	n := b.length

--- a/rows.go
+++ b/rows.go
@@ -111,6 +111,10 @@ func (rows *mysqlRows) Close() (err error) {
 		return err
 	}
 
+	// We can't reuse receive buffer when rows.Close() is called.
+	// See https://github.com/golang/go/commit/651ddbdb5056ded455f47f9c494c67b389622a47
+	mc.buf.discard()
+
 	// Remove unread packets from stream
 	if !rows.rs.done {
 		err = mc.readUntilEOF()


### PR DESCRIPTION
### Description

This pull request is based on #904.

#904 add one allocation for each rows, unless buffer size is increased by some reason.
This pull request increases the initial buffer size from 4KiB to 16KiB.
This will reduce number of allocations.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
