### PR TITLE
utils: parse using byteslice in parseDateTime

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,6 +55,7 @@ Julien Schmidt <go-sql-driver at julienschmidt.com>
 Justin Li <jli at j-li.net>
 Justin Nuß <nuss.justin at gmail.com>
 Kamil Dziedzic <kamil at klecza.pl>
+Kei Kamikawa <x00.x7f.x86 at gmail.com>
 Kevin Malachowski <kevin at chowski.com>
 Kieron Woodhouse <kieron.woodhouse at infosum.com>
 Lennart Rudolph <lrudolph at hmc.edu>

--- a/nulltime.go
+++ b/nulltime.go
@@ -28,7 +28,7 @@ func (nt *NullTime) Scan(value interface{}) (err error) {
 		nt.Time, nt.Valid = v, true
 		return
 	case []byte:
-		nt.Time, err = parseDateTime(string(v), time.UTC)
+		nt.Time, err = parseByteDateTime(v, time.UTC)
 		nt.Valid = (err == nil)
 		return
 	case string:

--- a/nulltime.go
+++ b/nulltime.go
@@ -28,11 +28,11 @@ func (nt *NullTime) Scan(value interface{}) (err error) {
 		nt.Time, nt.Valid = v, true
 		return
 	case []byte:
-		nt.Time, err = parseByteDateTime(v, time.UTC)
+		nt.Time, err = parseDateTime(v, time.UTC)
 		nt.Valid = (err == nil)
 		return
 	case string:
-		nt.Time, err = parseDateTime(v, time.UTC)
+		nt.Time, err = parseDateTime([]byte(v), time.UTC)
 		nt.Valid = (err == nil)
 		return
 	}

--- a/packets.go
+++ b/packets.go
@@ -777,8 +777,8 @@ func (rows *textRows) readRow(dest []driver.Value) error {
 					switch rows.rs.columns[i].fieldType {
 					case fieldTypeTimestamp, fieldTypeDateTime,
 						fieldTypeDate, fieldTypeNewDate:
-						dest[i], err = parseDateTime(
-							string(dest[i].([]byte)),
+						dest[i], err = parseByteDateTime(
+							dest[i].([]byte),
 							mc.cfg.Loc,
 						)
 						if err == nil {

--- a/packets.go
+++ b/packets.go
@@ -777,7 +777,7 @@ func (rows *textRows) readRow(dest []driver.Value) error {
 					switch rows.rs.columns[i].fieldType {
 					case fieldTypeTimestamp, fieldTypeDateTime,
 						fieldTypeDate, fieldTypeNewDate:
-						dest[i], err = parseByteDateTime(
+						dest[i], err = parseDateTime(
 							dest[i].([]byte),
 							mc.cfg.Loc,
 						)

--- a/utils.go
+++ b/utils.go
@@ -147,7 +147,7 @@ func parseByteDateTime(b []byte, loc *time.Location) (time.Time, error) {
 			return time.Time{}, fmt.Errorf("bad value for field: `%c`", b[4])
 		}
 
-		m, err := parseByte2Digits(b, 5)
+		m, err := parseByte2Digits(b[5], b[6])
 		if err != nil {
 			return time.Time{}, err
 		}
@@ -160,7 +160,7 @@ func parseByteDateTime(b []byte, loc *time.Location) (time.Time, error) {
 			return time.Time{}, fmt.Errorf("bad value for field: `%c`", b[7])
 		}
 
-		day, err := parseByte2Digits(b, 8)
+		day, err := parseByte2Digits(b[8], b[9])
 		if err != nil {
 			return time.Time{}, err
 		}
@@ -175,7 +175,7 @@ func parseByteDateTime(b []byte, loc *time.Location) (time.Time, error) {
 			return time.Time{}, fmt.Errorf("bad value for field: `%c`", b[10])
 		}
 
-		hour, err := parseByte2Digits(b, 11)
+		hour, err := parseByte2Digits(b[11], b[12])
 		if err != nil {
 			return time.Time{}, err
 		}
@@ -183,7 +183,7 @@ func parseByteDateTime(b []byte, loc *time.Location) (time.Time, error) {
 			return time.Time{}, fmt.Errorf("bad value for field: `%c`", b[13])
 		}
 
-		min, err := parseByte2Digits(b, 14)
+		min, err := parseByte2Digits(b[14], b[15])
 		if err != nil {
 			return time.Time{}, err
 		}
@@ -191,7 +191,7 @@ func parseByteDateTime(b []byte, loc *time.Location) (time.Time, error) {
 			return time.Time{}, fmt.Errorf("bad value for field: `%c`", b[16])
 		}
 
-		sec, err := parseByte2Digits(b, 17)
+		sec, err := parseByte2Digits(b[17], b[18])
 		if err != nil {
 			return time.Time{}, err
 		}
@@ -217,7 +217,7 @@ func parseByteYear(b []byte) (int, error) {
 	for i := 0; i < 4; i++ {
 		v, err := bToi(b[i])
 		if err != nil {
-			return 0, fmt.Errorf("invalid time bytes: %s", b)
+			return 0, err
 		}
 		year += v * n
 		n = n / 10
@@ -225,14 +225,14 @@ func parseByteYear(b []byte) (int, error) {
 	return year, nil
 }
 
-func parseByte2Digits(b []byte, index int) (int, error) {
-	d2, err := bToi(b[index])
+func parseByte2Digits(b1, b2 byte) (int, error) {
+	d2, err := bToi(b1)
 	if err != nil {
-		return 0, fmt.Errorf("invalid time bytes: %s", b)
+		return 0, err
 	}
-	d1, err := bToi(b[index+1])
+	d1, err := bToi(b2)
 	if err != nil {
-		return 0, fmt.Errorf("invalid time bytes: %s", b)
+		return 0, err
 	}
 	return d2*10 + d1, nil
 }
@@ -248,7 +248,7 @@ func parseByteNanoSec(b []byte) (int, error) {
 		ns += v * digit
 		digit /= 10
 	}
-	// nanoseconds has 10-digits.
+	// nanoseconds has 10-digits. (needs to scale digits)
 	// 10 - 6 = 4, so we have to multiple 1000.
 	return ns * 1000, nil
 }

--- a/utils.go
+++ b/utils.go
@@ -181,7 +181,7 @@ func parseDateTime(b []byte, loc *time.Location) (time.Time, error) {
 		if b[19] != '.' {
 			return time.Time{}, fmt.Errorf("bad value for field: `%c`", b[19])
 		}
-		nsec, err := parseByteNanoSec(b)
+		nsec, err := parseByteNanoSec(b[20:])
 		if err != nil {
 			return time.Time{}, err
 		}

--- a/utils.go
+++ b/utils.go
@@ -112,23 +112,7 @@ var (
 	nullTimeBaseByte = []byte(nullTimeBaseStr)
 )
 
-func parseDateTime(str string, loc *time.Location) (t time.Time, err error) {
-	switch len(str) {
-	case 10, 19, 21, 22, 23, 24, 25, 26: // up to "YYYY-MM-DD HH:MM:SS.MMMMMM"
-		if str == nullTimeBaseStr[:len(str)] {
-			return
-		}
-		if loc == time.UTC {
-			return time.Parse(timeFormat[:len(str)], str)
-		}
-		return time.ParseInLocation(timeFormat[:len(str)], str, loc)
-	default:
-		err = fmt.Errorf("invalid time string: %s", str)
-		return
-	}
-}
-
-func parseByteDateTime(b []byte, loc *time.Location) (time.Time, error) {
+func parseDateTime(b []byte, loc *time.Location) (time.Time, error) {
 	switch len(b) {
 	case 10, 19, 21, 22, 23, 24, 25, 26: // up to "YYYY-MM-DD HH:MM:SS.MMMMMM"
 		if bytes.Compare(b, nullTimeBaseByte[:len(b)]) == 0 {

--- a/utils.go
+++ b/utils.go
@@ -217,9 +217,8 @@ func parseByte2Digits(b1, b2 byte) (int, error) {
 }
 
 func parseByteNanoSec(b []byte) (int, error) {
-	l := len(b)
 	ns, digit := 0, 100000 // max is 6-digits
-	for i := 20; i < l; i++ {
+	for i := 0; i < len(b); i++ {
 		v, err := bToi(b[i])
 		if err != nil {
 			return 0, err

--- a/utils.go
+++ b/utils.go
@@ -205,15 +205,15 @@ func parseByteYear(b []byte) (int, error) {
 }
 
 func parseByte2Digits(b1, b2 byte) (int, error) {
-	d2, err := bToi(b1)
+	d1, err := bToi(b1)
 	if err != nil {
 		return 0, err
 	}
-	d1, err := bToi(b2)
+	d2, err := bToi(b2)
 	if err != nil {
 		return 0, err
 	}
-	return d2*10 + d1, nil
+	return d1*10 + d2, nil
 }
 
 func parseByteNanoSec(b []byte) (int, error) {

--- a/utils.go
+++ b/utils.go
@@ -108,7 +108,7 @@ func readBool(input string) (value bool, valid bool) {
 ******************************************************************************/
 
 var (
-	nullTimeBaseStr  = "0000-00-00 00:00:00.0000000"
+	nullTimeBaseStr  = "0000-00-00 00:00:00.000000"
 	nullTimeBaseByte = []byte(nullTimeBaseStr)
 )
 

--- a/utils.go
+++ b/utils.go
@@ -9,7 +9,6 @@
 package mysql
 
 import (
-	"bytes"
 	"crypto/tls"
 	"database/sql"
 	"database/sql/driver"
@@ -107,15 +106,11 @@ func readBool(input string) (value bool, valid bool) {
 *                           Time related utils                                *
 ******************************************************************************/
 
-var (
-	nullTimeBaseStr  = "0000-00-00 00:00:00.000000"
-	nullTimeBaseByte = []byte(nullTimeBaseStr)
-)
-
 func parseDateTime(b []byte, loc *time.Location) (time.Time, error) {
+	const base = "0000-00-00 00:00:00.000000"
 	switch len(b) {
 	case 10, 19, 21, 22, 23, 24, 25, 26: // up to "YYYY-MM-DD HH:MM:SS.MMMMMM"
-		if bytes.Compare(b, nullTimeBaseByte[:len(b)]) == 0 {
+		if string(b) == base[:len(b)] {
 			return time.Time{}, nil
 		}
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -327,10 +327,98 @@ func TestParseDateTime(t *testing.T) {
 	}
 }
 
+func TestParseByteDateTime(t *testing.T) {
+	cases := []struct {
+		name string
+		str  string
+	}{
+		{
+			name: "parse date",
+			str:  "2020-05-13",
+		},
+		{
+			name: "parse null date",
+			str:  sDate0,
+		},
+		{
+			name: "parse datetime",
+			str:  "2020-05-13 21:30:45",
+		},
+		{
+			name: "parse null datetime",
+			str:  sDateTime0,
+		},
+		{
+			name: "parse datetime nanosec 1-digit",
+			str:  "2020-05-25 23:22:01.1",
+		},
+		{
+			name: "parse datetime nanosec 2-digits",
+			str:  "2020-05-25 23:22:01.15",
+		},
+		{
+			name: "parse datetime nanosec 3-digits",
+			str:  "2020-05-25 23:22:01.159",
+		},
+		{
+			name: "parse datetime nanosec 4-digits",
+			str:  "2020-05-25 23:22:01.1594",
+		},
+		{
+			name: "parse datetime nanosec 5-digits",
+			str:  "2020-05-25 23:22:01.15949",
+		},
+		{
+			name: "parse datetime nanosec 6-digits",
+			str:  "2020-05-25 23:22:01.159491",
+		},
+	}
+
+	for _, loc := range []*time.Location{
+		time.UTC,
+		time.FixedZone("test", 8*60*60),
+	} {
+		for _, cc := range cases {
+			t.Run(cc.name+"-"+loc.String(), func(t *testing.T) {
+				want, err := parseDateTime(cc.str, loc)
+				if err != nil {
+					t.Fatal(err)
+				}
+				got, err := parseByteDateTime([]byte(cc.str), loc)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !want.Equal(got) {
+					t.Fatalf("want: %v, but got %v", want, got)
+				}
+			})
+		}
+	}
+}
+
 func BenchmarkParseDateTime(b *testing.B) {
 	str := "2020-05-13 21:30:45"
 	loc := time.FixedZone("test", 8*60*60)
 	for i := 0; i < b.N; i++ {
 		_, _ = parseDateTime(str, loc)
+	}
+}
+
+func BenchmarkParseByteDateTime(b *testing.B) {
+	bStr := []byte("2020-05-25 23:22:01.159491")
+	loc := time.FixedZone("test", 8*60*60)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = parseByteDateTime(bStr, loc)
+	}
+}
+
+func BenchmarkParseByteDateTimeStringCast(b *testing.B) {
+	bStr := []byte("2020-05-25 23:22:01.159491")
+	loc := time.FixedZone("test", 8*60*60)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = parseDateTime(string(bStr), loc)
 	}
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -295,9 +295,10 @@ func TestIsolationLevelMapping(t *testing.T) {
 }
 
 func deprecatedParseDateTime(str string, loc *time.Location) (t time.Time, err error) {
+	const base = "0000-00-00 00:00:00.000000"
 	switch len(str) {
 	case 10, 19, 21, 22, 23, 24, 25, 26: // up to "YYYY-MM-DD HH:MM:SS.MMMMMM"
-		if str == nullTimeBaseStr[:len(str)] {
+		if str == base[:len(str)] {
 			return
 		}
 		if loc == time.UTC {


### PR DESCRIPTION
### Description

When the time information is passed in byteslice, it takes a long time to parse it. The order in which the current parsing is done is

1. cast `dest[i]` to byteslice
2. cast byteslice to string
3. parseDateTime

And since the format for returning the time information to the client has been decided, I think it's obviously faster to do the parsing ownself right away. 


<img width="955" alt="スクリーンショット 2020-05-26 11 47 23" src="https://user-images.githubusercontent.com/6500104/82855596-b0be2580-9f46-11ea-8707-834aa6213ca2.png">

The benchmark results

```
$ go test -benchmem . -bench "(DateTime|Cast)$"
goos: darwin
goarch: amd64
pkg: github.com/go-sql-driver/mysql
BenchmarkParseDateTime-4                         5039470               250 ns/op               0 B/op          0 allocs/op
BenchmarkParseByteDateTime-4                    11188809                99.2 ns/op             0 B/op          0 allocs/op
BenchmarkParseByteDateTimeStringCast-4           3342747               356 ns/op              32 B/op          1 allocs/op
```

<details>
  <summary>Code</summary>

```go
func deprecatedParseDateTime(str string, loc *time.Location) (t time.Time, err error) {
	const base = "0000-00-00 00:00:00.000000"
	switch len(str) {
	case 10, 19, 21, 22, 23, 24, 25, 26: // up to "YYYY-MM-DD HH:MM:SS.MMMMMM"
		if str == base[:len(str)] {
			return
		}
		if loc == time.UTC {
			return time.Parse(timeFormat[:len(str)], str)
		}
		return time.ParseInLocation(timeFormat[:len(str)], str, loc)
	default:
		err = fmt.Errorf("invalid time string: %s", str)
		return
	}
}

func BenchmarkParseDateTime(b *testing.B) {
	str := "2020-05-13 21:30:45"
	loc := time.FixedZone("test", 8*60*60)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_, _ = deprecatedParseDateTime(str, loc)
	}
}

func BenchmarkParseByteDateTime(b *testing.B) {
	bStr := []byte("2020-05-25 23:22:01.159491")
	loc := time.FixedZone("test", 8*60*60)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_, _ = parseDateTime(bStr, loc)
	}
}

func BenchmarkParseByteDateTimeStringCast(b *testing.B) {
	bStr := []byte("2020-05-25 23:22:01.159491")
	loc := time.FixedZone("test", 8*60*60)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_, _ = deprecatedParseDateTime(string(bStr), loc)
	}
}
```

</details>

MySQL datetime format
https://dev.mysql.com/doc/refman/8.0/en/datetime.html

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
