### PR TITLE
Refactor: add a private constructor for connector

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -18,6 +18,10 @@ type connector struct {
 	cfg *Config // immutable private copy.
 }
 
+func newConnector(cfg *Config) *connector {
+	return &connector{cfg: cfg}
+}
+
 // Connect implements driver.Connector interface.
 // Connect returns a connection to the database.
 func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {

--- a/driver.go
+++ b/driver.go
@@ -74,10 +74,7 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	c := &connector{
-		cfg: cfg,
-	}
-	return c.Connect(context.Background())
+	return newConnector(cfg).Connect(context.Background())
 }
 
 func init() {
@@ -92,7 +89,7 @@ func NewConnector(cfg *Config) (driver.Connector, error) {
 	if err := cfg.normalize(); err != nil {
 		return nil, err
 	}
-	return &connector{cfg: cfg}, nil
+	return newConnector(cfg), nil
 }
 
 // OpenConnector implements driver.DriverContext.
@@ -101,7 +98,5 @@ func (d MySQLDriver) OpenConnector(dsn string) (driver.Connector, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &connector{
-		cfg: cfg,
-	}, nil
+	return newConnector(cfg), nil
 }


### PR DESCRIPTION
### Description
This is a minor refactoring that will allow to prepare more things when the `Connector` is created and do less on each `Connect`. Those changes will be proposed in further PRs (spoil: I intend to move some code from `handleParams` once #1111 is merged).

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
