### PR TITLE
packets: reset read deadline before conn check

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -108,7 +108,17 @@ func (mc *mysqlConn) writePacket(data []byte) error {
 		if mc.rawConn != nil {
 			conn = mc.rawConn
 		}
-		if err := connCheck(conn); err != nil {
+		var err error
+		// If this connection has a ReadTimeout which we've been setting on
+		// reads, reset it to its default value before we attempt a non-blocking
+		// read, otherwise the scheduler will just time us out before we can read
+		if mc.cfg.ReadTimeout != 0 {
+			err = conn.SetReadDeadline(time.Now().Add(mc.cfg.ReadTimeout))
+		}
+		if err == nil {
+			err = connCheck(conn)
+		}
+		if err != nil {
 			errLog.Print("closing bad idle connection: ", err)
 			mc.Close()
 			return driver.ErrBadConn

--- a/packets.go
+++ b/packets.go
@@ -113,7 +113,7 @@ func (mc *mysqlConn) writePacket(data []byte) error {
 		// reads, reset it to its default value before we attempt a non-blocking
 		// read, otherwise the scheduler will just time us out before we can read
 		if mc.cfg.ReadTimeout != 0 {
-			err = conn.SetReadDeadline(time.Now().Add(mc.cfg.ReadTimeout))
+			err = conn.SetReadDeadline(time.Time{})
 		}
 		if err == nil {
 			err = connCheck(conn)


### PR DESCRIPTION
Hiii mysqlinos! Here's a fix for an issue that @lrita reported. Fixes #963.

cc @methane @julienschmidt 

### Description
```
If a MySQL connection has been configured with a short `ReadTimeout`,
each read from the TCP connection will be preceded by a
`SetReadDeadline` call, which lingers until the next `SetReadDeadline`.

This can be an issue if the connection becomes stale after staying too
long in the connection pool, because when we attempt to perform a stale
connection check, the Go runtime scheduler will return a timedout error
from the scheduler itself, without letting us get to the kernel to
perform the non-blocking read.

To fix this, reset the read deadline before we perform the connection
check.
```

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
