### PR TITLE
Put zero filler into the SSL handshake packet.

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -349,6 +349,12 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, plugin string
 		return errors.New("unknown collation")
 	}
 
+	// Filler [23 bytes] (all 0x00)
+	pos := 13
+	for ; pos < 13+23; pos++ {
+		data[pos] = 0
+	}
+
 	// SSL Connection Request Packet
 	// http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::SSLRequest
 	if mc.cfg.tls != nil {
@@ -365,12 +371,6 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, plugin string
 		mc.rawConn = mc.netConn
 		mc.netConn = tlsConn
 		mc.buf.nc = tlsConn
-	}
-
-	// Filler [23 bytes] (all 0x00)
-	pos := 13
-	for ; pos < 13+23; pos++ {
-		data[pos] = 0
 	}
 
 	// User [null terminated string]


### PR DESCRIPTION
According to the linked documentation at
http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::SSLRequest
SSLRequest packet should have zero filler similar to the regular handshake request,
but now the driver puts zeros only in the regular request. Luckily vanilla MySQL
doesn't rely on this zero filler and doesn't verify its presence, thus the driver worked
fine so far. But MySQL can change to rely on zeros at any point.

The problem was discovered while testing against a customized MySQL.

### Description
Please explain the changes you made here.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
