### PR TITLE
add Go 1.16 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,12 @@ jobs:
       - name: list
         id: set-matrix
         run: |
-          from __future__ import print_function
           import json
           go = [
               # Keep the most recent production release at the top
-              '1.15',
+              '1.16',
               # Older production releases
+              '1.15',
               '1.14',
               '1.13',
               '1.12',


### PR DESCRIPTION
### Description

Go 1.16 has been released. https://golang.org/doc/go1.16
I added Go 1.16 into the build matrix.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
