### PR TITLE
driver: Add Open/OpenWithContext

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -70,6 +70,7 @@ Lucas Liu <extrafliu at gmail.com>
 Lunny Xiao <xiaolunwen at gmail.com>
 Luke Scott <luke at webconnex.com>
 Maciej Zimnoch <maciej.zimnoch at codilime.com>
+Matt Robenolt <matt at ydekproductions.com>
 Michael Woolnough <michael.woolnough at gmail.com>
 Nathanial Murphy <nathanial.murphy at gmail.com>
 Nicola Peduzzi <thenikso at gmail.com>

--- a/driver.go
+++ b/driver.go
@@ -74,10 +74,7 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	c := &connector{
-		cfg: cfg,
-	}
-	return c.Connect(context.Background())
+	return Open(cfg)
 }
 
 func init() {
@@ -104,4 +101,17 @@ func (d MySQLDriver) OpenConnector(dsn string) (driver.Connector, error) {
 	return &connector{
 		cfg: cfg,
 	}, nil
+}
+
+// Open new Connection directly with the driver using a Config.
+func Open(cfg *Config) (driver.Conn, error) {
+	return OpenWithContext(context.Background(), cfg)
+}
+
+// OpenWithContext opens a new Connection directly with the driver using a Config.
+func OpenWithContext(ctx context.Context, cfg *Config) (driver.Conn, error) {
+	c := &connector{
+		cfg: cfg,
+	}
+	return c.Connect(ctx)
 }


### PR DESCRIPTION
This adds the ability to directly do `mysql.Open(..)` instead of
relying on the generic `sql.Open("mysql", ...)` API. The benefit of using this
path is being able to pass a `mysql.Config{}` directly instead of a DSN.
This also skips the steps of doing `cfg.ParseDSN()` then the driver
doing `ParseDSN` on the string, just to satisfy the `sql.Open` API. If
we're in a context where we're using mysql explicitly, we can directly
use `mysql.Open` instead.

I'm open to any and all feedback here. I wasn't sure if we wanted `mysql.Open(...)` to take a DSN to mirror the sql.Open API, then have an additional `mysql.OpenConfig(...)` or something to explicitly call by passing a Config object, but this didn't personally feel necessary since if I'm going to pass a string DSN, I might as well just go through sql.Open instead. But as an example, this is what `lib/pq` does: https://pkg.go.dev/github.com/lib/pq#Open Granted, we don't need to mirror what they've done, it's just a precedent. They also don't have a way to work with a structured connection string either, so they don't have that feature at all.