### PR TITLE
buffer: Use a double-buffering scheme to prevent data races

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -317,3 +317,52 @@ func BenchmarkExecContext(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkQueryRawBytes benchmarks fetching 100 blobs using sql.RawBytes.
+// "size=" means size of each blobs.
+func BenchmarkQueryRawBytes(b *testing.B) {
+	var sizes []int = []int{100, 1000, 2000, 4000, 8000, 12000, 16000, 32000, 64000, 256000}
+	db := initDB(b,
+		"DROP TABLE IF EXISTS bench_rawbytes",
+		"CREATE TABLE bench_rawbytes (id INT PRIMARY KEY, val LONGBLOB)",
+	)
+	defer db.Close()
+
+	blob := make([]byte, sizes[len(sizes)-1])
+	for i := range blob {
+		blob[i] = 42
+	}
+	for i := 0; i < 100; i++ {
+		_, err := db.Exec("INSERT INTO bench_rawbytes VALUES (?, ?)", i, blob)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	for _, s := range sizes {
+		b.Run(fmt.Sprintf("size=%v", s), func(b *testing.B) {
+			b.ReportAllocs()
+			for j := 0; j < b.N; j++ {
+				rows, err := db.Query("SELECT LEFT(val, ?) as v FROM bench_rawbytes", s)
+				if err != nil {
+					b.Fatal(err)
+				}
+				nrows := 0
+				for rows.Next() {
+					var buf sql.RawBytes
+					err := rows.Scan(&buf)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if len(buf) != s {
+						b.Fatalf("size mismatch: expected %v, got %v", s, len(buf))
+					}
+					nrows++
+				}
+				rows.Close()
+				if nrows != 100 {
+					b.Fatalf("numbers of rows mismatch: expected %v, got %v", 100, nrows)
+				}
+			}
+		})
+	}
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -338,9 +338,14 @@ func BenchmarkQueryRawBytes(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+
 	for _, s := range sizes {
 		b.Run(fmt.Sprintf("size=%v", s), func(b *testing.B) {
+			db.SetMaxIdleConns(0)
+			db.SetMaxIdleConns(1)
 			b.ReportAllocs()
+			b.ResetTimer()
+
 			for j := 0; j < b.N; j++ {
 				rows, err := db.Query("SELECT LEFT(val, ?) as v FROM bench_rawbytes", s)
 				if err != nil {

--- a/buffer.go
+++ b/buffer.go
@@ -74,7 +74,7 @@ func (b *buffer) fill(need int) error {
 	// if we're filling the fg buffer, move the existing data to the start of it.
 	// if we're filling the bg buffer, copy over the data
 	if n > 0 {
-		copy(dest[0:n], b.buf[b.idx:])
+		copy(dest[:n], b.buf[b.idx:])
 	}
 
 	b.buf = dest

--- a/buffer.go
+++ b/buffer.go
@@ -15,7 +15,7 @@ import (
 )
 
 const defaultBufSize = 4096
-const maxCachedBufSize = 16 * 1024
+const maxCachedBufSize = 256 * 1024
 
 // A buffer which is used for both reading and writing.
 // This is possible since communication on each connection is synchronous.

--- a/buffer.go
+++ b/buffer.go
@@ -15,47 +15,69 @@ import (
 )
 
 const defaultBufSize = 4096
+const maxCachedBufSize = 16 * 1024
 
 // A buffer which is used for both reading and writing.
 // This is possible since communication on each connection is synchronous.
 // In other words, we can't write and read simultaneously on the same connection.
 // The buffer is similar to bufio.Reader / Writer but zero-copy-ish
 // Also highly optimized for this particular use case.
+// This buffer is backed by two byte slices in a double-buffering scheme
 type buffer struct {
 	buf     []byte // buf is a byte buffer who's length and capacity are equal.
 	nc      net.Conn
 	idx     int
 	length  int
 	timeout time.Duration
+	dbuf    [2][]byte // dbuf is an array with the two byte slices that back this buffer
+	flipcnt uint      // flipccnt is the current buffer counter for double-buffering
 }
 
 // newBuffer allocates and returns a new buffer.
 func newBuffer(nc net.Conn) buffer {
+	fg := make([]byte, defaultBufSize)
 	return buffer{
-		buf: make([]byte, defaultBufSize),
-		nc:  nc,
+		buf:  fg,
+		nc:   nc,
+		dbuf: [2][]byte{fg, nil},
 	}
+}
+
+// flip replaces the active buffer with the background buffer
+// this is a delayed flip that simply increases the buffer counter;
+// the actual flip will be performed the next time we call `buffer.fill`
+func (b *buffer) flip() {
+	b.flipcnt += 1
 }
 
 // fill reads into the buffer until at least _need_ bytes are in it
 func (b *buffer) fill(need int) error {
 	n := b.length
+	// fill data into its double-buffering target: if we've called
+	// flip on this buffer, we'll be copying to the background buffer,
+	// and then filling it with network data; otherwise we'll just move
+	// the contents of the current buffer to the front before filling it
+	dest := b.dbuf[b.flipcnt&1]
 
-	// move existing data to the beginning
-	if n > 0 && b.idx > 0 {
-		copy(b.buf[0:n], b.buf[b.idx:])
-	}
-
-	// grow buffer if necessary
-	// TODO: let the buffer shrink again at some point
-	//       Maybe keep the org buf slice and swap back?
-	if need > len(b.buf) {
+	// grow buffer if necessary to fit the whole packet.
+	if need > len(dest) {
 		// Round up to the next multiple of the default size
-		newBuf := make([]byte, ((need/defaultBufSize)+1)*defaultBufSize)
-		copy(newBuf, b.buf)
-		b.buf = newBuf
+		dest = make([]byte, ((need/defaultBufSize)+1)*defaultBufSize)
+
+		// if the allocated buffer is not too large, move it to backing storage
+		// to prevent extra allocations on applications that perform large reads
+		if len(dest) <= maxCachedBufSize {
+			b.dbuf[b.flipcnt&1] = dest
+		}
 	}
 
+	// if we're filling the fg buffer, move the existing data to the start of it.
+	// if we're filling the bg buffer, copy over the data
+	if n > 0 {
+		copy(dest[0:n], b.buf[b.idx:])
+	}
+
+	b.buf = dest
 	b.idx = 0
 
 	for {

--- a/driver_test.go
+++ b/driver_test.go
@@ -2938,3 +2938,58 @@ func TestValuerWithValueReceiverGivenNilValue(t *testing.T) {
 		// This test will panic on the INSERT if ConvertValue() does not check for typed nil before calling Value()
 	})
 }
+
+// TestRawBytesAreNotModified checks for a race condition that arises when a query context
+// is canceled while a user is calling rows.Scan. This is a more stringent test than the one
+// proposed in https://github.com/golang/go/issues/23519. Here we're explicitly using
+// `sql.RawBytes` to check the contents of our internal buffers are not modified after an implicit
+// call to `Rows.Close`, so Context cancellation should **not** invalidate the backing buffers.
+func TestRawBytesAreNotModified(t *testing.T) {
+	const blob = "abcdefghijklmnop"
+	const contextRaceIterations = 20
+	const blobSize = defaultBufSize * 3 / 4 // Second row overwrites first row.
+	const insertRows = 4
+
+	var sqlBlobs = [2]string{
+		strings.Repeat(blob, blobSize/len(blob)),
+		strings.Repeat(strings.ToUpper(blob), blobSize/len(blob)),
+	}
+
+	runTests(t, dsn, func(dbt *DBTest) {
+		dbt.mustExec("CREATE TABLE test (id int, value BLOB) CHARACTER SET utf8")
+		for i := 0; i < insertRows; i++ {
+			dbt.mustExec("INSERT INTO test VALUES (?, ?)", i+1, sqlBlobs[i&1])
+		}
+
+		for i := 0; i < contextRaceIterations; i++ {
+			func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				rows, err := dbt.db.QueryContext(ctx, `SELECT id, value FROM test`)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				var b int
+				var raw sql.RawBytes
+				for rows.Next() {
+					if err := rows.Scan(&b, &raw); err != nil {
+						t.Fatal(err)
+					}
+
+					before := string(raw)
+					// Ensure cancelling the query does not corrupt the contents of `raw`
+					cancel()
+					time.Sleep(time.Microsecond * 100)
+					after := string(raw)
+
+					if before != after {
+						t.Fatalf("the backing storage for sql.RawBytes has been modified (i=%v)", i)
+					}
+				}
+				rows.Close()
+			}()
+		}
+	})
+}

--- a/rows.go
+++ b/rows.go
@@ -111,6 +111,13 @@ func (rows *mysqlRows) Close() (err error) {
 		return err
 	}
 
+	// flip the buffer for this connection if we need to drain it.
+	// note that for a successful query (i.e. one where rows.next()
+	// has been called until it returns false), `rows.mc` will be nil
+	// by the time the user calls `(*Rows).Close`, so we won't reach this
+	// see: https://github.com/golang/go/commit/651ddbdb5056ded455f47f9c494c67b389622a47
+	mc.buf.flip()
+
 	// Remove unread packets from stream
 	if !rows.rs.done {
 		err = mc.readUntilEOF()


### PR DESCRIPTION
### Description

This is a potential fix for #902, #903. Some context:

The Go 1.10 release [changed the API contract for `driver.Rows.Next` in `sql/driver`](https://github.com/golang/go/commit/651ddbdb5056ded455f47f9c494c67b389622a47). Previously, we could modify the backing storage behind the `[]Value` slice that is passed to our driver's `driver.Rows.Next` function when the user calls the `sql.Rows.Close` method from the public interface. This is no longer the case: we can no longer modify this backing storage **outside of the `driver.Rows.Next` call**, or this will lead to a data race.

Although in theory, `sql.Rows.Scan` and `sql.Rows.Close` are always called sequentially from user's code, there is a corner case with `context` cancellation: if you've performed a query with `QueryContext` and your `Context` is cancelled or timeouts while reading the `Rows` result of that query, `Rows.Close` can be called simultaneously with `sql.Rows.Scan`, which is where this data race happens.

Now, **why are we modifying the backing storage we return from `driver.Rows.Next`?** This is a complex issue arising from a design constraint in MySQL's protocol. When the Go `sql` package cancels an on-flight query, before this query's connection can be re-used to perform any more queries, we must "drain" it, i.e. read all the remaining query results until an EOF packet that may have already been sent from MySQL. This draining is a complex operation, because although most of the drained data is discarded, we still need to read packet headers to figure out the size of each incoming packet, and we still have to read the `EOF` (and any potential `ERR`) packets whole, so we can keep track of our connection status.

This means that **draining a connection after a query writes data to our connection buffer**, by necessity. When the `db/sql` package is performing `Scan` on the fields we've returned from `driver.Rows.Next`, these fields are often backed by our connection buffer, so any writes to it **will corrupt the `Scan` values**. This is a serious vulnerability that needs to be addressed asap.

I have spent some time evaluating all possible fixes for this issue, and I believe the fix proposed here has the best ratio between complexity and extra memory usage. Let us review the other options I've discarded:

- **Truncate & allocate a new buffer during the `Close` call**: this has been implemented by @methane in https://github.com/go-sql-driver/mysql/pull/904 and rejected by @julienschmidt. I do agree with Julien that allocating a new buffer per close is too expensive. It can cause significant memory churn in the library.

- **Delay the discard operation on the connection**: since we do not know how long after a `Rows.Close` call is it safe to start reading from the connection and writing to our buffer to "drain" the remaining rows, it could in theory be possible to simply "flag" the connection with a "needs draining" flag on `Close`, and then performing the draining on the next `Query`. I don't think this is a good idea because it could add arbitrary latency from a previous query to the following one, and because it's a bit scary to leave MySQL hanging with packets; it could lead to connection timeouts.

- **Discard the remaining packets without writing to the connection buffer**: [I have sketched an implementation of this here](https://github.com/vmg/mysql/compare/vmg/conncheck...vmg:vmg/race?expand=1). I am wary of this approach because discarding packets straight from the wire introduces a lot of extra complexity: it is not possible to perform the discarding without using _some_ scratch storage to read `EOF` and `ERR` packets, so we need to allocate a small discard buffer for each connection (64 bytes). The code to switch between the discard and packet-read buffers is complex. Although the resulting performance is very good (better than _before_ the fix, because we're discarding large packets directly instead of allocating and returning them), and the fix does not allocate extra memory, I believe the complexity trade-off is not worth it.

- **Use a double-buffering scheme**: this is the solution proposed in this PR. It's far from a novel idea. Double-buffering has been used for decades in graphic buffers to, huh, avoid data races! It consists on allocating two buffers and switching between them once "data" has been returned to the user (in this case, "data" is the contents of the Rows to scan; in Graphics "data" is a rendered frame). There is an obvious upfront memory cost, which is that each connection requires _two_ connection buffers (so an overhead of 4kb per connection), but once we've allocated the foreground and background buffers on a new connection, the performance is great, there are no further memory allocations, and the code to swap between the buffers is minimal.

@julienschmidt: I know you're wary of increasing memory usage in the library but I'd urge you to review this PR. The included stress test (`TestContextCancelQueryWhileScan`) proves there's a very real race here that can lead to data corruption, and the overhead cost for this fix is amortized throughout the lifetime of each connection. As explained, [the code in this branch](https://github.com/vmg/mysql/compare/vmg/conncheck...vmg:vmg/race?expand=1) performs the discarding with allocating significantly less memory, but I don't think the complexity trade-off is worth it.

@methane: Please do review this PR. I hope you'll agree this is a good compromise for a simple but relatively efficient fix for this serious issue.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
