### PR TITLE
fix: remove last 0 byte for mysql_old_password when password is empty

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -85,6 +85,7 @@ Soroush Pour <me at soroushjp.com>
 Stan Putrya <root.vagner at gmail.com>
 Stanley Gunawan <gunawan.stanley at gmail.com>
 Steven Hartland <steven.hartland at multiplay.co.uk>
+Tan Jinhua <312841925 at qq.com>
 Thomas Wodarek <wodarekwebpage at gmail.com>
 Tim Ruffles <timruffles at gmail.com>
 Tom Jenkinson <tom at tjenkinson.me>

--- a/auth.go
+++ b/auth.go
@@ -136,10 +136,6 @@ func pwHash(password []byte) (result [2]uint32) {
 
 // Hash password using insecure pre 4.1 method
 func scrambleOldPassword(scramble []byte, password string) []byte {
-	if len(password) == 0 {
-		return nil
-	}
-
 	scramble = scramble[:8]
 
 	hashPw := pwHash([]byte(password))
@@ -246,6 +242,9 @@ func (mc *mysqlConn) auth(authData []byte, plugin string) ([]byte, error) {
 	case "mysql_old_password":
 		if !mc.cfg.AllowOldPasswords {
 			return nil, ErrOldPassword
+		}
+		if len(mc.cfg.Passwd) == 0 {
+			return nil, nil
 		}
 		// Note: there are edge cases where this should work but doesn't;
 		// this is currently "wontfix":

--- a/auth_test.go
+++ b/auth_test.go
@@ -1157,7 +1157,7 @@ func TestAuthSwitchOldPasswordEmpty(t *testing.T) {
 		t.Errorf("got error: %v", err)
 	}
 
-	expectedReply := []byte{1, 0, 0, 3, 0}
+	expectedReply := []byte{0, 0, 0, 3}
 	if !bytes.Equal(conn.written, expectedReply) {
 		t.Errorf("got unexpected data: %v", conn.written)
 	}
@@ -1184,7 +1184,7 @@ func TestOldAuthSwitchPasswordEmpty(t *testing.T) {
 		t.Errorf("got error: %v", err)
 	}
 
-	expectedReply := []byte{1, 0, 0, 3, 0}
+	expectedReply := []byte{0, 0, 0, 3}
 	if !bytes.Equal(conn.written, expectedReply) {
 		t.Errorf("got unexpected data: %v", conn.written)
 	}


### PR DESCRIPTION
### Description
When I create a user with `mysql_old_password` as auth plugin but without password, and use this user to login(refer this test: https://github.com/rainingmaster/go-mysql-test), it will failed, as [my test here](https://github.com/rainingmaster/go-mysql-test/blob/master/origin/origin_test.go#L19), and report [Error 1043: Bad handshake](https://travis-ci.org/github/rainingmaster/go-mysql-test/jobs/700726250#L677).

After my investigation, I have compared the login data from mysql client(which is successful), I found client do not need to send the last `0' byte for the auth switch, if we append last `0` byte  even empty password, the hand shake will be broken.

For `maradb:5.5` to `maradb:10.3`, it wont response auth switch by response ok straightly.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
