### PR TITLE
Fix checking cancelled connections back into the connection pool

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -107,3 +107,4 @@ Multiplay Ltd.
 Percona LLC
 Pivotal Inc.
 Stripe Inc.
+Zendesk Inc.

--- a/connection.go
+++ b/connection.go
@@ -489,6 +489,10 @@ func (mc *mysqlConn) Ping(ctx context.Context) (err error) {
 
 // BeginTx implements driver.ConnBeginTx interface
 func (mc *mysqlConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if mc.closed.IsSet() {
+		return nil, driver.ErrBadConn
+	}
+
 	if err := mc.watchCancel(ctx); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description
If
* BeginTx is called with a non-default isolation level,
* The context is canceled before SET TRANSACTION ISOLATION LEVEL completes,

then the connection:
* has the cancelled property set to "context cancelled",
* has the closed property set to true,

and,
* BeginTx returns "context canceled"

Because of this, the connection gets put back into the connection pool. When it is checked out again, if BeginTx is called on it again _without_ an isolation level,
* then we fall into the mc.closed.IsSet() check in begin(),
* so we return ErrBadConn,
* so the driver kicks the broken connection out of the pool
* (and transparently retries to get a new connection that isn't broken too).

However, if BeginTx is called on the connection _with_ an isolation
level, then we return a context canceled error from the SET TRANSACTION
ISOLATION LEVEL call.

That means the broken connection will stick around in the pool forever
(or until it's checked out for some other operation that correctly
returns ErrBadConn).

The fix is to check for the connection being closed before executing SET
TRANSACTION ISOLATION LEVEL.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
