### PR TITLE
Go 1.17 and MariaDB 10.6 are released

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,9 @@ jobs:
           import json
           go = [
               # Keep the most recent production release at the top
-              '1.16',
+              '1.17',
               # Older production releases
+              '1.16',
               '1.15',
               '1.14',
               '1.13',
@@ -32,6 +33,7 @@ jobs:
               '8.0',
               '5.7',
               '5.6',
+              'mariadb-10.6',
               'mariadb-10.5',
               'mariadb-10.4',
               'mariadb-10.3',

--- a/driver_test.go
+++ b/driver_test.go
@@ -1479,7 +1479,7 @@ func TestCollation(t *testing.T) {
 		defaultCollation, // driver default
 		"latin1_general_ci",
 		"binary",
-		"utf8_unicode_ci",
+		"utf8mb4_unicode_ci",
 		"cp1257_bin",
 	}
 


### PR DESCRIPTION
### Description
add Go 1.17 and MariaDB 10.6 into the build matrix

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
