### PR TITLE
fix zero time arg string

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -243,7 +243,7 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 			}
 		case time.Time:
 			if v.IsZero() {
-				buf = append(buf, "'0000-00-00'"...)
+				buf = append(buf, "'0000-00-00 00:00:00'"...)
 			} else {
 				buf = append(buf, '\'')
 				buf, err = appendDateTime(buf, v.In(mc.cfg.Loc))

--- a/packets.go
+++ b/packets.go
@@ -1114,7 +1114,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 				var b = a[:0]
 
 				if v.IsZero() {
-					b = append(b, "0000-00-00"...)
+					b = append(b, "0000-00-00 00:00:00"...)
 				} else {
 					b, err = appendDateTime(b, v.In(mc.cfg.Loc))
 					if err != nil {


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

### Description
Please explain the changes you made here.

```go
	rows, err := db.Query( "SELECT cast(? as TIME)", time.Time{})
```

the related SQL is:

before this PR:

```sql
SELECT cast("0000-00-00" as TIME)
```

this PR:

```sql
SELECT cast("0000-00-00 00:00:00" as TIME)
```

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
