### PR TITLE
Fix go vet error

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -127,7 +127,8 @@ func BenchmarkExec(b *testing.B) {
 				}
 
 				if _, err := stmt.Exec(); err != nil {
-					b.Fatal(err.Error())
+					b.Logf("stmt.Exec failed: %v", err)
+					b.Fail()
 				}
 			}
 		}()


### PR DESCRIPTION
### Description

Fix https://travis-ci.com/github/go-sql-driver/mysql/jobs/448595379#L663

```
$ go vet ./...
# github.com/go-sql-driver/mysql
./benchmark_test.go:130:6: call to (*B).Fatal from a non-test goroutine
The command "go vet ./..." exited with 2.
```

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
