### PR TITLE
Distinguish net read timeout from other errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -29,6 +29,7 @@ var (
 	ErrPktSyncMul        = errors.New("commands out of sync. Did you run multiple statements at once?")
 	ErrPktTooLarge       = errors.New("packet for query is too large. Try adjusting the 'max_allowed_packet' variable on the server")
 	ErrBusyBuffer        = errors.New("busy buffer")
+	ErrNetReadTimeout    = errors.New("net read timeout")
 
 	// errBadConnNoWrite is used for connection errors where nothing was sent to the database yet.
 	// If this happens first in a function starting a database interaction, it should be replaced by driver.ErrBadConn

--- a/packets.go
+++ b/packets.go
@@ -728,12 +728,12 @@ func (mc *mysqlConn) readColumns(count int) ([]mysqlField, error) {
 
 		// Decimals [uint8]
 		columns[i].decimals = data[pos]
-		// pos++
+		//pos++
 
 		// Default value [len coded binary]
-		// if pos < len(data) {
+		//if pos < len(data) {
 		//	defaultVal, _, err = bytesToLengthCodedBinary(data[pos:])
-		// }
+		//}
 	}
 }
 

--- a/packets.go
+++ b/packets.go
@@ -36,6 +36,9 @@ func (mc *mysqlConn) readPacket() ([]byte, error) {
 			}
 			errLog.Print(err)
 			mc.Close()
+			if isNetTimeoutErr(err) {
+				return nil, ErrNetReadTimeout
+			}
 			return nil, ErrInvalidConn
 		}
 
@@ -72,6 +75,9 @@ func (mc *mysqlConn) readPacket() ([]byte, error) {
 			}
 			errLog.Print(err)
 			mc.Close()
+			if isNetTimeoutErr(err) {
+				return nil, ErrNetReadTimeout
+			}
 			return nil, ErrInvalidConn
 		}
 
@@ -722,12 +728,12 @@ func (mc *mysqlConn) readColumns(count int) ([]mysqlField, error) {
 
 		// Decimals [uint8]
 		columns[i].decimals = data[pos]
-		//pos++
+		// pos++
 
 		// Default value [len coded binary]
-		//if pos < len(data) {
+		// if pos < len(data) {
 		//	defaultVal, _, err = bytesToLengthCodedBinary(data[pos:])
-		//}
+		// }
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"strconv"
 	"strings"
 	"sync"
@@ -871,4 +872,11 @@ func mapIsolationLevel(level driver.IsolationLevel) (string, error) {
 	default:
 		return "", fmt.Errorf("mysql: unsupported isolation level: %v", level)
 	}
+}
+
+func isNetTimeoutErr(err error) bool {
+	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
### Description
In a production environment, it is sometimes necessary to distinguish between network timeouts and other network errors, and handle timeouts, such as reconnection at the business level.

I've added the ErrNetReadTimeout variable. Now it returns ErrNetReadTimeout   instead of ErrInvalidConn if `mc.buf.readNext` returns a timeout error  in the `mysqlConn.readPacket` method.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
