### PR TITLE
Fix test for MySQL 8.0

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -1450,11 +1450,11 @@ func TestCharset(t *testing.T) {
 	mustSetCharset("charset=ascii", "ascii")
 
 	// when the first charset is invalid, use the second
-	mustSetCharset("charset=none,utf8", "utf8")
+	mustSetCharset("charset=none,utf8mb4", "utf8mb4")
 
 	// when the first charset is valid, use it
 	mustSetCharset("charset=ascii,utf8", "ascii")
-	mustSetCharset("charset=utf8,ascii", "utf8")
+	mustSetCharset("charset=utf8mb4,ascii", "utf8mb4")
 }
 
 func TestFailingCharset(t *testing.T) {


### PR DESCRIPTION
"utf8" is now alias of "utf8mb3" in MySQL 8.0.

### Description

TestCharset is failing because MySQL 8.0 returns "utf8mb3" instead of "utf8".
This pull request uses "utf8mb4" in tests, instead of "utf8".

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
