### PR TITLE
fix appengine

### DIFF
--- a/conncheck.go
+++ b/conncheck.go
@@ -14,7 +14,7 @@ import (
 	"errors"
 	"io"
 	"net"
-	"golang.org/x/sys/unix"
+	syscall "golang.org/x/sys/unix"
 )
 
 var errUnexpectedRead = errors.New("unexpected read from socket")
@@ -26,7 +26,7 @@ func connCheck(c net.Conn) error {
 		buff [1]byte
 	)
 
-	sconn, ok := c.(unix.Conn)
+	sconn, ok := c.(syscall.Conn)
 	if !ok {
 		return nil
 	}
@@ -35,7 +35,7 @@ func connCheck(c net.Conn) error {
 		return err
 	}
 	rerr := rc.Read(func(fd uintptr) bool {
-		n, err = unix.Read(int(fd), buff[:])
+		n, err = syscall.Read(int(fd), buff[:])
 		return true
 	})
 	switch {
@@ -45,7 +45,7 @@ func connCheck(c net.Conn) error {
 		return io.EOF
 	case n > 0:
 		return errUnexpectedRead
-	case err == unix.EAGAIN || err == unix.EWOULDBLOCK:
+	case err == syscall.EAGAIN || err == syscall.EWOULDBLOCK:
 		return nil
 	default:
 		return err

--- a/conncheck.go
+++ b/conncheck.go
@@ -14,7 +14,7 @@ import (
 	"errors"
 	"io"
 	"net"
-	syscall "golang.org/x/sys/unix"
+	"syscall"
 )
 
 var errUnexpectedRead = errors.New("unexpected read from socket")

--- a/conncheck_dummy.go
+++ b/conncheck_dummy.go
@@ -1,5 +1,3 @@
-package mysql
-
 // Go MySQL Driver - A MySQL-Driver for Go's database/sql package
 //
 // Copyright 2019 The Go-MySQL-Driver Authors. All rights reserved.
@@ -7,6 +5,10 @@ package mysql
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build windows appengine
+
+package mysql
 
 import "net"
 


### PR DESCRIPTION
### Description

* syscall package can not be used on AppEngine Standard.
* ~~"syscall" package is deprecated.~~ Using deprecated "syscall" package is unavoidable for `SyscallConn` method.

Fixes #944

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
