### PR TITLE
Allow registering custom CredentialProviders for per-conn passwords

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -103,3 +103,4 @@ Multiplay Ltd.
 Percona LLC
 Pivotal Inc.
 Stripe Inc.
+Zendesk Inc.

--- a/README.md
+++ b/README.md
@@ -209,6 +209,16 @@ SELECT u.id FROM users as u
 
 will return `u.id` instead of just `id` if `columnsWithAlias=true`.
 
+#### `credentialProvider`
+
+```
+Type:           string
+Valid Values:   <name>
+Default:        ""
+```
+
+If set, this must refer to a credential provider name registerd with `RegisterCredentialProvider`. When this is set, the username and password in the DSN will be ignored; instead, each time a conneciton is to be opened, the named credential provider function will be called to obtain a username/password to connect with. This is useful when using, for example, IAM database auth in Amazon AWS, where "passwords" are actually temporary tokens that expire.
+
 ##### `interpolateParams`
 
 ```

--- a/auth.go
+++ b/auth.go
@@ -15,13 +15,16 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"sync"
 )
 
 // server pub keys registry
 var (
-	serverPubKeyLock     sync.RWMutex
-	serverPubKeyRegistry map[string]*rsa.PublicKey
+	serverPubKeyLock           sync.RWMutex
+	serverPubKeyRegistry       map[string]*rsa.PublicKey
+	credentialProviderLock     sync.RWMutex
+	credentialProviderRetistry map[string]CredentialProviderFunc
 )
 
 // RegisterServerPubKey registers a server RSA public key which can be used to
@@ -79,6 +82,44 @@ func getServerPubKey(name string) (pubKey *rsa.PublicKey) {
 	}
 	serverPubKeyLock.RUnlock()
 	return
+}
+
+// CredentialProviderFunc is a function which can be used to fetch a username/password
+// pair for use when opening a new MySQL connection. The first return value is the username
+// and the second the password.
+type CredentialProviderFunc func() (string, string, error)
+
+// RegisterCredentialProvider registers a function to be called on every connection open to
+// get the username and password to call
+func RegisterCredentialProvider(name string, providerFunc CredentialProviderFunc) {
+	credentialProviderLock.Lock()
+	if credentialProviderRetistry == nil {
+		credentialProviderRetistry = make(map[string]CredentialProviderFunc)
+	}
+	credentialProviderRetistry[name] = providerFunc
+	credentialProviderLock.Unlock()
+}
+
+// DeregisterCredentialProvider removes a function registered with RegisterCredentialProvider
+func DeregisterCredentialProvider(name string) {
+	credentialProviderLock.Lock()
+	if credentialProviderRetistry != nil {
+		delete(credentialProviderRetistry, name)
+	}
+	credentialProviderLock.Unlock()
+}
+
+func getCredentialsFromConfig(cfg *Config) (string, string, error) {
+	if cfg.CredentialProvider != "" {
+		credentialProviderLock.RLock()
+		defer credentialProviderLock.RUnlock()
+		cpFunc, ok := credentialProviderRetistry[cfg.CredentialProvider]
+		if !ok {
+			return "", "", fmt.Errorf("credential provider %s not registered", cfg.CredentialProvider)
+		}
+		return cpFunc()
+	}
+	return cfg.User, cfg.Passwd, nil
 }
 
 // Hash password using pre 4.1 (old password) method
@@ -237,10 +278,10 @@ func (mc *mysqlConn) sendEncryptedPassword(seed []byte, pub *rsa.PublicKey) erro
 	return mc.writeAuthSwitchPacket(enc)
 }
 
-func (mc *mysqlConn) auth(authData []byte, plugin string) ([]byte, error) {
+func (mc *mysqlConn) auth(authData []byte, plugin string, password string) ([]byte, error) {
 	switch plugin {
 	case "caching_sha2_password":
-		authResp := scrambleSHA256Password(authData, mc.cfg.Passwd)
+		authResp := scrambleSHA256Password(authData, password)
 		return authResp, nil
 
 	case "mysql_old_password":
@@ -250,7 +291,7 @@ func (mc *mysqlConn) auth(authData []byte, plugin string) ([]byte, error) {
 		// Note: there are edge cases where this should work but doesn't;
 		// this is currently "wontfix":
 		// https://github.com/go-sql-driver/mysql/issues/184
-		authResp := append(scrambleOldPassword(authData[:8], mc.cfg.Passwd), 0)
+		authResp := append(scrambleOldPassword(authData[:8], password), 0)
 		return authResp, nil
 
 	case "mysql_clear_password":
@@ -259,7 +300,7 @@ func (mc *mysqlConn) auth(authData []byte, plugin string) ([]byte, error) {
 		}
 		// http://dev.mysql.com/doc/refman/5.7/en/cleartext-authentication-plugin.html
 		// http://dev.mysql.com/doc/refman/5.7/en/pam-authentication-plugin.html
-		return append([]byte(mc.cfg.Passwd), 0), nil
+		return append([]byte(password), 0), nil
 
 	case "mysql_native_password":
 		if !mc.cfg.AllowNativePasswords {
@@ -267,16 +308,16 @@ func (mc *mysqlConn) auth(authData []byte, plugin string) ([]byte, error) {
 		}
 		// https://dev.mysql.com/doc/internals/en/secure-password-authentication.html
 		// Native password authentication only need and will need 20-byte challenge.
-		authResp := scramblePassword(authData[:20], mc.cfg.Passwd)
+		authResp := scramblePassword(authData[:20], password)
 		return authResp, nil
 
 	case "sha256_password":
-		if len(mc.cfg.Passwd) == 0 {
+		if len(password) == 0 {
 			return []byte{0}, nil
 		}
 		if mc.cfg.tls != nil || mc.cfg.Net == "unix" {
 			// write cleartext auth packet
-			return append([]byte(mc.cfg.Passwd), 0), nil
+			return append([]byte(password), 0), nil
 		}
 
 		pubKey := mc.cfg.pubKey
@@ -286,7 +327,7 @@ func (mc *mysqlConn) auth(authData []byte, plugin string) ([]byte, error) {
 		}
 
 		// encrypted password
-		enc, err := encryptPassword(mc.cfg.Passwd, authData, pubKey)
+		enc, err := encryptPassword(password, authData, pubKey)
 		return enc, err
 
 	default:
@@ -295,7 +336,7 @@ func (mc *mysqlConn) auth(authData []byte, plugin string) ([]byte, error) {
 	}
 }
 
-func (mc *mysqlConn) handleAuthResult(oldAuthData []byte, plugin string) error {
+func (mc *mysqlConn) handleAuthResult(oldAuthData []byte, plugin string, password string) error {
 	// Read Result Packet
 	authData, newPlugin, err := mc.readAuthResult()
 	if err != nil {
@@ -315,7 +356,7 @@ func (mc *mysqlConn) handleAuthResult(oldAuthData []byte, plugin string) error {
 
 		plugin = newPlugin
 
-		authResp, err := mc.auth(authData, plugin)
+		authResp, err := mc.auth(authData, plugin, password)
 		if err != nil {
 			return err
 		}
@@ -352,7 +393,7 @@ func (mc *mysqlConn) handleAuthResult(oldAuthData []byte, plugin string) error {
 			case cachingSha2PasswordPerformFullAuthentication:
 				if mc.cfg.tls != nil || mc.cfg.Net == "unix" {
 					// write cleartext auth packet
-					err = mc.writeAuthSwitchPacket(append([]byte(mc.cfg.Passwd), 0))
+					err = mc.writeAuthSwitchPacket(append([]byte(password), 0))
 					if err != nil {
 						return err
 					}

--- a/auth_test.go
+++ b/auth_test.go
@@ -85,11 +85,11 @@ func TestAuthFastCachingSHA256PasswordCached(t *testing.T) {
 	plugin := "caching_sha2_password"
 
 	// Send Client Authentication Packet
-	authResp, err := mc.auth(authData, plugin)
+	authResp, err := mc.auth(authData, plugin, mc.cfg.Passwd)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin, mc.cfg.User)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +115,7 @@ func TestAuthFastCachingSHA256PasswordCached(t *testing.T) {
 	conn.maxReads = 1
 
 	// Handle response to auth packet
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 }
@@ -130,11 +130,11 @@ func TestAuthFastCachingSHA256PasswordEmpty(t *testing.T) {
 	plugin := "caching_sha2_password"
 
 	// Send Client Authentication Packet
-	authResp, err := mc.auth(authData, plugin)
+	authResp, err := mc.auth(authData, plugin, mc.cfg.Passwd)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin, mc.cfg.User)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func TestAuthFastCachingSHA256PasswordEmpty(t *testing.T) {
 	conn.maxReads = 1
 
 	// Handle response to auth packet
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 }
@@ -172,11 +172,11 @@ func TestAuthFastCachingSHA256PasswordFullRSA(t *testing.T) {
 	plugin := "caching_sha2_password"
 
 	// Send Client Authentication Packet
-	authResp, err := mc.auth(authData, plugin)
+	authResp, err := mc.auth(authData, plugin, mc.cfg.Passwd)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin, mc.cfg.User)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,7 +208,7 @@ func TestAuthFastCachingSHA256PasswordFullRSA(t *testing.T) {
 	conn.maxReads = 3
 
 	// Handle response to auth packet
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -228,11 +228,11 @@ func TestAuthFastCachingSHA256PasswordFullRSAWithKey(t *testing.T) {
 	plugin := "caching_sha2_password"
 
 	// Send Client Authentication Packet
-	authResp, err := mc.auth(authData, plugin)
+	authResp, err := mc.auth(authData, plugin, mc.cfg.Passwd)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin, mc.cfg.User)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -261,7 +261,7 @@ func TestAuthFastCachingSHA256PasswordFullRSAWithKey(t *testing.T) {
 	conn.maxReads = 2
 
 	// Handle response to auth packet
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -280,11 +280,11 @@ func TestAuthFastCachingSHA256PasswordFullSecure(t *testing.T) {
 	plugin := "caching_sha2_password"
 
 	// Send Client Authentication Packet
-	authResp, err := mc.auth(authData, plugin)
+	authResp, err := mc.auth(authData, plugin, mc.cfg.Passwd)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin, mc.cfg.User)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -317,7 +317,7 @@ func TestAuthFastCachingSHA256PasswordFullSecure(t *testing.T) {
 	conn.maxReads = 3
 
 	// Handle response to auth packet
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -336,7 +336,7 @@ func TestAuthFastCleartextPasswordNotAllowed(t *testing.T) {
 	plugin := "mysql_clear_password"
 
 	// Send Client Authentication Packet
-	_, err := mc.auth(authData, plugin)
+	_, err := mc.auth(authData, plugin, mc.cfg.Passwd)
 	if err != ErrCleartextPassword {
 		t.Errorf("expected ErrCleartextPassword, got %v", err)
 	}
@@ -353,11 +353,11 @@ func TestAuthFastCleartextPassword(t *testing.T) {
 	plugin := "mysql_clear_password"
 
 	// Send Client Authentication Packet
-	authResp, err := mc.auth(authData, plugin)
+	authResp, err := mc.auth(authData, plugin, mc.cfg.Passwd)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin, mc.cfg.User)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -380,7 +380,7 @@ func TestAuthFastCleartextPassword(t *testing.T) {
 	conn.maxReads = 1
 
 	// Handle response to auth packet
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 }
@@ -396,11 +396,11 @@ func TestAuthFastCleartextPasswordEmpty(t *testing.T) {
 	plugin := "mysql_clear_password"
 
 	// Send Client Authentication Packet
-	authResp, err := mc.auth(authData, plugin)
+	authResp, err := mc.auth(authData, plugin, mc.cfg.Passwd)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin, mc.cfg.User)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -423,7 +423,7 @@ func TestAuthFastCleartextPasswordEmpty(t *testing.T) {
 	conn.maxReads = 1
 
 	// Handle response to auth packet
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 }
@@ -439,7 +439,7 @@ func TestAuthFastNativePasswordNotAllowed(t *testing.T) {
 	plugin := "mysql_native_password"
 
 	// Send Client Authentication Packet
-	_, err := mc.auth(authData, plugin)
+	_, err := mc.auth(authData, plugin, mc.cfg.Passwd)
 	if err != ErrNativePassword {
 		t.Errorf("expected ErrNativePassword, got %v", err)
 	}
@@ -455,11 +455,11 @@ func TestAuthFastNativePassword(t *testing.T) {
 	plugin := "mysql_native_password"
 
 	// Send Client Authentication Packet
-	authResp, err := mc.auth(authData, plugin)
+	authResp, err := mc.auth(authData, plugin, mc.cfg.Passwd)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin, mc.cfg.User)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -483,7 +483,7 @@ func TestAuthFastNativePassword(t *testing.T) {
 	conn.maxReads = 1
 
 	// Handle response to auth packet
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 }
@@ -498,11 +498,11 @@ func TestAuthFastNativePasswordEmpty(t *testing.T) {
 	plugin := "mysql_native_password"
 
 	// Send Client Authentication Packet
-	authResp, err := mc.auth(authData, plugin)
+	authResp, err := mc.auth(authData, plugin, mc.cfg.Passwd)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin, mc.cfg.User)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -525,7 +525,7 @@ func TestAuthFastNativePasswordEmpty(t *testing.T) {
 	conn.maxReads = 1
 
 	// Handle response to auth packet
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 }
@@ -540,11 +540,11 @@ func TestAuthFastSHA256PasswordEmpty(t *testing.T) {
 	plugin := "sha256_password"
 
 	// Send Client Authentication Packet
-	authResp, err := mc.auth(authData, plugin)
+	authResp, err := mc.auth(authData, plugin, mc.cfg.Passwd)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin, mc.cfg.User)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -569,7 +569,7 @@ func TestAuthFastSHA256PasswordEmpty(t *testing.T) {
 	conn.maxReads = 2
 
 	// Handle response to auth packet
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -588,11 +588,11 @@ func TestAuthFastSHA256PasswordRSA(t *testing.T) {
 	plugin := "sha256_password"
 
 	// Send Client Authentication Packet
-	authResp, err := mc.auth(authData, plugin)
+	authResp, err := mc.auth(authData, plugin, mc.cfg.Passwd)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin, mc.cfg.User)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -617,7 +617,7 @@ func TestAuthFastSHA256PasswordRSA(t *testing.T) {
 	conn.maxReads = 2
 
 	// Handle response to auth packet
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -637,11 +637,11 @@ func TestAuthFastSHA256PasswordRSAWithKey(t *testing.T) {
 	plugin := "sha256_password"
 
 	// Send Client Authentication Packet
-	authResp, err := mc.auth(authData, plugin)
+	authResp, err := mc.auth(authData, plugin, mc.cfg.Passwd)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin, mc.cfg.User)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -651,7 +651,7 @@ func TestAuthFastSHA256PasswordRSAWithKey(t *testing.T) {
 	conn.maxReads = 1
 
 	// Handle response to auth packet
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 }
@@ -670,7 +670,7 @@ func TestAuthFastSHA256PasswordSecure(t *testing.T) {
 	plugin := "sha256_password"
 
 	// send Client Authentication Packet
-	authResp, err := mc.auth(authData, plugin)
+	authResp, err := mc.auth(authData, plugin, mc.cfg.Passwd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -678,7 +678,7 @@ func TestAuthFastSHA256PasswordSecure(t *testing.T) {
 	// unset TLS config to prevent the actual establishment of a TLS wrapper
 	mc.cfg.tls = nil
 
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin, mc.cfg.User)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -699,7 +699,7 @@ func TestAuthFastSHA256PasswordSecure(t *testing.T) {
 	conn.maxReads = 1
 
 	// Handle response to auth packet
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -728,7 +728,7 @@ func TestAuthSwitchCachingSHA256PasswordCached(t *testing.T) {
 		47, 43, 9, 41, 112, 67, 110}
 	plugin := "mysql_native_password"
 
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -761,7 +761,7 @@ func TestAuthSwitchCachingSHA256PasswordEmpty(t *testing.T) {
 		47, 43, 9, 41, 112, 67, 110}
 	plugin := "mysql_native_password"
 
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -797,7 +797,7 @@ func TestAuthSwitchCachingSHA256PasswordFullRSA(t *testing.T) {
 		47, 43, 9, 41, 112, 67, 110}
 	plugin := "mysql_native_password"
 
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -842,7 +842,7 @@ func TestAuthSwitchCachingSHA256PasswordFullRSAWithKey(t *testing.T) {
 		47, 43, 9, 41, 112, 67, 110}
 	plugin := "mysql_native_password"
 
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -885,7 +885,7 @@ func TestAuthSwitchCachingSHA256PasswordFullSecure(t *testing.T) {
 		47, 43, 9, 41, 112, 67, 110}
 	plugin := "mysql_native_password"
 
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -912,7 +912,7 @@ func TestAuthSwitchCleartextPasswordNotAllowed(t *testing.T) {
 	authData := []byte{123, 87, 15, 84, 20, 58, 37, 121, 91, 117, 51, 24, 19,
 		47, 43, 9, 41, 112, 67, 110}
 	plugin := "mysql_native_password"
-	err := mc.handleAuthResult(authData, plugin)
+	err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd)
 	if err != ErrCleartextPassword {
 		t.Errorf("expected ErrCleartextPassword, got %v", err)
 	}
@@ -935,7 +935,7 @@ func TestAuthSwitchCleartextPassword(t *testing.T) {
 		47, 43, 9, 41, 112, 67, 110}
 	plugin := "mysql_native_password"
 
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -962,7 +962,7 @@ func TestAuthSwitchCleartextPasswordEmpty(t *testing.T) {
 		47, 43, 9, 41, 112, 67, 110}
 	plugin := "mysql_native_password"
 
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -984,7 +984,7 @@ func TestAuthSwitchNativePasswordNotAllowed(t *testing.T) {
 	authData := []byte{96, 71, 63, 8, 1, 58, 75, 12, 69, 95, 66, 60, 117, 31,
 		48, 31, 89, 39, 55, 31}
 	plugin := "caching_sha2_password"
-	err := mc.handleAuthResult(authData, plugin)
+	err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd)
 	if err != ErrNativePassword {
 		t.Errorf("expected ErrNativePassword, got %v", err)
 	}
@@ -1009,7 +1009,7 @@ func TestAuthSwitchNativePassword(t *testing.T) {
 		48, 31, 89, 39, 55, 31}
 	plugin := "caching_sha2_password"
 
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -1039,7 +1039,7 @@ func TestAuthSwitchNativePasswordEmpty(t *testing.T) {
 		48, 31, 89, 39, 55, 31}
 	plugin := "caching_sha2_password"
 
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -1059,7 +1059,7 @@ func TestAuthSwitchOldPasswordNotAllowed(t *testing.T) {
 	authData := []byte{95, 84, 103, 43, 61, 49, 123, 61, 91, 50, 40, 113, 35,
 		84, 96, 101, 92, 123, 121, 107}
 	plugin := "mysql_native_password"
-	err := mc.handleAuthResult(authData, plugin)
+	err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd)
 	if err != ErrOldPassword {
 		t.Errorf("expected ErrOldPassword, got %v", err)
 	}
@@ -1075,7 +1075,7 @@ func TestOldAuthSwitchNotAllowed(t *testing.T) {
 	authData := []byte{95, 84, 103, 43, 61, 49, 123, 61, 91, 50, 40, 113, 35,
 		84, 96, 101, 92, 123, 121, 107}
 	plugin := "mysql_native_password"
-	err := mc.handleAuthResult(authData, plugin)
+	err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd)
 	if err != ErrOldPassword {
 		t.Errorf("expected ErrOldPassword, got %v", err)
 	}
@@ -1099,7 +1099,7 @@ func TestAuthSwitchOldPassword(t *testing.T) {
 		84, 96, 101, 92, 123, 121, 107}
 	plugin := "mysql_native_password"
 
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -1126,7 +1126,7 @@ func TestOldAuthSwitch(t *testing.T) {
 		84, 96, 101, 92, 123, 121, 107}
 	plugin := "mysql_native_password"
 
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -1153,7 +1153,7 @@ func TestAuthSwitchOldPasswordEmpty(t *testing.T) {
 		84, 96, 101, 92, 123, 121, 107}
 	plugin := "mysql_native_password"
 
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -1180,7 +1180,7 @@ func TestOldAuthSwitchPasswordEmpty(t *testing.T) {
 		84, 96, 101, 92, 123, 121, 107}
 	plugin := "mysql_native_password"
 
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -1209,7 +1209,7 @@ func TestAuthSwitchSHA256PasswordEmpty(t *testing.T) {
 		47, 43, 9, 41, 112, 67, 110}
 	plugin := "mysql_native_password"
 
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -1244,7 +1244,7 @@ func TestAuthSwitchSHA256PasswordRSA(t *testing.T) {
 		47, 43, 9, 41, 112, 67, 110}
 	plugin := "mysql_native_password"
 
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -1280,7 +1280,7 @@ func TestAuthSwitchSHA256PasswordRSAWithKey(t *testing.T) {
 		47, 43, 9, 41, 112, 67, 110}
 	plugin := "mysql_native_password"
 
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 
@@ -1316,7 +1316,7 @@ func TestAuthSwitchSHA256PasswordSecure(t *testing.T) {
 		47, 43, 9, 41, 112, 67, 110}
 	plugin := "mysql_native_password"
 
-	if err := mc.handleAuthResult(authData, plugin); err != nil {
+	if err := mc.handleAuthResult(authData, plugin, mc.cfg.Passwd); err != nil {
 		t.Errorf("got error: %v", err)
 	}
 

--- a/dsn.go
+++ b/dsn.go
@@ -34,22 +34,23 @@ var (
 // If a new Config is created instead of being parsed from a DSN string,
 // the NewConfig function should be used, which sets default values.
 type Config struct {
-	User             string            // Username
-	Passwd           string            // Password (requires User)
-	Net              string            // Network type
-	Addr             string            // Network address (requires Net)
-	DBName           string            // Database name
-	Params           map[string]string // Connection parameters
-	Collation        string            // Connection collation
-	Loc              *time.Location    // Location for time.Time values
-	MaxAllowedPacket int               // Max packet size allowed
-	ServerPubKey     string            // Server public key name
-	pubKey           *rsa.PublicKey    // Server public key
-	TLSConfig        string            // TLS configuration name
-	tls              *tls.Config       // TLS configuration
-	Timeout          time.Duration     // Dial timeout
-	ReadTimeout      time.Duration     // I/O read timeout
-	WriteTimeout     time.Duration     // I/O write timeout
+	User               string            // Username
+	Passwd             string            // Password (requires User)
+	CredentialProvider string            // Credential provider name registered with RegisterCredentialProvider
+	Net                string            // Network type
+	Addr               string            // Network address (requires Net)
+	DBName             string            // Database name
+	Params             map[string]string // Connection parameters
+	Collation          string            // Connection collation
+	Loc                *time.Location    // Location for time.Time values
+	MaxAllowedPacket   int               // Max packet size allowed
+	ServerPubKey       string            // Server public key name
+	pubKey             *rsa.PublicKey    // Server public key
+	TLSConfig          string            // TLS configuration name
+	tls                *tls.Config       // TLS configuration
+	Timeout            time.Duration     // Dial timeout
+	ReadTimeout        time.Duration     // I/O read timeout
+	WriteTimeout       time.Duration     // I/O write timeout
 
 	AllowAllFiles           bool // Allow all files to be used with LOAD DATA LOCAL INFILE
 	AllowCleartextPasswords bool // Allows the cleartext client side plugin
@@ -347,6 +348,16 @@ func (cfg *Config) FormatDSN() string {
 
 	}
 
+	if cfg.CredentialProvider != "" {
+		if hasParam {
+			buf.WriteString("&credentialProvider=")
+		} else {
+			hasParam = true
+			buf.WriteString("?credentialProvider=")
+		}
+		buf.WriteString(cfg.CredentialProvider)
+	}
+
 	// other params
 	if cfg.Params != nil {
 		var params []string
@@ -613,6 +624,8 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			if err != nil {
 				return
 			}
+		case "credentialProvider":
+			cfg.CredentialProvider = value
 		default:
 			// lazy init
 			if cfg.Params == nil {

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -71,8 +71,10 @@ var testDSNs = []struct {
 }, {
 	"tcp(de:ad:be:ef::ca:fe)/dbname",
 	&Config{Net: "tcp", Addr: "[de:ad:be:ef::ca:fe]:3306", DBName: "dbname", Collation: "utf8mb4_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true},
-},
-}
+}, {
+	"tcp(localhost)/dbname?credentialProvider=foobar",
+	&Config{Net: "tcp", Addr: "localhost:3306", DBName: "dbname", Collation: "utf8mb4_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true, CredentialProvider: "foobar"},
+}}
 
 func TestDSNParser(t *testing.T) {
 	for i, tst := range testDSNs {

--- a/packets.go
+++ b/packets.go
@@ -276,7 +276,7 @@ func (mc *mysqlConn) readHandshakePacket() (data []byte, plugin string, err erro
 
 // Client Authentication Packet
 // http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::HandshakeResponse
-func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, plugin string) error {
+func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, plugin string, user string) error {
 	// Adjust client flags based on server support
 	clientFlags := clientProtocol41 |
 		clientSecureConn |
@@ -310,7 +310,7 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, plugin string
 		clientFlags |= clientPluginAuthLenEncClientData
 	}
 
-	pktLen := 4 + 4 + 1 + 23 + len(mc.cfg.User) + 1 + len(authRespLEI) + len(authResp) + 21 + 1
+	pktLen := 4 + 4 + 1 + 23 + len(user) + 1 + len(authRespLEI) + len(authResp) + 21 + 1
 
 	// To specify a db name
 	if n := len(mc.cfg.DBName); n > 0 {
@@ -373,8 +373,8 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, plugin string
 	}
 
 	// User [null terminated string]
-	if len(mc.cfg.User) > 0 {
-		pos += copy(data[pos:], mc.cfg.User)
+	if len(user) > 0 {
+		pos += copy(data[pos:], user)
 	}
 	data[pos] = 0x00
 	pos++


### PR DESCRIPTION
### Description
When using a temporary credential system for MySQL, for example IAM database authenticaiton on AWS or the Database secret backend for Hashicorp Vault, it may not be the case that the same username and password be used for opening every connection in a `sql.DB`.

This PR adds funcionality whereby the caller can, instead of specifying `cfg.User` and `cfg.Passwd` (or in the DSN as user:pass@...), specify a `credentialProvider=` argument which refers to a callback registered with `RegisterCredentialProvider`.

When a new connection is to be opened, if the `CredentialProvider` callback is specified, that is called to obtain a username/password pair rather than using the values from the DSN.

We need this in order to use it with IAM database authentication for Aurora. With IAM database authentication, the "password" you use to connect is in fact a signed token generated with https://docs.aws.amazon.com/sdk-for-go/api/service/rds/rdsutils/#BuildAuthToken. However, the token is signed with an expiry of 15 minutes; so, if a `sql.DB` is constructed with such a token as the password, the database driver will fail to open any new connections after 15 minutes. By allowing a callback to be used to generate the password, we can re-sign it each time, so that it stays valid.

Although the AWS Aurora usecase only requires changing the password, I suspect some users of the database secrets engine in Hashicorp vault (https://www.vaultproject.io/docs/secrets/databases/mysql-maria.html) will find it useful to be able to change the username as well; Vault works by creating temporary users in the database, so when they expire, vault deletes the actual users out of MySQL and replaces it with one named differently. So this usecase would require being able to change the username in the callback as well as the password.

Anyway, keen to get some 👀  on this and see if people think this would be a useful addition to the library!

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
