### PR TITLE
fix: parse datetime with zero year

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,6 +26,7 @@ Carlos Nieto <jose.carlos at menteslibres.net>
 Chris Kirkland <chriskirkland at github.com>
 Chris Moos <chris at tech9computers.com>
 Craig Wilson <craiggwilson at gmail.com>
+Daniel Milde <daniel at milde.cz>
 Daniel Montoya <dsmontoyam at gmail.com>
 Daniel Nichter <nil at codenode.com>
 Daniël van Eeden <git at myname.nl>

--- a/utils.go
+++ b/utils.go
@@ -117,7 +117,7 @@ func parseDateTime(b []byte, loc *time.Location) (time.Time, error) {
 		if err != nil {
 			return time.Time{}, err
 		}
-		if year <= 0 {
+		if year < 0 {
 			year = 1
 		}
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -351,6 +351,10 @@ func TestParseDateTime(t *testing.T) {
 			name: "parse datetime nanosec 6-digits",
 			str:  "2020-05-25 23:22:01.159491",
 		},
+		{
+			name: "parse datetime with zero year",
+			str:  "0000-05-25 23:22:01",
+		},
 	}
 
 	for _, loc := range []*time.Location{


### PR DESCRIPTION
### Description
MySQL supports datetimes with zero year (e.g. `0000-01-01 00:00:00`). Other libraries parse it and return it correctly, we should too.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
