### PR TITLE
Create a `mysql.Connect` API.

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -105,3 +105,15 @@ func (d MySQLDriver) OpenConnector(dsn string) (driver.Connector, error) {
 		cfg: cfg,
 	}, nil
 }
+
+// Connect connects to MySQL server.
+// You can use this function to create custom connector which dynamically
+// change the config.  The cfg object must not be changed during calling
+// this function.
+func Connect(ctx context.Context, cfg *Config) (driver.Conn, error) {
+	connector, err := NewConnector(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return connector.Connect(ctx)
+}

--- a/driver.go
+++ b/driver.go
@@ -108,7 +108,7 @@ func (d MySQLDriver) OpenConnector(dsn string) (driver.Connector, error) {
 
 // Connect connects to MySQL server.
 // You can use this function to create custom connector which dynamically
-// change the config.  The cfg object must not be changed during calling
+// change the config. The cfg object must not be changed during calling
 // this function.
 func Connect(ctx context.Context, cfg *Config) (driver.Conn, error) {
 	connector, err := NewConnector(cfg)


### PR DESCRIPTION
### Description

This is a counter-proposal to #1042. 

You can create a custom Connector object using this new API:

```go
import (
    "database/sql"
    "database/sql/driver"
    "github.com/go-sql-driver/mysql"
)

type CustomConnector struct {
    cfg *mysql.Config
}

func (cc *CustomConnector) Connect(ctx Context) (driver.Conn, error) {
    cc.cfg.Host = getCurrentMySQLHost()
    cfg.User, cfg.Password = getCurrentMySQLAuth()
    return mysql.Connect(ctx, cc.cfg)
}

func (cc *CustomConnector) Driver() driver.Driver {
    return nil
}
```

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
