### PR TITLE
use utf8mb4 instead of utf8 in TestCharset

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -1450,11 +1450,11 @@ func TestCharset(t *testing.T) {
 	mustSetCharset("charset=ascii", "ascii")
 
 	// when the first charset is invalid, use the second
-	mustSetCharset("charset=none,utf8", "utf8")
+	mustSetCharset("charset=none,utf8mb4", "utf8mb4")
 
 	// when the first charset is valid, use it
-	mustSetCharset("charset=ascii,utf8", "ascii")
-	mustSetCharset("charset=utf8,ascii", "utf8")
+	mustSetCharset("charset=ascii,utf8mb4", "ascii")
+	mustSetCharset("charset=utf8mb4,ascii", "utf8mb4")
 }
 
 func TestFailingCharset(t *testing.T) {


### PR DESCRIPTION
### Description

This fixes a broken test of TestCharset.

https://github.com/go-sql-driver/mysql/runs/2947684909?check_suite_focus=true#step:6:161

```
=== RUN   TestCharset
    driver_test.go:1444: expected connection charset utf8 but got utf8mb3
--- FAIL: TestCharset (0.01s)
```

From MySQL 8.0.24, `SELECT @@character_set_connection` reports utf8mb3 or utf8mb4 instead of utf8.
Because utf8 is currently an alias for utf8mb3, however at some point utf8 is expected to become a reference to utf8mb4.

> ref. https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-24.html#mysqld-8-0-24-bug
> Important Note: When a utf8mb3 collation was specified in a CREATE TABLE statement, SHOW CREATE TABLE, DEFAULT CHARSET,
> the values of system variables containing character set names,
> and the binary log all subsequently displayed the character set as utf8 which is becoming a synonym for utf8mb4.
> Now in such cases, utf8mb3 is shown instead, and CREATE TABLE raises the warning 'collation_name' is a collation of the deprecated character set UTF8MB3.
> Please consider using UTF8MB4 with an appropriate collation instead. (Bug #27225287, Bug #32085357, Bug #32122844)
>
> References: See also: Bug #30624990.

The document says that we should use utf8mb4 instead of utf8, so we should follow it.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
