### PR TITLE
fix(connection): panic in startWatcher

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -13,6 +13,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"strconv"
@@ -619,7 +620,11 @@ func (mc *mysqlConn) startWatcher() {
 
 			select {
 			case <-ctx.Done():
-				mc.cancel(ctx.Err())
+				err := ctx.Err()
+				if err == nil {
+					err = errors.New("unexpected error")
+				}
+				mc.cancel(err)
 			case <-finished:
 			case <-mc.closech:
 				return


### PR DESCRIPTION
### Description
I found a panic in my apps:
```
panic: sync/atomic: store of nil value into Value
	/usr/local/go/src/sync/atomic/value.go:47 +0x12c
	/go/pkg/mod/github.com/go-sql-driver/mysql@v1.6.0/utils.go:831
	/go/pkg/mod/github.com/go-sql-driver/mysql@v1.6.0/connection.go:435 +0x51
	/go/pkg/mod/github.com/go-sql-driver/mysql@v1.6.0/connection.go:622 +0x19a
        /go/pkg/mod/github.com/go-sql-driver/mysql@v1.6.0/connection.go:611 +0xbe
```

But according the [document](https://pkg.go.dev/context), `ctx.Err()` should not be `nil`, after `ctx.Done()` is emitted:
```
// If Done is not yet closed, Err returns nil.
// If Done is closed, Err returns a non-nil error explaining why:
// Canceled if the context was canceled
// or DeadlineExceeded if the context's deadline passed.
// After Err returns a non-nil error, successive calls to Err return the same error.
Err() [error](https://pkg.go.dev/builtin#error)
```
I CAN NOT UNDERSTAND WHY.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
