### PR TITLE
On connect, set all variables in a single SET statement

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -47,9 +47,10 @@ type mysqlConn struct {
 
 // Handles parameters set in DSN after the connection is established
 func (mc *mysqlConn) handleParams() (err error) {
+	var params []string
 	for param, val := range mc.cfg.Params {
 		switch param {
-		// Charset
+		// Charset: character_set_connection, character_set_client, character_set_results
 		case "charset":
 			charsets := strings.Split(val, ",")
 			for i := range charsets {
@@ -63,12 +64,16 @@ func (mc *mysqlConn) handleParams() (err error) {
 				return
 			}
 
-		// System Vars
+		// Other system vars
 		default:
-			err = mc.exec("SET " + param + "=" + val + "")
-			if err != nil {
-				return
-			}
+			params = append(params, param+"="+val)
+		}
+	}
+
+	if len(params) > 0 {
+		err = mc.exec("SET " + strings.Join(params, ","))
+		if err != nil {
+			return
 		}
 	}
 


### PR DESCRIPTION
### Description
For faster connection startup this patch use (almost) a single `SET` statement to set all variables at once instead of a `SET` statement for each variable.

MySQL doc about the `SET` statement: https://dev.mysql.com/doc/refman/8.0/en/set-variable.html

Before:
- `SET <variable1>=<value1>`
- `SET NAMES utf8mb4`
- `SET <variable2>=<value2>`
- `SET <variable3>=<value3>`

Now:
- `SET NAMES utf8mb4`
- `SET <variable1>=<value1>,<variable2>=<value2>,<variable3>=<value3>`

This patch should make establishing new connection must faster as it reduce the number of roundtrips necessary before the first query when multiple variables are defined in the DSN.

As a side effect, the `SET NAMES` statement is always executed first. This will fix the possibility of some `SET` statements being executed before the right charset is set (for the case where the database default charset is not the one we want to use for the connection, e.g. Latin1).

Here is how to test this patch with your own Go project built with Go modules:
```
$ go mod edit -replace=github.com/go-sql-driver/mysql=github.com/dolmen/mysql@v0.0.0-20200513153212-0b8f76b0751c
```

Background: on MySQL 5.7 database hosted on Amazon RDS we noticed that in Performance Insights that some costly queries were hidden by `SET` statements. Sometimes we saw a `SET time_zone=...`, sometimes a `SET group_concat_max_len=...`, sometimes `SET sql_mode='TRADITIONAL'`. 

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing: https://travis-ci.org/github/dolmen/mysql/builds/686635632
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
