### PR TITLE
Map `time.Duration` param into MySQL `TIME` type

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -252,6 +252,13 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 				}
 				buf = append(buf, '\'')
 			}
+		case time.Duration:
+			buf = append(buf, '\'')
+			buf, err = appendTime(buf, v)
+			if err != nil {
+				return "", err
+			}
+			buf = append(buf, '\'')
 		case json.RawMessage:
 			buf = append(buf, '\'')
 			if mc.status&statusNoBackslashEscapes == 0 {


### PR DESCRIPTION
### Description

Map `time.Duration` param into MySQL `TIME` type (fits the **time interval** definition).

> https://dev.mysql.com/doc/refman/8.0/en/time.html

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
