### PR TITLE
Add a new "tls-mode=preferred" DSN parameter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,6 +25,7 @@ Daniel Montoya <dsmontoyam at gmail.com>
 Daniel Nichter <nil at codenode.com>
 Daniël van Eeden <git at myname.nl>
 Dave Protasowski <dprotaso at gmail.com>
+David Weitzman <dweitzman at gmail.com>
 DisposaBoy <disposaboy at dby.me>
 Egor Smolyakov <egorsmkv at gmail.com>
 Evan Shaw <evan at vendhq.com>

--- a/README.md
+++ b/README.md
@@ -335,6 +335,17 @@ Default:        false
 `tls=true` enables TLS / SSL encrypted connection to the server. Use `skip-verify` if you want to use a self-signed or invalid certificate (server side) or use `preferred` to use TLS only when advertised by the server. This is similar to `skip-verify`, but additionally allows a fallback to a connection which is not encrypted. Neither `skip-verify` nor `preferred` add any reliable security. You can use a custom TLS config after registering it with [`mysql.RegisterTLSConfig`](https://godoc.org/github.com/go-sql-driver/mysql#RegisterTLSConfig).
 
 
+##### `tls-mode`
+
+```
+Type:           string
+Valid Values:   preferred
+Default:        <none>
+```
+
+Use `tls-mode=preferred` to opt-in to TLS / SSL only with servers that support it. `preferred` does not authenticate the server but allows servers to optionally authenticate clients. The [`tls`](#tls) DSN parameter allows customizing the TLS config.
+
+
 ##### `writeTimeout`
 
 ```

--- a/packets.go
+++ b/packets.go
@@ -194,7 +194,7 @@ func (mc *mysqlConn) readHandshakePacket() (data []byte, plugin string, err erro
 		return nil, "", ErrOldProtocol
 	}
 	if mc.flags&clientSSL == 0 && mc.cfg.tls != nil {
-		if mc.cfg.TLSConfig == "preferred" {
+		if mc.cfg.TLSOptional {
 			mc.cfg.tls = nil
 		} else {
 			return nil, "", ErrNoTLS


### PR DESCRIPTION
Add a new "tls-mode=preferred" DSN parameter

### Description
    
Separating "preferred" into its own parameter instead of making it a special value in the "tls=" parameter makes it possible to use custom TLS config with this mode. This is useful when clients don't need to authenticate servers using TLS but a server may or may not need to authenticate the client using TLS.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
