### PR TITLE
Fix a broken link to cleartext client side plugin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -79,6 +79,7 @@ Reed Allman <rdallman10 at gmail.com>
 Richard Wilkes <wilkes at me.com>
 Robert Russell <robert at rrbrussell.com>
 Runrioter Wung <runrioter at gmail.com>
+Sho Iizuka <sho.i518 at gmail.com>
 Sho Ikeda <suicaicoca at gmail.com>
 Shuode Li <elemount at qq.com>
 Simon J Mudd <sjmudd at pobox.com>

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Valid Values:   true, false
 Default:        false
 ```
 
-`allowCleartextPasswords=true` allows using the [cleartext client side plugin](http://dev.mysql.com/doc/en/cleartext-authentication-plugin.html) if required by an account, such as one defined with the [PAM authentication plugin](http://dev.mysql.com/doc/en/pam-authentication-plugin.html). Sending passwords in clear text may be a security problem in some configurations. To avoid problems if there is any possibility that the password would be intercepted, clients should connect to MySQL Server using a method that protects the password. Possibilities include [TLS / SSL](#tls), IPsec, or a private network.
+`allowCleartextPasswords=true` allows using the [cleartext client side plugin](https://dev.mysql.com/doc/en/cleartext-pluggable-authentication.html) if required by an account, such as one defined with the [PAM authentication plugin](http://dev.mysql.com/doc/en/pam-authentication-plugin.html). Sending passwords in clear text may be a security problem in some configurations. To avoid problems if there is any possibility that the password would be intercepted, clients should connect to MySQL Server using a method that protects the password. Possibilities include [TLS / SSL](#tls), IPsec, or a private network.
 
 ##### `allowNativePasswords`
 


### PR DESCRIPTION
### Description
Fix a broken link in README.md.

http://dev.mysql.com/doc/en/cleartext-authentication-plugin.html returns 404.

### Checklist
- [ ] ~~Code compiles correctly~~
- [ ] ~~Created tests which fail without the change (if possible)~~
- [ ] ~~All tests passing~~
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
