### PR TITLE
connector: don't return ErrBadConn when failing to connect

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -91,6 +91,7 @@ Zhenye Xie <xiezhenye at gmail.com>
 
 Barracuda Networks, Inc.
 Counting Ltd.
+DigitalOcean Inc.
 Facebook Inc.
 GitHub Inc.
 Google Inc.

--- a/connector.go
+++ b/connector.go
@@ -44,10 +44,6 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 	}
 
 	if err != nil {
-		if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
-			errLog.Print("net.Error from Dial()': ", nerr.Error())
-			return nil, driver.ErrBadConn
-		}
 		return nil, err
 	}
 

--- a/connector_test.go
+++ b/connector_test.go
@@ -1,0 +1,30 @@
+package mysql
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestConnectorReturnsTimeout(t *testing.T) {
+	connector := &connector{&Config{
+		Net:     "tcp",
+		Addr:    "1.1.1.1:1234",
+		Timeout: 10 * time.Millisecond,
+	}}
+
+	_, err := connector.Connect(context.Background())
+	if err == nil {
+		t.Fatal("error expected")
+	}
+
+	if nerr, ok := err.(*net.OpError); ok {
+		expected := "dial tcp 1.1.1.1:1234: i/o timeout"
+		if nerr.Error() != expected {
+			t.Fatalf("expected %q, got %q", expected, nerr.Error())
+		}
+	} else {
+		t.Fatalf("expected %T, got %T", nerr, err)
+	}
+}

--- a/driver_test.go
+++ b/driver_test.go
@@ -1874,7 +1874,7 @@ func TestDialNonRetryableNetErr(t *testing.T) {
 
 func TestDialTemporaryNetErr(t *testing.T) {
 	testErr := netErrorMock{temporary: true}
-	testDialError(t, testErr, driver.ErrBadConn)
+	testDialError(t, testErr, testErr)
 }
 
 // Tests custom dial functions


### PR DESCRIPTION
ErrBadConn should only be returned for an already established connection, not when creating a new one.

This reverts #867

### Description

Fixes https://github.com/go-sql-driver/mysql/issues/1019, see description there.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Added myself / the copyright holder to the AUTHORS file
