### PR TITLE
conncheck: move var declarations into closure

### DIFF
--- a/conncheck_dummy.go
+++ b/conncheck_dummy.go
@@ -12,6 +12,6 @@ package mysql
 
 import "net"
 
-func connCheck(c net.Conn) error {
+func connCheck(conn net.Conn) error {
 	return nil
 }


### PR DESCRIPTION
### Description
Reduces the number of heap allocations caused by the connection check.

Updates #996

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
