### PR TITLE
Add MySQL system variable example to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Rules:
 Examples:
   * `autocommit=1`: `SET autocommit=1`
   * [`time_zone=%27Europe%2FParis%27`](https://dev.mysql.com/doc/refman/5.5/en/time-zone-support.html): `SET time_zone='Europe/Paris'`
-  * [`tx_isolation=%27REPEATABLE-READ%27`](https://dev.mysql.com/doc/refman/5.5/en/server-system-variables.html#sysvar_tx_isolation): `SET tx_isolation='REPEATABLE-READ'`
+  * [`transaction_isolation=%27REPEATABLE-READ%27`](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_transaction_isolation): `SET transaction_isolation='REPEATABLE-READ'`
 
 
 #### Examples


### PR DESCRIPTION
### Description

MySQL system variable [`tx_isolation`](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_tx_isolation) is removed in MySQL 8.0. It is required to use `transaction_isolation` instead of `tx_isolation`.

> transaction_read_only was added in MySQL 5.7.20 as an alias for tx_read_only, which is now deprecated and is removed in MySQL 8.0.

If `tx_isolation` is set into DSN params to use MySQL 8.0, an error occurs

```
$ go run main.go
Error 1193: Unknown system variable 'tx_isolation'
```

### Checklist

omitted below because of updating only README.md

- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
