### PR TITLE
Return ErrBadConn in Prepare

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -154,7 +154,9 @@ func (mc *mysqlConn) Prepare(query string) (driver.Stmt, error) {
 	// Send command
 	err := mc.writeCommandPacketStr(comStmtPrepare, query)
 	if err != nil {
-		return nil, mc.markBadConn(err)
+		// STMT_PREPARE is safe to retry.  So we can return ErrBadConn here.
+		errLog.Print(err)
+		return nil, driver.ErrBadConn
 	}
 
 	stmt := &mysqlStmt{


### PR DESCRIPTION
### Description

STMT_PREPARE doesn't have side effect so we can return ErrBadConn after we send a COM_STMT_PREPARE.

Fixes #983.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
