### PR TITLE
fix compile error of connCheck.go

### DIFF
--- a/conncheck.go
+++ b/conncheck.go
@@ -6,7 +6,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// +build !windows,!appengine
+// +build linux darwin
+// +build !appengine
 
 package mysql
 

--- a/conncheck.go
+++ b/conncheck.go
@@ -7,7 +7,6 @@
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // +build linux darwin
-// +build !appengine
 
 package mysql
 

--- a/conncheck_dummy.go
+++ b/conncheck_dummy.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// +build windows appengine
+// +build !linux,!darwin appengine
 
 package mysql
 

--- a/conncheck_dummy.go
+++ b/conncheck_dummy.go
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// +build !linux,!darwin appengine
+// +build !linux,!darwin
 
 package mysql
 

--- a/conncheck_test.go
+++ b/conncheck_test.go
@@ -6,7 +6,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// +build go1.10,!windows
+// +build linux darwin
+// +build !appengine
 
 package mysql
 

--- a/conncheck_test.go
+++ b/conncheck_test.go
@@ -7,7 +7,6 @@
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // +build linux darwin
-// +build !appengine
 
 package mysql
 


### PR DESCRIPTION
### Description

fix compile error of connCheck.go on plan9

ref. https://github.com/go-sql-driver/mysql/pull/1047#issuecomment-570735475

```
$ GOOS=plan9 GOARCH= amd64 go build github.com/go-sql-driver/mysql
# github.com/go-sql-driver/mysql
./conncheck.go:42:15: undefined: syscall.EAGAIN
./conncheck.go:42:40: undefined: syscall.EWOULDBLOCK
```

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
