### PR TITLE
Support returning uint64 from Valuer in ConvertValue

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -79,6 +79,7 @@ Reed Allman <rdallman10 at gmail.com>
 Richard Wilkes <wilkes at me.com>
 Robert Russell <robert at rrbrussell.com>
 Runrioter Wung <runrioter at gmail.com>
+Sho Ikeda <suicaicoca at gmail.com>
 Shuode Li <elemount at qq.com>
 Simon J Mudd <sjmudd at pobox.com>
 Soroush Pour <me at soroushjp.com>

--- a/statement.go
+++ b/statement.go
@@ -154,10 +154,16 @@ func (c converter) ConvertValue(v interface{}) (driver.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		if !driver.IsValue(sv) {
-			return nil, fmt.Errorf("non-Value type %T returned from Value", sv)
+		if driver.IsValue(sv) {
+			return sv, nil
 		}
-		return sv, nil
+		// A value returend from the Valuer interface can be "a type handled by
+		// a database driver's NamedValueChecker interface" so we should accept
+		// uint64 here as well.
+		if u, ok := sv.(uint64); ok {
+			return u, nil
+		}
+		return nil, fmt.Errorf("non-Value type %T returned from Value", sv)
 	}
 	rv := reflect.ValueOf(v)
 	switch rv.Kind() {

--- a/statement_test.go
+++ b/statement_test.go
@@ -10,6 +10,7 @@ package mysql
 
 import (
 	"bytes"
+	"database/sql/driver"
 	"encoding/json"
 	"testing"
 )
@@ -96,6 +97,14 @@ func TestConvertSignedIntegers(t *testing.T) {
 	}
 }
 
+type myUint64 struct {
+	value uint64
+}
+
+func (u myUint64) Value() (driver.Value, error) {
+	return u.value, nil
+}
+
 func TestConvertUnsignedIntegers(t *testing.T) {
 	values := []interface{}{
 		uint8(42),
@@ -103,6 +112,7 @@ func TestConvertUnsignedIntegers(t *testing.T) {
 		uint32(42),
 		uint64(42),
 		uint(42),
+		myUint64{uint64(42)},
 	}
 
 	for _, value := range values {


### PR DESCRIPTION
### Description
Changed `ConvertValue` implementation to support returning uint64 from `Valuer` interface.

https://golang.org/pkg/database/sql/driver/#Value says:

> Value is a value that drivers must be able to handle. It is either nil, **a type handled by a database driver's NamedValueChecker interface**, or an instance of one of these types:

Because this drivers' `NamedValueChecker`s (mysqlConn and mysqlStmt) suppot `uint64` through `ConvertValue`, we should allow `Valuer` to return `uint64` as well.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
