### PR TITLE
Tests cleanup: close rows when done to avoid resource leak during testing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Jacek Szwec <szwec.jacek at gmail.com>
 James Harr <james.harr at gmail.com>
 Jeff Hodges <jeff at somethingsimilar.com>
 Jeffrey Charles <jeffreycharles at gmail.com>
+Jerome Meyer <jxmeyer at gmail.com>
 Jian Zhen <zhenjl at gmail.com>
 Joshua Prunier <joshua.prunier at gmail.com>
 Julien Lefevre <julien.lefevr at gmail.com>


### PR DESCRIPTION
### Description
Close rows after we are done using them avoids having a bunch of connections hanging around.

### Checklist
- [X] Code compiles correctly
- [X] All tests passing
- [X] Added myself / the copyright holder to the AUTHORS file