### PR TITLE
Fixed SetReadDeadline before connCheck

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -110,14 +110,13 @@ func (mc *mysqlConn) writePacket(data []byte) error {
 			conn = mc.rawConn
 		}
 		var err error
-		// If this connection has a ReadTimeout which we've been setting on
-		// reads, reset it to its default value before we attempt a non-blocking
-		// read, otherwise the scheduler will just time us out before we can read
-		if mc.cfg.ReadTimeout != 0 {
-			err = conn.SetReadDeadline(time.Time{})
-		}
-		if err == nil && mc.cfg.CheckConnLiveness {
-			err = connCheck(conn)
+		if mc.cfg.CheckConnLiveness {
+			if mc.cfg.ReadTimeout != 0 {
+				err = conn.SetReadDeadline(time.Now().Add(mc.cfg.ReadTimeout))
+			}
+			if err == nil {
+				err = connCheck(conn)
+			}
 		}
 		if err != nil {
 			errLog.Print("closing bad idle connection: ", err)


### PR DESCRIPTION
there's no need to set conn's readline if CheckConnLiveness is false,
and the ReadTimeout shall works with rawConn.Read inside conncheck.

### Description
don't do SetReadDeadline CheckConnLiveness is false,
and use readtimeout deadline for conncheck.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
