### PR TITLE
migrate set-output to the environment file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
           }
           output = json.dumps(matrix, separators=(',', ':'))
           with open(os.environ["GITHUB_OUTPUT"], 'a', encoding="utf-8") as f:
-              f.write('matrix={0}'.format(output))
+              f.write('matrix={0}\n'.format(output))
         shell: python
   test:
     needs: list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         id: set-matrix
         run: |
           import json
+          import os
           go = [
               # Keep the most recent production release at the top
               '1.19',
@@ -55,7 +56,8 @@ jobs:
               'include': includes
           }
           output = json.dumps(matrix, separators=(',', ':'))
-          print('::set-output name=matrix::{0}'.format(output))
+          with open(os.environ["GITHUB_OUTPUT"], 'a', encoding="utf-8") as f:
+              f.write('matrix={0}'.format(output))
         shell: python
   test:
     needs: list


### PR DESCRIPTION
### Description

see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
GitHub Actions: Deprecating save-state and set-output commands

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
