### PR TITLE
Ignore user exception when RejectReadOnly

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -110,6 +110,7 @@ Ziheng Lyu <zihenglv at gmail.com>
 Barracuda Networks, Inc.
 Counting Ltd.
 DigitalOcean Inc.
+dyves labs AG
 Facebook Inc.
 GitHub Inc.
 Google Inc.


### PR DESCRIPTION
SQLSTATE '45000' is for user-defined exceptions.
Their errno can collide with system exceptions however.
Don't close the connection on user exceptions.

### Description
The connection would wrongly be closed when the config option RejectReadOnly is true and the following stored procedure is called:
```sql
DELIMITER $$

CREATE PROCEDURE `CloseConnection`()
BEGIN
    SIGNAL SQLSTATE '45000' 
        SET MYSQL_ERRNO = 1792, MESSAGE_TEXT ='no connection for you';
END$$

DELIMITER ;
```

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
