### PR TITLE
fix go get to go install at README

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -80,6 +80,7 @@ Peter Schultz <peter.schultz at classmarkets.com>
 Rebecca Chin <rchin at pivotal.io>
 Reed Allman <rdallman10 at gmail.com>
 Richard Wilkes <wilkes at me.com>
+Riku Shinohara <rinjyou0031 at toki.waseda.jp>
 Robert Russell <robert at rrbrussell.com>
 Runrioter Wung <runrioter at gmail.com>
 Santhosh Kumar Tekuri <santhosh.tekuri at gmail.com>

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A MySQL-Driver for Go's [database/sql](https://golang.org/pkg/database/sql/) pac
 ## Installation
 Simple install the package to your [$GOPATH](https://github.com/golang/go/wiki/GOPATH "GOPATH") with the [go tool](https://golang.org/cmd/go/ "go command") from shell:
 ```bash
-$ go get -u github.com/go-sql-driver/mysql
+$ go install github.com/go-sql-driver/mysql
 ```
 Make sure [Git is installed](https://git-scm.com/downloads) on your machine and in your system's `PATH`.
 


### PR DESCRIPTION
### Description
issue #1314 
go get will be removed from go1.18.  And not recommended from go1.17. As a result I fixed README.md installation.

`$ go install github.com/go-sql-driver/mysql `

And I check this command works well.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
