### PR TITLE
travis: update image versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
         - go get golang.org/x/tools/cmd/cover
         - go get github.com/mattn/goveralls
         - docker pull mysql:8.0
-        - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
+        - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ALLOW_EMPTY_PASSWORD=yes
           mysql:8.0 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB --local-infile=1
         - cp .travis/docker.cnf ~/.my.cnf
         - .travis/wait_mysql.sh
@@ -53,7 +53,7 @@ jobs:
         - go get golang.org/x/tools/cmd/cover
         - go get github.com/mattn/goveralls
         - docker pull mysql:5.7
-        - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
+        - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ALLOW_EMPTY_PASSWORD=yes
           mysql:5.7 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB --local-infile=1
         - cp .travis/docker.cnf ~/.my.cnf
         - .travis/wait_mysql.sh
@@ -72,7 +72,7 @@ jobs:
         - go get golang.org/x/tools/cmd/cover
         - go get github.com/mattn/goveralls
         - docker pull mariadb:5.5
-        - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
+        - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ALLOW_EMPTY_PASSWORD=yes
           mariadb:5.5 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB --local-infile=1
         - cp .travis/docker.cnf ~/.my.cnf
         - .travis/wait_mysql.sh
@@ -91,7 +91,7 @@ jobs:
         - go get golang.org/x/tools/cmd/cover
         - go get github.com/mattn/goveralls
         - docker pull mariadb:10.1
-        - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret
+        - docker run -d -p 127.0.0.1:3307:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ALLOW_EMPTY_PASSWORD=yes
           mariadb:10.1 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB --local-infile=1
         - cp .travis/docker.cnf ~/.my.cnf
         - .travis/wait_mysql.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
 
   include:
     - env: DB=MYSQL8
-      dist: trusty
+      dist: xenial
       go: 1.14.x
       services:
         - docker
@@ -45,7 +45,7 @@ jobs:
         - export MYSQL_TEST_CONCURRENT=1
 
     - env: DB=MYSQL57
-      dist: trusty
+      dist: xenial
       go: 1.14.x
       services:
         - docker
@@ -64,7 +64,7 @@ jobs:
         - export MYSQL_TEST_CONCURRENT=1
 
     - env: DB=MARIA55
-      dist: trusty
+      dist: xenial
       go: 1.14.x
       services:
         - docker
@@ -83,7 +83,7 @@ jobs:
         - export MYSQL_TEST_CONCURRENT=1
 
     - env: DB=MARIA10_1
-      dist: trusty
+      dist: xenial
       go: 1.14.x
       services:
         - docker
@@ -102,7 +102,7 @@ jobs:
         - export MYSQL_TEST_CONCURRENT=1
 
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode11.4
       addons:
         homebrew:
           packages:

--- a/.travis/wait_mysql.sh
+++ b/.travis/wait_mysql.sh
@@ -7,7 +7,7 @@
 
 while :
 do
-    if mysql --protocol=tcp --password=${MYSQL_ROOT_PASSWORD} -e 'select version()'; then
+    if mysql --protocol=tcp -e 'select version()'; then
         break
     fi
     sleep 3

--- a/.travis/wait_mysql.sh
+++ b/.travis/wait_mysql.sh
@@ -1,7 +1,13 @@
 #!/bin/sh
+
+# use the mysql client inside the docker container if docker is running
+[ "$(docker inspect -f '{{.State.Running}}' mysqld 2>/dev/null)" = "true" ] && mysql() {
+    docker exec mysqld mysql "${@}"
+}
+
 while :
 do
-    if mysql -e 'select version()' 2>&1 | grep 'version()\|ERROR 2059 (HY000):'; then
+    if mysql -e 'select version()'; then
         break
     fi
     sleep 3

--- a/.travis/wait_mysql.sh
+++ b/.travis/wait_mysql.sh
@@ -7,7 +7,7 @@
 
 while :
 do
-    if mysql --protocol=tcp -e 'select version()'; then
+    if mysql --protocol=tcp --password=${MYSQL_ROOT_PASSWORD} -e 'select version()'; then
         break
     fi
     sleep 3

--- a/.travis/wait_mysql.sh
+++ b/.travis/wait_mysql.sh
@@ -7,7 +7,7 @@
 
 while :
 do
-    if mysql -e 'select version()'; then
+    if mysql --protocol=tcp -e 'select version()'; then
         break
     fi
     sleep 3


### PR DESCRIPTION
### Description
Updates the images on Travis to latest versions.
For better comparability (and thus less hacks), it further changes the `mysql_wait.sh` script to use the mysql client inside the docker container if docker is running.

### Checklist
- [X] Code compiles correctly
- [X] All tests passing
