### PR TITLE
Improve readability follows `go-staticcheck`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -101,6 +101,7 @@ Xiuming Chen <cc at cxm.cc>
 Xuehong Chan <chanxuehong at gmail.com>
 Zhenye Xie <xiezhenye at gmail.com>
 Zhixin Wen <john.wenzhixin at gmail.com>
+Ziheng Lyu <zihenglv at gmail.com>
 
 # Organizations
 

--- a/dsn.go
+++ b/dsn.go
@@ -426,7 +426,6 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 		// Collation
 		case "collation":
 			cfg.Collation = value
-			break
 
 		case "columnsWithAlias":
 			var isBool bool

--- a/statement_test.go
+++ b/statement_test.go
@@ -36,7 +36,7 @@ func TestConvertDerivedByteSlice(t *testing.T) {
 		t.Fatal("Byte slice not convertible", err)
 	}
 
-	if bytes.Compare(output.([]byte), []byte("value")) != 0 {
+	if !bytes.Equal(output.([]byte), []byte("value")) {
 		t.Fatalf("Byte slice not converted, got %#v %T", output, output)
 	}
 }

--- a/utils.go
+++ b/utils.go
@@ -199,7 +199,7 @@ func parseByteYear(b []byte) (int, error) {
 			return 0, err
 		}
 		year += v * n
-		n = n / 10
+		n /= 10
 	}
 	return year, nil
 }


### PR DESCRIPTION
### Description

Improve readability follows `go-staticcheck`:

- Use division assignment operator in function `parseByteYear`.
- Remove necessary `break` in `dsn.go`.
- Use clear `bytes.Equal` API.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
