### PR TITLE
Add ConfigFlag() func to simplify providing DSN via command-line flag

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -13,6 +13,7 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"errors"
+	"flag"
 	"fmt"
 	"math/big"
 	"net"
@@ -633,4 +634,28 @@ func ensureHavePort(addr string) string {
 		return net.JoinHostPort(addr, "3306")
 	}
 	return addr
+}
+
+// Implements flag.Value
+type configFlag struct {
+	config Config
+}
+
+func (f *configFlag) String() string {
+	return f.config.FormatDSN()
+}
+
+func (f *configFlag) Set(dsn string) error {
+	cfg, err := ParseDSN(dsn)
+	if err != nil {
+		return err
+	}
+	f.config = *cfg
+	return nil
+}
+
+func ConfigFlag(name string, value Config, usage string) *Config {
+	f := configFlag{config: value}
+	flag.Var(&f, name, usage)
+	return &f.config
 }


### PR DESCRIPTION
### Description

Added a `ConfigFlag()` func. It integrates with the standard `flag` package and reports an invalid DSN as an invalid flag value.

It can be used as follows:
```go
mysql.ConfigFlag("mysql_dsn", mysql.Config{DBName: "test", User: "test"}, "Data source name")
```

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
