### PR TITLE
Drop Go 1.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: go
 go:
-  - 1.9.x
   - 1.10.x
   - 1.11.x
   - 1.12.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
   - 1.10.x
   - 1.11.x
   - 1.12.x
+  - 1.13.x
   - master
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A MySQL-Driver for Go's [database/sql](https://golang.org/pkg/database/sql/) pac
   * Optional placeholder interpolation
 
 ## Requirements
-  * Go 1.9 or higher. We aim to support the 3 latest versions of Go.
+  * Go 1.10 or higher. We aim to support the 3 latest versions of Go.
   * MySQL (4.1+), MariaDB, Percona Server, Google CloudSQL or Sphinx (2.2.3+)
 
 ---------------------------------------

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-sql-driver/mysql
 
-go 1.9
+go 1.10


### PR DESCRIPTION
### Description

Legacy GAE/Go is gone.

README says  "We aim to support the 3 latest versions of Go."
"the 3 latest versions of Go" are 1.13, 1.12, and 1.11.

But there is no enough reason to drop 1.10 support at the moment.
So we keep Go 1.10 support in v1.5.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
