### PR TITLE
Convert VARCHAR, VARBINARY type to string

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -73,6 +73,7 @@ Maciej Zimnoch <maciej.zimnoch at codilime.com>
 Michael Woolnough <michael.woolnough at gmail.com>
 Nathanial Murphy <nathanial.murphy at gmail.com>
 Nicola Peduzzi <thenikso at gmail.com>
+Nitin Gurram <nigurr at github.com>
 Olivier Mengué <dolmen at cpan.org>
 oscarzhao <oscarzhaosl at gmail.com>
 Paul Bonser <misterpib at gmail.com>

--- a/fields.go
+++ b/fields.go
@@ -93,9 +93,6 @@ func (mf *mysqlField) typeDatabaseName() string {
 		}
 		return "TINYBLOB"
 	case fieldTypeVarChar:
-		if mf.charSet == collations[binaryCollation] {
-			return "VARBINARY"
-		}
 		return "VARCHAR"
 	case fieldTypeVarString:
 		if mf.charSet == collations[binaryCollation] {
@@ -110,21 +107,23 @@ func (mf *mysqlField) typeDatabaseName() string {
 }
 
 var (
-	scanTypeFloat32   = reflect.TypeOf(float32(0))
-	scanTypeFloat64   = reflect.TypeOf(float64(0))
-	scanTypeInt8      = reflect.TypeOf(int8(0))
-	scanTypeInt16     = reflect.TypeOf(int16(0))
-	scanTypeInt32     = reflect.TypeOf(int32(0))
-	scanTypeInt64     = reflect.TypeOf(int64(0))
-	scanTypeNullFloat = reflect.TypeOf(sql.NullFloat64{})
-	scanTypeNullInt   = reflect.TypeOf(sql.NullInt64{})
-	scanTypeNullTime  = reflect.TypeOf(sql.NullTime{})
-	scanTypeUint8     = reflect.TypeOf(uint8(0))
-	scanTypeUint16    = reflect.TypeOf(uint16(0))
-	scanTypeUint32    = reflect.TypeOf(uint32(0))
-	scanTypeUint64    = reflect.TypeOf(uint64(0))
-	scanTypeRawBytes  = reflect.TypeOf(sql.RawBytes{})
-	scanTypeUnknown   = reflect.TypeOf(new(interface{}))
+	scanTypeFloat32    = reflect.TypeOf(float32(0))
+	scanTypeFloat64    = reflect.TypeOf(float64(0))
+	scanTypeInt8       = reflect.TypeOf(int8(0))
+	scanTypeInt16      = reflect.TypeOf(int16(0))
+	scanTypeInt32      = reflect.TypeOf(int32(0))
+	scanTypeInt64      = reflect.TypeOf(int64(0))
+	scanTypeNullFloat  = reflect.TypeOf(sql.NullFloat64{})
+	scanTypeNullInt    = reflect.TypeOf(sql.NullInt64{})
+	scanTypeNullTime   = reflect.TypeOf(sql.NullTime{})
+	scanTypeUint8      = reflect.TypeOf(uint8(0))
+	scanTypeUint16     = reflect.TypeOf(uint16(0))
+	scanTypeUint32     = reflect.TypeOf(uint32(0))
+	scanTypeUint64     = reflect.TypeOf(uint64(0))
+	scanTypeString     = reflect.TypeOf(string(""))
+	scanTypeNullString = reflect.TypeOf(sql.NullString{})
+	scanTypeRawBytes   = reflect.TypeOf(sql.RawBytes{})
+	scanTypeUnknown    = reflect.TypeOf(new(interface{}))
 )
 
 type mysqlField struct {
@@ -187,10 +186,24 @@ func (mf *mysqlField) scanType() reflect.Type {
 		}
 		return scanTypeNullFloat
 
-	case fieldTypeDecimal, fieldTypeNewDecimal, fieldTypeVarChar,
+	case fieldTypeVarChar:
+		if mf.flags&flagNotNULL != 0 {
+			return scanTypeString
+		}
+		return scanTypeNullString
+	case fieldTypeVarString:
+		if mf.charSet == collations[binaryCollation] {
+			return scanTypeRawBytes
+		}
+		if mf.flags&flagNotNULL != 0 {
+			return scanTypeString
+		}
+		return scanTypeNullString
+
+	case fieldTypeDecimal, fieldTypeNewDecimal,
 		fieldTypeBit, fieldTypeEnum, fieldTypeSet, fieldTypeTinyBLOB,
 		fieldTypeMediumBLOB, fieldTypeLongBLOB, fieldTypeBLOB,
-		fieldTypeVarString, fieldTypeString, fieldTypeGeometry, fieldTypeJSON,
+		fieldTypeString, fieldTypeGeometry, fieldTypeJSON,
 		fieldTypeTime:
 		return scanTypeRawBytes
 

--- a/packets.go
+++ b/packets.go
@@ -1265,10 +1265,27 @@ func (rows *binaryRows) readRow(dest []driver.Value) error {
 			continue
 
 		// Length coded Binary Strings
-		case fieldTypeDecimal, fieldTypeNewDecimal, fieldTypeVarChar,
+		case fieldTypeVarChar, fieldTypeVarString:
+			var isNull bool
+			var n int
+			s, isNull, n, err := readLengthEncodedString(data[pos:])
+			pos += n
+			if err == nil {
+				if !isNull {
+					dest[i] = string(s)
+					continue
+				} else {
+					dest[i] = nil
+					continue
+				}
+			}
+			return err
+
+		// Length coded Binary Strings
+		case fieldTypeDecimal, fieldTypeNewDecimal,
 			fieldTypeBit, fieldTypeEnum, fieldTypeSet, fieldTypeTinyBLOB,
 			fieldTypeMediumBLOB, fieldTypeLongBLOB, fieldTypeBLOB,
-			fieldTypeVarString, fieldTypeString, fieldTypeGeometry, fieldTypeJSON:
+			fieldTypeString, fieldTypeGeometry, fieldTypeJSON:
 			var isNull bool
 			var n int
 			dest[i], isNull, n, err = readLengthEncodedString(data[pos:])


### PR DESCRIPTION
### Description
Currently driver returns `VARCHAR` columns as `[]byte`. 
When using `MapScan`, the specific column contains only byte information where it can be represented as `string` (similar issue https://github.com/golang/go/issues/22544)

```go
r := make(map[string]interface{})
    rows.MapScan(r)
```

For example: MySQL Java driver maps this properly to `string`
https://github.com/mysql/mysql-connector-j/blob/4f7120a617b9d5efb9dedda9064b9896db424a60/src/main/core-api/java/com/mysql/cj/MysqlType.java#L277-L280

Similarly other `sql vendor` go clients map `VARCHAR` type to `string`.

This PR fix the mapping of `VARCHAR` to `string`.


### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
