### PR TITLE
fix: benchmarkExecContext is unused

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -314,7 +314,7 @@ func BenchmarkExecContext(b *testing.B) {
 	defer db.Close()
 	for _, p := range []int{1, 2, 3, 4} {
 		b.Run(fmt.Sprintf("%d", p), func(b *testing.B) {
-			benchmarkQueryContext(b, db, p)
+			benchmarkExecContext(b, db, p)
 		})
 	}
 }


### PR DESCRIPTION
### Description

I found that `benchmarkExecContext` is unused.
`BenchmarkExecContext` should call it instead of `benchmarkQueryContext`.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
