### PR TITLE
Fix regression in appengine.go

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,6 +27,7 @@ Daniël van Eeden <git at myname.nl>
 Dave Protasowski <dprotaso at gmail.com>
 DisposaBoy <disposaboy at dby.me>
 Egor Smolyakov <egorsmkv at gmail.com>
+Erwan Martin <hello at erwan.io>
 Evan Shaw <evan at vendhq.com>
 Frederick Mayle <frederickmayle at gmail.com>
 Gustavo Kristic <gkristic at gmail.com>

--- a/appengine.go
+++ b/appengine.go
@@ -12,12 +12,13 @@ package mysql
 
 import (
 	"context"
+	"net"
 
 	"google.golang.org/appengine/cloudsql"
 )
 
 func init() {
-	RegisterDialContext("cloudsql", func(_ context.Context, instance addr) (net.Conn, error) {
+	RegisterDialContext("cloudsql", func(_ context.Context, instance string) (net.Conn, error) {
 		// XXX: the cloudsql driver still does not export a Context-aware dialer.
 		return cloudsql.Dial(instance)
 	})


### PR DESCRIPTION
### Description
This package can't be built anymore with Google App Engine:
```go
github.com/go-sql-driver/mysql/appengine.go:20:67: undefined: addr
github.com/go-sql-driver/mysql/appengine.go:20:74: undefined: net
```

Looks like the issue is related with this change: https://github.com/go-sql-driver/mysql/commit/89ec2a9ec85e27afb0f0fcd3c2399e72cc360ae4 (#941)

### Checklist
- [X] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
- [X] Added myself / the copyright holder to the AUTHORS file


