### PR TITLE
Support optional resultset metadata

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -95,6 +95,7 @@ Tan Jinhua <312841925 at qq.com>
 Thomas Wodarek <wodarekwebpage at gmail.com>
 Tim Ruffles <timruffles at gmail.com>
 Tom Jenkinson <tom at tjenkinson.me>
+Tzu-Chiao Yeh <su3g4284zo6y7 at gmail.com>
 Vladimir Kovpak <cn007b at gmail.com>
 Vladyslav Zhelezniak <zhvladi at gmail.com>
 Xiangyu Hu <xiangyu.hu at outlook.com>

--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ Examples:
   * `autocommit=1`: `SET autocommit=1`
   * [`time_zone=%27Europe%2FParis%27`](https://dev.mysql.com/doc/refman/5.5/en/time-zone-support.html): `SET time_zone='Europe/Paris'`
   * [`transaction_isolation=%27REPEATABLE-READ%27`](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_transaction_isolation): `SET transaction_isolation='REPEATABLE-READ'`
+  * metata=none`](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_resultset_metadata): `SET resultset_metadata=none` (note that this is only applicable to MySQL 8.0+ versions).
 
 
 #### Examples

--- a/connector.go
+++ b/connector.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"net"
+	"strings"
 )
 
 type connector struct {
@@ -86,6 +87,20 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 
 	if plugin == "" {
 		plugin = defaultAuthPlugin
+	}
+
+	// Set the optionalResultSetMetadata ahead to set the client capability flag.
+	if resultSetMetadata, ok := mc.cfg.Params["resultset_metadata"]; ok {
+		upperVal := strings.ToUpper(resultSetMetadata)
+		switch upperVal {
+		case resultSetMetadataSysVarNone:
+			mc.optionalResultSetMetadata = true
+			mc.resultSetMetadata = resultSetMetadataNone
+		case resultSetMetadataSysVarFull:
+			mc.optionalResultSetMetadata = true
+			mc.resultSetMetadata = resultSetMetadataFull
+		}
+		// To be consistent with other params, in case the param is passed wrongly still send to MySQL to let the server side rejects it.
 	}
 
 	// Send Client Authentication Packet

--- a/const.go
+++ b/const.go
@@ -56,6 +56,7 @@ const (
 	clientCanHandleExpiredPasswords
 	clientSessionTrack
 	clientDeprecateEOF
+	clientOptionalResultSetMetadata
 )
 
 const (
@@ -171,4 +172,17 @@ const (
 	cachingSha2PasswordRequestPublicKey          = 2
 	cachingSha2PasswordFastAuthSuccess           = 3
 	cachingSha2PasswordPerformFullAuthentication = 4
+)
+
+const (
+	// One-byte metadata flag
+	// https://dev.mysql.com/worklog/task/?id=8134
+	resultSetMetadataNone uint8 = iota
+	resultSetMetadataFull
+)
+
+const (
+	// ResultSet Metadata system var
+	resultSetMetadataSysVarNone = "NONE"
+	resultSetMetadataSysVarFull = "FULL"
 )

--- a/dsn.go
+++ b/dsn.go
@@ -34,22 +34,22 @@ var (
 // If a new Config is created instead of being parsed from a DSN string,
 // the NewConfig function should be used, which sets default values.
 type Config struct {
-	User             string            // Username
-	Passwd           string            // Password (requires User)
-	Net              string            // Network type
-	Addr             string            // Network address (requires Net)
-	DBName           string            // Database name
-	Params           map[string]string // Connection parameters
-	Collation        string            // Connection collation
-	Loc              *time.Location    // Location for time.Time values
-	MaxAllowedPacket int               // Max packet size allowed
-	ServerPubKey     string            // Server public key name
-	pubKey           *rsa.PublicKey    // Server public key
-	TLSConfig        string            // TLS configuration name
-	tls              *tls.Config       // TLS configuration
-	Timeout          time.Duration     // Dial timeout
-	ReadTimeout      time.Duration     // I/O read timeout
-	WriteTimeout     time.Duration     // I/O write timeout
+	User              string            // Username
+	Passwd            string            // Password (requires User)
+	Net               string            // Network type
+	Addr              string            // Network address (requires Net)
+	DBName            string            // Database name
+	Params            map[string]string // Connection parameters
+	Collation         string            // Connection collation
+	Loc               *time.Location    // Location for time.Time values
+	MaxAllowedPacket  int               // Max packet size allowed
+	ServerPubKey      string            // Server public key name
+	pubKey            *rsa.PublicKey    // Server public key
+	TLSConfig         string            // TLS configuration name
+	tls               *tls.Config       // TLS configuration
+	Timeout           time.Duration     // Dial timeout
+	ReadTimeout       time.Duration     // I/O read timeout
+	WriteTimeout      time.Duration     // I/O write timeout
 
 	AllowAllFiles           bool // Allow all files to be used with LOAD DATA LOCAL INFILE
 	AllowCleartextPasswords bool // Allows the cleartext client side plugin

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -45,6 +45,9 @@ var testDSNs = []struct {
 	"user:password@/dbname?allowNativePasswords=false&checkConnLiveness=false&maxAllowedPacket=0",
 	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Collation: "utf8mb4_general_ci", Loc: time.UTC, MaxAllowedPacket: 0, AllowNativePasswords: false, CheckConnLiveness: false},
 }, {
+	"user:password@/dbname?allowNativePasswords=false&checkConnLiveness=false&maxAllowedPacket=0",
+	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Collation: "utf8mb4_general_ci", Loc: time.UTC, MaxAllowedPacket: 0, AllowNativePasswords: false, CheckConnLiveness: false},
+}, {
 	"user:p@ss(word)@tcp([de:ad:be:ef::ca:fe]:80)/dbname?loc=Local",
 	&Config{User: "user", Passwd: "p@ss(word)", Net: "tcp", Addr: "[de:ad:be:ef::ca:fe]:80", DBName: "dbname", Collation: "utf8mb4_general_ci", Loc: time.Local, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true, CheckConnLiveness: true},
 }, {

--- a/errors.go
+++ b/errors.go
@@ -17,18 +17,20 @@ import (
 
 // Various errors the driver might return. Can change between driver versions.
 var (
-	ErrInvalidConn       = errors.New("invalid connection")
-	ErrMalformPkt        = errors.New("malformed packet")
-	ErrNoTLS             = errors.New("TLS requested but server does not support TLS")
-	ErrCleartextPassword = errors.New("this user requires clear text authentication. If you still want to use it, please add 'allowCleartextPasswords=1' to your DSN")
-	ErrNativePassword    = errors.New("this user requires mysql native password authentication.")
-	ErrOldPassword       = errors.New("this user requires old password authentication. If you still want to use it, please add 'allowOldPasswords=1' to your DSN. See also https://github.com/go-sql-driver/mysql/wiki/old_passwords")
-	ErrUnknownPlugin     = errors.New("this authentication plugin is not supported")
-	ErrOldProtocol       = errors.New("MySQL server does not support required protocol 41+")
-	ErrPktSync           = errors.New("commands out of sync. You can't run this command now")
-	ErrPktSyncMul        = errors.New("commands out of sync. Did you run multiple statements at once?")
-	ErrPktTooLarge       = errors.New("packet for query is too large. Try adjusting the 'max_allowed_packet' variable on the server")
-	ErrBusyBuffer        = errors.New("busy buffer")
+	ErrInvalidConn                  = errors.New("invalid connection")
+	ErrMalformPkt                   = errors.New("malformed packet")
+	ErrNoTLS                        = errors.New("TLS requested but server does not support TLS")
+	ErrCleartextPassword            = errors.New("this user requires clear text authentication. If you still want to use it, please add 'allowCleartextPasswords=1' to your DSN")
+	ErrNativePassword               = errors.New("this user requires mysql native password authentication")
+	ErrOldPassword                  = errors.New("this user requires old password authentication. If you still want to use it, please add 'allowOldPasswords=1' to your DSN. See also https://github.com/go-sql-driver/mysql/wiki/old_passwords")
+	ErrUnknownPlugin                = errors.New("this authentication plugin is not supported")
+	ErrOldProtocol                  = errors.New("MySQL server does not support required protocol 41+")
+	ErrPktSync                      = errors.New("commands out of sync. You can't run this command now")
+	ErrPktSyncMul                   = errors.New("commands out of sync. Did you run multiple statements at once?")
+	ErrPktTooLarge                  = errors.New("packet for query is too large. Try adjusting the 'max_allowed_packet' variable on the server")
+	ErrBusyBuffer                   = errors.New("busy buffer")
+	ErrNoOptionalResultMetadataSet  = errors.New("requested optional resultset metadata but server does not support")
+	ErrOptionalResultSetMetadataPkt = errors.New("malformed optional resultset metadata packets")
 
 	// errBadConnNoWrite is used for connection errors where nothing was sent to the database yet.
 	// If this happens first in a function starting a database interaction, it should be replaced by driver.ErrBadConn

--- a/packets.go
+++ b/packets.go
@@ -234,10 +234,18 @@ func (mc *mysqlConn) readHandshakePacket() (data []byte, plugin string, err erro
 	if len(data) > pos {
 		// character set [1 byte]
 		// status flags [2 bytes]
+		pos += 1 + 2
 		// capability flags (upper 2 bytes) [2 bytes]
+		upperFlags := clientFlag(binary.LittleEndian.Uint16(data[pos : pos+2]))
+		mc.flags |= upperFlags << 16
+		pos += 2
+		if mc.flags&clientOptionalResultSetMetadata == 0 && mc.optionalResultSetMetadata {
+			return nil, "", ErrNoOptionalResultMetadataSet
+		}
+
 		// length of auth-plugin-data [1 byte]
 		// reserved (all [00]) [10 bytes]
-		pos += 1 + 2 + 2 + 1 + 10
+		pos += 1 + 10
 
 		// second part of the password cipher [mininum 13 bytes],
 		// where len=MAX(13, length of auth-plugin-data - 8)
@@ -298,6 +306,10 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, plugin string
 
 	if mc.cfg.MultiStatements {
 		clientFlags |= clientMultiStatements
+	}
+
+	if mc.optionalResultSetMetadata {
+		clientFlags |= clientOptionalResultSetMetadata
 	}
 
 	// encode length of the auth plugin data
@@ -551,6 +563,17 @@ func (mc *mysqlConn) readResultSetHeaderPacket() (int, error) {
 		// column count
 		num, _, n := readLengthEncodedInteger(data)
 		if n-len(data) == 0 {
+			return int(num), nil
+		}
+
+		// Sniff one extra byte for resultset metadata if we set capability
+		// CLIENT_OPTIONAL_RESULTSET_METADTA
+		// https://dev.mysql.com/worklog/task/?id=8134
+		if len(data) == 2 && mc.flags&clientOptionalResultSetMetadata != 0 {
+			// ResultSet metadata flag check
+			if mc.resultSetMetadata != data[1] {
+				return 0, ErrOptionalResultSetMetadataPkt
+			}
 			return int(num), nil
 		}
 


### PR DESCRIPTION
Allow optional resultset metadata.
Can potentially improve the performance in many scenario.

Issue #1105

### Note

I believe this flag was introduced in MySQL 8.0+ only.

Some open questions are: 
* Should we introduce this flag/system var?
* If yes, how can we let user know the version they operate on is compatible with this flag or not? I believe we had some existing usage that may break versions, some documentation added will be great.
* I don't really feel like current tests against MySQL matrix on CI w/ different versions are reliable, maybe a better way is catching up environment variable (e.g. DB) to test each version, instead of relying on `maybeSkip`. 

Need your feedback on this, thank you!

### Description
Add support optional resultset metadata.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
