### PR TITLE
Automatically reprepare statements on error 1615

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,6 +50,7 @@ Jeffrey Charles <jeffreycharles at gmail.com>
 Jerome Meyer <jxmeyer at gmail.com>
 Jiajia Zhong <zhong2plus at gmail.com>
 Jian Zhen <zhenjl at gmail.com>
+Joseph Boudou <joseph.boudou@matabio.net>
 Joshua Prunier <joshua.prunier at gmail.com>
 Julien Lefevre <julien.lefevr at gmail.com>
 Julien Schmidt <go-sql-driver at julienschmidt.com>

--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ Default:        false
 ```
 `allowOldPasswords=true` allows the usage of the insecure old password method. This should be avoided, but is necessary in some cases. See also [the old_passwords wiki page](https://github.com/go-sql-driver/mysql/wiki/old_passwords).
 
+##### `autoReprepare`
+
+```
+Type:           decimal number
+Default:        0
+```
+When `autoReprepare` is greater than zero, the driver will re-prepare statements when error 1615 is received from the database. Some known bugs of MySQL and MariaDB spuriously invalidate prepared statements, resulting in this error being sent. This parameter is meant to workaround these bugs. More precisely, the value of `autoReprepare` indicates how many successive errors 1615 are handled before the execution of the statement fails; hence, it should not be greater than one.
+
 ##### `charset`
 
 ```

--- a/connection.go
+++ b/connection.go
@@ -175,7 +175,8 @@ func (mc *mysqlConn) Prepare(query string) (driver.Stmt, error) {
 	}
 
 	stmt := &mysqlStmt{
-		mc: mc,
+		mc:       mc,
+		queryStr: query,
 	}
 
 	// Read Result

--- a/connection.go
+++ b/connection.go
@@ -176,7 +176,9 @@ func (mc *mysqlConn) Prepare(query string) (driver.Stmt, error) {
 
 	stmt := &mysqlStmt{
 		mc:       mc,
-		queryStr: query,
+	}
+	if stmt.mc.cfg.AutoReprepare > 0 {
+		stmt.queryStr = query
 	}
 
 	// Read Result

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -45,6 +45,9 @@ var testDSNs = []struct {
 	"user:password@/dbname?allowNativePasswords=false&checkConnLiveness=false&maxAllowedPacket=0",
 	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Collation: "utf8mb4_general_ci", Loc: time.UTC, MaxAllowedPacket: 0, AllowNativePasswords: false, CheckConnLiveness: false},
 }, {
+	"username:password@protocol(address)/dbname?autoReprepare=2",
+	&Config{User: "username", Passwd: "password", Net: "protocol", Addr: "address", DBName: "dbname", Collation: "utf8mb4_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true, AutoReprepare: 2, CheckConnLiveness: true},
+}, {
 	"user:p@ss(word)@tcp([de:ad:be:ef::ca:fe]:80)/dbname?loc=Local",
 	&Config{User: "user", Passwd: "p@ss(word)", Net: "tcp", Addr: "[de:ad:be:ef::ca:fe]:80", DBName: "dbname", Collation: "utf8mb4_general_ci", Loc: time.Local, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true, CheckConnLiveness: true},
 }, {

--- a/statement.go
+++ b/statement.go
@@ -154,8 +154,16 @@ func (stmt *mysqlStmt) query(args []driver.Value) (*binaryRows, error) {
 func (stmt *mysqlStmt) reprepare() error {
 	errLog.Print("Re-Prepare statement")
 
-	// Send command
-	err := stmt.mc.writeCommandPacketStr(comStmtPrepare, stmt.queryStr)
+	// Close
+	err := stmt.mc.writeCommandPacketUint32(comStmtClose, stmt.id)
+	if err != nil {
+		return err
+	}
+	stmt.id = 0
+	stmt.paramCount = 0
+
+	// Send prepare
+	err = stmt.mc.writeCommandPacketStr(comStmtPrepare, stmt.queryStr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description
This pull request proposes a workaround for a bug in both MySQL and [MariaDB](https://jira.mariadb.org/browse/MDEV-17124). This bug spuriously invalidates prepared statements, forcing the client to reprepare them. The implemented workaround just do that: it automatically reprepares statements when error 1615 is raised. The workaround is optional and controlled by a new DSN parameter named autoReprepare.

Due to the lack of a comprehensive connection mock, I've been unable to implement proper tests for the new code. Discussion on that issue would be welcome.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
