### PR TITLE
Fixed parseTime and DATE #881 issue

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -249,7 +249,7 @@ func parseBinaryDateTime(num uint64, data []byte, loc *time.Location) (driver.Va
 			int(data[3]),                              // day
 			0, 0, 0, 0,
 			loc,
-		), nil
+		).Format("2006-01-02"), nil
 	case 7:
 		return time.Date(
 			int(binary.LittleEndian.Uint16(data[:2])), // year


### PR DESCRIPTION
### Description
add format so that when the target is DATE, it won't change into DATETIME

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
