### PR TITLE
mysqlStmt Implements CheckNamedValue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,5 +125,6 @@ script:
   - go test -v -covermode=count -coverprofile=coverage.out
   - go vet ./...
   - .travis/gofmt.sh
+  - .travis/complie_check.sh
 after_script:
   - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci

--- a/.travis/complie_check.sh
+++ b/.travis/complie_check.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e 
+dist_list=$(go tool dist list)
+
+for dist in ${dist_list}; do
+    GOOS=$(echo ${dist} | cut  -d "/" -f 1)
+    GOARCH=$(echo ${dist} | cut -d "/" -f 2)
+    set +e
+    GOOS=${GOOS} GOARCH=${GOARCH} go tool compile -V > /dev/null 2>&1 
+    if [[ $? -ne 0 ]]; then
+        echo "Compile support for ${GOOS}/${GOARCH} is not provided; skipping"
+        continue
+    fi
+    set -e
+    echo "Building  ${GOOS}/${GOARCH}"
+    GOOS=${GOOS} GOARCH=${GOARCH} go build  -o /dev/null
+ done

--- a/AUTHORS
+++ b/AUTHORS
@@ -91,6 +91,7 @@ Xiangyu Hu <xiangyu.hu at outlook.com>
 Xiaobing Jiang <s7v7nislands at gmail.com>
 Xiuming Chen <cc at cxm.cc>
 Zhenye Xie <xiezhenye at gmail.com>
+Zhixin Wen <john.wenzhixin at gmail.com>
 
 # Organizations
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ Achille Roussel <achille.roussel at gmail.com>
 Alex Snast <alexsn at fb.com>
 Alexey Palazhchenko <alexey.palazhchenko at gmail.com>
 Andrew Reid <andrew.reid at tixtrack.com>
+Animesh Ray <mail.rayanimesh at gmail.com>
 Arne Hormann <arnehormann at gmail.com>
 Ariel Mashraki <ariel at mashraki.co.il>
 Asta Xie <xiemengjun at gmail.com>


### PR DESCRIPTION
### Description
uint support is broken in `v1.5.0` when working with [instrument library](https://github.com/luna-duclos/instrumentedsql) (which is essentially a wrapper around `go-sql-driver/mydriver`). The issue is in `sql`, it would check if the wrapper implements `CheckNamedValue`. The wrapper does implement `CheckNamedValue`, but it when it checks the underlying `mysqlStmt`does not implement this, so it just returns `driver.ErrSkip` (which is the correct behavior to me).

In `sql`, when it sees `driver.ErrSkip`, it would use `ccChecker.CheckNamedValue` to do the conversion. However, it would fail in:
```
	nv.Value, err = c.cci.ColumnConverter(index).ConvertValue(arg)
	if err != nil {
		return err
	}
	if !driver.IsValue(nv.Value) {
		return fmt.Errorf("driver ColumnConverter error converted %T to unsupported type %T", arg, nv.Value)
	}
```
because nv.Value would be of type `uint64` (before 1.5.0, it would return `int64`), and `driver.IsValue` would return false.

The easiest way to fix it is to add `CheckNamedValue` to `mysqlStmt`. It also makes the driver complies to the general sql protocol.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Added myself / the copyright holder to the AUTHORS file
