### PR TITLE
Fix benchmark test

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -83,6 +83,7 @@ Sho Iizuka <sho.i518 at gmail.com>
 Sho Ikeda <suicaicoca at gmail.com>
 Shuode Li <elemount at qq.com>
 Simon J Mudd <sjmudd at pobox.com>
+sivchari <shibuuuu5@gmail.com>
 Soroush Pour <me at soroushjp.com>
 Stan Putrya <root.vagner at gmail.com>
 Stanley Gunawan <gunawan.stanley at gmail.com>

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -343,7 +343,7 @@ func BenchmarkQueryRawBytes(b *testing.B) {
 	for _, s := range sizes {
 		b.Run(fmt.Sprintf("size=%v", s), func(b *testing.B) {
 			db.SetMaxIdleConns(0)
-			db.SetMaxIdleConns(1)
+			db.SetMaxOpenConns(1)
 			b.ReportAllocs()
 			b.ResetTimer()
 


### PR DESCRIPTION
### Description
Fixed benchmark_test.go because SetMaxIdleConns was being set twice.
The fix is to call SetMaxIdleConns once and SetMaxOpenConns to set the maximum number of connections to 1.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Added myself / the copyright holder to the AUTHORS file
