### PR TITLE
Use the last `?` as the database name terminator

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -348,7 +348,12 @@ func ParseDSN(dsn string) (cfg *Config, err error) {
 					break
 				}
 			}
-			cfg.DBName = dsn[i+1 : j]
+
+			if j > i {
+				cfg.DBName = dsn[i+1 : j]
+			} else {
+				cfg.DBName = dsn[i+1:]
+			}
 
 			break
 		}

--- a/dsn.go
+++ b/dsn.go
@@ -339,8 +339,8 @@ func ParseDSN(dsn string) (cfg *Config, err error) {
 			}
 
 			// dbname[?param1=value1&...&paramN=valueN]
-			// Find the first '?' in dsn[i+1:]
-			for j = i + 1; j < len(dsn); j++ {
+			// Find the last '?' in dsn[i+1:]
+			for j = len(dsn) - 1; j > i; j-- {
 				if dsn[j] == '?' {
 					if err = parseDSNParams(cfg, dsn[j+1:]); err != nil {
 						return


### PR DESCRIPTION
### Description

There is a security issue in DSN parsing. In the current implementation, we look for the first "?" in the DSN string as the terminator of the database name and the start of the DSN parameter list. This behavior makes it possible to inject malicious parameters in the database name to trigger a DSN injection attack. The following code shows an example:

```
package main

import (
        "fmt"

        "github.com/go-sql-driver/mysql"
)

func NewCfg(username string, password string, host string, port int, db string) *mysql.Config {
        cfg := mysql.NewConfig()
        cfg.Net = "mysql"
        cfg.User = username
        cfg.Passwd = password
        cfg.Addr = fmt.Sprintf("%s:%d", host, port)
        cfg.DBName = db
        cfg.MultiStatements = true

        return cfg
}

func main() {
        dsn := NewCfg("root", "123456", "127.0.0.1", 3306, "test?allowAllFiles=true&").FormatDSN()
        fmt.Printf("DSN: %s\n", dsn)

        cfg, err := mysql.ParseDSN(dsn)
        if err != nil {
                panic(err.Error())
        }
        fmt.Printf("AllowAllFiles: %+v\n", cfg.AllowAllFiles)
}
```

One possible scenario for such an attack is to attack the data migration service on the cloud. An attacker can control the data migration service to access the malicious MySQL server, and inject the parameters (allowAllFiles=true) into the database name field to obtain file read permission, and finally read the files in the file system where the cloud service is located.

The way to fix this vulnerability is very simple, as long as the last "?" is used as the terminator of the database name field, we can prevent the attack of injecting malicious parameters in the database name field.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
