### PR TITLE
return error in Config.FormatDSN

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -150,7 +150,7 @@ func (cfg *Config) normalize() error {
 
 // FormatDSN formats the given Config into a DSN string which can be passed to
 // the driver.
-func (cfg *Config) FormatDSN() string {
+func (cfg *Config) FormatDSN() (dsn string, err error) {
 	var buf bytes.Buffer
 
 	// [username[:password]@]
@@ -368,7 +368,7 @@ func (cfg *Config) FormatDSN() string {
 		}
 	}
 
-	return buf.String()
+	return buf.String(), nil
 }
 
 // ParseDSN parses the DSN string to a Config

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -120,7 +120,7 @@ func TestDSNReformat(t *testing.T) {
 		cfg1.tls = nil // pointer not static
 		res1 := fmt.Sprintf("%+v", cfg1)
 
-		dsn2 := cfg1.FormatDSN()
+		dsn2, _ := cfg1.FormatDSN()
 		cfg2, err := ParseDSN(dsn2)
 		if err != nil {
 			t.Error(err.Error())
@@ -312,7 +312,7 @@ func TestParamsAreSorted(t *testing.T) {
 		"quux":   "loo",
 		"foobar": "baz",
 	}
-	actual := cfg.FormatDSN()
+	actual, _ := cfg.FormatDSN()
 	if actual != expected {
 		t.Errorf("generic Config.Params were not sorted: want %#v, got %#v", expected, actual)
 	}


### PR DESCRIPTION
### Description
Not all configs may be representable by a DSN string in the future, e.g. #771

Updates #771.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
