### PR TITLE
Allow to preserve the location for time.Time values

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -83,6 +83,7 @@ Richard Wilkes <wilkes at me.com>
 Robert Russell <robert at rrbrussell.com>
 Runrioter Wung <runrioter at gmail.com>
 Santhosh Kumar Tekuri <santhosh.tekuri at gmail.com>
+Santiago Corredoira <scorredoira at gmail.com>
 Sho Iizuka <sho.i518 at gmail.com>
 Sho Ikeda <suicaicoca at gmail.com>
 Shuode Li <elemount at qq.com>

--- a/README.md
+++ b/README.md
@@ -268,6 +268,18 @@ Note that this sets the location for time.Time values but does not change MySQL'
 
 Please keep in mind, that param values must be [url.QueryEscape](https://golang.org/pkg/net/url/#QueryEscape)'ed. Alternatively you can manually replace the `/` with `%2F`. For example `US/Pacific` would be `loc=US%2FPacific`.
 
+##### `localTime`
+
+```
+Type:           bool
+Valid Values:   true, false
+Default:        false
+```
+Don't alter the location for time.Time values.
+
+Note that this ignores the `loc` setting.
+
+
 ##### `maxAllowedPacket`
 ```
 Type:          decimal number

--- a/connection.go
+++ b/connection.go
@@ -246,7 +246,11 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 				buf = append(buf, "'0000-00-00'"...)
 			} else {
 				buf = append(buf, '\'')
-				buf, err = appendDateTime(buf, v.In(mc.cfg.Loc))
+				if mc.cfg.LocalTime {
+					buf, err = appendDateTime(buf, v)
+				} else {
+					buf, err = appendDateTime(buf, v.In(mc.cfg.Loc))
+				}
 				if err != nil {
 					return "", err
 				}

--- a/dsn.go
+++ b/dsn.go
@@ -42,6 +42,7 @@ type Config struct {
 	Params           map[string]string // Connection parameters
 	Collation        string            // Connection collation
 	Loc              *time.Location    // Location for time.Time values
+	LocalTime        bool              // Don't alter the location for time.Time values
 	MaxAllowedPacket int               // Max packet size allowed
 	ServerPubKey     string            // Server public key name
 	pubKey           *rsa.PublicKey    // Server public key
@@ -454,6 +455,14 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			cfg.Loc, err = time.LoadLocation(value)
 			if err != nil {
 				return
+			}
+
+		// LocalTime
+		case "localTime":
+			var isBool bool
+			cfg.LocalTime, isBool = readBool(value)
+			if !isBool {
+				return errors.New("invalid bool value: " + value)
 			}
 
 		// multiple statements in one query

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -403,6 +403,17 @@ func TestNormalizeTLSConfig(t *testing.T) {
 	}
 }
 
+func TestDNSLocalTime(t *testing.T) {
+	dsn := "User:password@tcp(localhost:5555)/dbname?localTime=true"
+	cfg, err := ParseDSN(dsn)
+
+	if err != nil {
+		t.Error(err.Error())
+	} else if !cfg.LocalTime {
+		t.Errorf("expected localTime enabled")
+	}
+}
+
 func BenchmarkParseDSN(b *testing.B) {
 	b.ReportAllocs()
 

--- a/packets.go
+++ b/packets.go
@@ -1115,7 +1115,11 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 				if v.IsZero() {
 					b = append(b, "0000-00-00"...)
 				} else {
-					b, err = appendDateTime(b, v.In(mc.cfg.Loc))
+					if mc.cfg.LocalTime {
+						b, err = appendDateTime(b, v)
+					} else {
+						b, err = appendDateTime(b, v.In(mc.cfg.Loc))
+					}
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
Use the DNS setting localTime=true:

 "User:password@tcp(localhost:5555)/dbname?localTime=true"

### Description
Allows to insert datetime values without altering their timezone.

Currently this is only possible by setting the location for the connecton using the `loc` setting. 
If you need to handle the logic by the application this setting allows you to do it. An example of why this may be need is a multi-tenant application where each tenant has its own timezone and dates are always local to the tenant.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
