### PR TITLE
Travis allow Go master to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ go:
   - 1.13.x
   - master
 
-jobs:
-  allow_failures:
-  - go: master
-
 before_install:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
@@ -21,7 +17,10 @@ before_script:
   - .travis/wait_mysql.sh
   - mysql -e 'create database gotest;'
 
-matrix:
+jobs:
+  allow_failures:
+  - go: master
+
   include:
     - env: DB=MYSQL8
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ jobs:
 
   include:
     - env: DB=MYSQL8
-      sudo: required
       dist: trusty
       go: 1.10.x
       services:
@@ -42,7 +41,6 @@ jobs:
         - export MYSQL_TEST_CONCURRENT=1
 
     - env: DB=MYSQL57
-      sudo: required
       dist: trusty
       go: 1.10.x
       services:
@@ -62,7 +60,6 @@ jobs:
         - export MYSQL_TEST_CONCURRENT=1
 
     - env: DB=MARIA55
-      sudo: required
       dist: trusty
       go: 1.10.x
       services:
@@ -82,7 +79,6 @@ jobs:
         - export MYSQL_TEST_CONCURRENT=1
 
     - env: DB=MARIA10_1
-      sudo: required
       dist: trusty
       go: 1.10.x
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: go
 go:
   - 1.10.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ go:
   - 1.13.x
   - master
 
+jobs:
+  allow_failures:
+  - go: master
+
 before_install:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls


### PR DESCRIPTION
### Description
We currently test against the `master` branch of golang/go with Travis CI. That is useful when we need to adapt to changes or want to test against features not yet available in a Go release.

However, the master branch is not always without errors. Currently the cross-compile check errors because for one platform the golang/go `master` is broken.

This PR allows `master` to fail: https://travis-ci.com/github/go-sql-driver/mysql/builds/163720889 (also failing here).
Further, it removes the obsolete `sudo` keys from the travis config.
