### PR TITLE
README: mysql.NullTime as an alternative to parseTime=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,8 @@ However, many want to scan MySQL `DATE` and `DATETIME` values into `time.Time` v
 
 **Caution:** As of Go 1.1, this makes `time.Time` the only variable type you can scan `DATE` and `DATETIME` values into. This breaks for example [`sql.RawBytes` support](https://github.com/go-sql-driver/mysql/wiki/Examples#rawbytes).
 
+Alternatively, you may use [`mysql.NullTime`](https://pkg.go.dev/github.com/go-sql-driver/mysql#NullTime) to scan the internal `[]byte` value and obtain a `time.Time` from it.
+`mysql.NullTime` also allows you to detect NULL values.
 
 ### Unicode support
 Since version 1.5 Go-MySQL-Driver automatically uses the collation ` utf8mb4_general_ci` by default.


### PR DESCRIPTION
### Description
`parseTime=true` cannot parse `TIMESTAMP` columns and has a subtle limitation.
`mysql.NullTime` is a great alternative to that option, so I think it is worth mentioning.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
