### PR TITLE
noCopy implements sync.Locker

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -790,6 +790,12 @@ type noCopy struct{}
 // Lock is a no-op used by -copylocks checker from `go vet`.
 func (*noCopy) Lock() {}
 
+// Unlock is a no-op used by -copylocks checker from `go vet`.
+// noCopy should implement sync.Locker from Go 1.11
+// https://github.com/golang/go/commit/c2eba53e7f80df21d51285879d51ab81bcfbf6bc
+// https://github.com/golang/go/issues/26165
+func (*noCopy) Unlock() {}
+
 // atomicBool is a wrapper around uint32 for usage as a boolean value with
 // atomic access.
 type atomicBool struct {

--- a/utils_test.go
+++ b/utils_test.go
@@ -228,7 +228,9 @@ func TestAtomicBool(t *testing.T) {
 		t.Fatal("Expected value to be false")
 	}
 
-	ab._noCopy.Lock() // we've "tested" it ¯\_(ツ)_/¯
+	// we've "tested" them ¯\_(ツ)_/¯
+	ab._noCopy.Lock()
+	defer ab._noCopy.Unlock()
 }
 
 func TestAtomicError(t *testing.T) {


### PR DESCRIPTION
### Description

noCopy is used by `-copylocks` checker from `go vet`.
see https://github.com/golang/go/issues/8005#issuecomment-190753527 for details.
but it doesn't work from Go 1.11, because of https://github.com/golang/go/commit/c2eba53e7f80df21d51285879d51ab81bcfbf6bc and https://github.com/golang/go/issues/26165
`-copylock` now works with structs that implement sync.Locker.
So, noCopy should implement sync.Locker.

related tweets (written in Japanese):
- https://twitter.com/shibu_jp/status/1397004843047288834?s=20
- https://twitter.com/orisano/status/1397022250381938689?s=20

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
