### PR TITLE
dialog auth

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -76,6 +76,7 @@ Stanley Gunawan <gunawan.stanley at gmail.com>
 Steven Hartland <steven.hartland at multiplay.co.uk>
 Thomas Wodarek <wodarekwebpage at gmail.com>
 Tom Jenkinson <tom at tjenkinson.me>
+Tom Petr <trpetr at gmail.com>
 Xiangyu Hu <xiangyu.hu at outlook.com>
 Xiaobing Jiang <s7v7nislands at gmail.com>
 Xiuming Chen <cc at cxm.cc>

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Valid Values:   true, false
 Default:        false
 ```
 
-`allowCleartextPasswords=true` allows using the [cleartext client side plugin](http://dev.mysql.com/doc/en/cleartext-authentication-plugin.html) if required by an account, such as one defined with the [PAM authentication plugin](http://dev.mysql.com/doc/en/pam-authentication-plugin.html). Sending passwords in clear text may be a security problem in some configurations. To avoid problems if there is any possibility that the password would be intercepted, clients should connect to MySQL Server using a method that protects the password. Possibilities include [TLS / SSL](#tls), IPsec, or a private network.
+`allowCleartextPasswords=true` allows using the [cleartext client side plugin](http://dev.mysql.com/doc/en/cleartext-authentication-plugin.html) or [dialog plugin](https://mariadb.com/kb/en/library/development-pluggable-authentication/#dialog-client-plugin) if required by an account, such as one defined with the [PAM authentication plugin](http://dev.mysql.com/doc/en/pam-authentication-plugin.html). Sending passwords in clear text may be a security problem in some configurations. To avoid problems if there is any possibility that the password would be intercepted, clients should connect to MySQL Server using a method that protects the password. Possibilities include [TLS / SSL](#tls), IPsec, or a private network.
 
 ##### `allowNativePasswords`
 

--- a/auth.go
+++ b/auth.go
@@ -294,7 +294,7 @@ func (mc *mysqlConn) auth(authData []byte, plugin string) ([]byte, error) {
 			return nil, ErrCleartextPassword
 		}
 		if mc.cfg.DialogFunc != nil {
-			dialogPasswd, err := mc.cfg.DialogFunc(authData[0] >> 1, string(authData[1:]))
+			dialogPasswd, err := mc.cfg.DialogFunc(authData[0]>>1, string(authData[1:]))
 			if err != nil {
 				return nil, err
 			}

--- a/dsn.go
+++ b/dsn.go
@@ -60,6 +60,8 @@ type Config struct {
 	MultiStatements         bool // Allow multiple statements in one query
 	ParseTime               bool // Parse time values to time.Time
 	RejectReadOnly          bool // Reject read-only connections
+
+	DialogFunc func(byte, string) (string, error) // Optional dialog auth implementation
 }
 
 // NewConfig creates a new Config and sets default values.


### PR DESCRIPTION
### Description
This PR adds support for the `dialog` authentication plugin. I cut some corners by leaving the `DialogFunc()` implementation to the user instead of attempting to load a shared library, but I think this is a good enough start. If `DialogFunc()` is not implemented, we simply use whatever password is defined in the DSN. 

Related to https://github.com/go-sql-driver/mysql/issues/803.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
