### PR TITLE
performance improvement for parseDateTime

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -90,6 +90,7 @@ Vladimir Kovpak <cn007b at gmail.com>
 Xiangyu Hu <xiangyu.hu at outlook.com>
 Xiaobing Jiang <s7v7nislands at gmail.com>
 Xiuming Chen <cc at cxm.cc>
+Xuehong Chan <chanxuehong at gmail.com>
 Zhenye Xie <xiezhenye at gmail.com>
 Zhixin Wen <john.wenzhixin at gmail.com>
 

--- a/utils.go
+++ b/utils.go
@@ -113,20 +113,14 @@ func parseDateTime(str string, loc *time.Location) (t time.Time, err error) {
 		if str == base[:len(str)] {
 			return
 		}
-		t, err = time.Parse(timeFormat[:len(str)], str)
+		if loc == time.UTC {
+			return time.Parse(timeFormat[:len(str)], str)
+		}
+		return time.ParseInLocation(timeFormat[:len(str)], str, loc)
 	default:
 		err = fmt.Errorf("invalid time string: %s", str)
 		return
 	}
-
-	// Adjust location
-	if err == nil && loc != time.UTC {
-		y, mo, d := t.Date()
-		h, mi, s := t.Clock()
-		t, err = time.Date(y, mo, d, h, mi, s, t.Nanosecond(), loc), nil
-	}
-
-	return
 }
 
 func parseBinaryDateTime(num uint64, data []byte, loc *time.Location) (driver.Value, error) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -14,6 +14,7 @@ import (
 	"database/sql/driver"
 	"encoding/binary"
 	"testing"
+	"time"
 )
 
 func TestLengthEncodedInteger(t *testing.T) {
@@ -289,5 +290,47 @@ func TestIsolationLevelMapping(t *testing.T) {
 	}
 	if err.Error() != expectedErr {
 		t.Fatalf("Expected error to be %q, got %q", expectedErr, err)
+	}
+}
+
+func TestParseDateTime(t *testing.T) {
+	// UTC loc
+	{
+		str := "2020-05-13 21:30:45"
+		t1, err := parseDateTime(str, time.UTC)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		t2 := time.Date(2020, 5, 13,
+			21, 30, 45, 0, time.UTC)
+		if !t1.Equal(t2) {
+			t.Errorf("want equal, have: %v, want: %v", t1, t2)
+			return
+		}
+	}
+	// non-UTC loc
+	{
+		str := "2020-05-13 21:30:45"
+		loc := time.FixedZone("test", 8*60*60)
+		t1, err := parseDateTime(str, loc)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		t2 := time.Date(2020, 5, 13,
+			21, 30, 45, 0, loc)
+		if !t1.Equal(t2) {
+			t.Errorf("want equal, have: %v, want: %v", t1, t2)
+			return
+		}
+	}
+}
+
+func BenchmarkParseDateTime(b *testing.B) {
+	str := "2020-05-13 21:30:45"
+	loc := time.FixedZone("test", 8*60*60)
+	for i := 0; i < b.N; i++ {
+		_, _ = parseDateTime(str, loc)
 	}
 }


### PR DESCRIPTION
### Description
Please explain the changes you made here.

for now, if loc is not nil, will call t.Date and t.Clock, this PR saves these costs

Benchmark_parseDateTime
Benchmark_parseDateTime-8   	 4921956	       238 ns/op

Benchmark_parseDateTimeOld
Benchmark_parseDateTimeOld-8   	 3827149	       319 ns/op

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
