### PR TITLE
Add API to express like a `--ssl-mode=PREFERRED` MySQL client

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,6 +61,7 @@ Kamil Dziedzic <kamil at klecza.pl>
 Kei Kamikawa <x00.x7f.x86 at gmail.com>
 Kevin Malachowski <kevin at chowski.com>
 Kieron Woodhouse <kieron.woodhouse at infosum.com>
+Lance Tian <lance6716 at gmail.com>
 Lennart Rudolph <lrudolph at hmc.edu>
 Leonardo YongUk Kim <dalinaum at gmail.com>
 Linh Tran Tuan <linhduonggnu at gmail.com>

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Valid Values:   true, false
 Default:        false
 ```
 
-`allowFallbackToNoTLS=true` acts like a `--ssl-mode=mode=PREFERRED` MySQL client as described in [Command Options for Connecting to the Server](https://dev.mysql.com/doc/refman/5.7/en/connection-options.html#option_general_ssl-mode)
+`allowFallbackToNoTLS=true` acts like a `--ssl-mode=PREFERRED` MySQL client as described in [Command Options for Connecting to the Server](https://dev.mysql.com/doc/refman/5.7/en/connection-options.html#option_general_ssl-mode)
 
 ##### `allowNativePasswords`
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,17 @@ Default:        false
 
 `allowCleartextPasswords=true` allows using the [cleartext client side plugin](https://dev.mysql.com/doc/en/cleartext-pluggable-authentication.html) if required by an account, such as one defined with the [PAM authentication plugin](http://dev.mysql.com/doc/en/pam-authentication-plugin.html). Sending passwords in clear text may be a security problem in some configurations. To avoid problems if there is any possibility that the password would be intercepted, clients should connect to MySQL Server using a method that protects the password. Possibilities include [TLS / SSL](#tls), IPsec, or a private network.
 
+
+##### `allowFallbackToNoTLS`
+
+```
+Type:           bool
+Valid Values:   true, false
+Default:        false
+```
+
+`allowFallbackToNoTLS=true` acts like a `--ssl-mode=mode=PREFERRED` MySQL client as described in [Command Options for Connecting to the Server](https://dev.mysql.com/doc/refman/5.7/en/connection-options.html#option_general_ssl-mode)
+
 ##### `allowNativePasswords`
 
 ```

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Default:        false
 `allowCleartextPasswords=true` allows using the [cleartext client side plugin](https://dev.mysql.com/doc/en/cleartext-pluggable-authentication.html) if required by an account, such as one defined with the [PAM authentication plugin](http://dev.mysql.com/doc/en/pam-authentication-plugin.html). Sending passwords in clear text may be a security problem in some configurations. To avoid problems if there is any possibility that the password would be intercepted, clients should connect to MySQL Server using a method that protects the password. Possibilities include [TLS / SSL](#tls), IPsec, or a private network.
 
 
-##### `allowFallbackToNoTLS`
+##### `allowFallbackToPlaintext`
 
 ```
 Type:           bool
@@ -166,7 +166,7 @@ Valid Values:   true, false
 Default:        false
 ```
 
-`allowFallbackToNoTLS=true` acts like a `--ssl-mode=PREFERRED` MySQL client as described in [Command Options for Connecting to the Server](https://dev.mysql.com/doc/refman/5.7/en/connection-options.html#option_general_ssl-mode)
+`allowFallbackToPlaintext=true` acts like a `--ssl-mode=PREFERRED` MySQL client as described in [Command Options for Connecting to the Server](https://dev.mysql.com/doc/refman/5.7/en/connection-options.html#option_general_ssl-mode)
 
 ##### `allowNativePasswords`
 

--- a/auth.go
+++ b/auth.go
@@ -275,7 +275,7 @@ func (mc *mysqlConn) auth(authData []byte, plugin string) ([]byte, error) {
 		}
 		// unlike caching_sha2_password, sha256_password does not accept
 		// cleartext password on unix transport.
-		if mc.cfg.tls != nil {
+		if mc.cfg.TLS != nil {
 			// write cleartext auth packet
 			return append([]byte(mc.cfg.Passwd), 0), nil
 		}
@@ -351,7 +351,7 @@ func (mc *mysqlConn) handleAuthResult(oldAuthData []byte, plugin string) error {
 				}
 
 			case cachingSha2PasswordPerformFullAuthentication:
-				if mc.cfg.tls != nil || mc.cfg.Net == "unix" {
+				if mc.cfg.TLS != nil || mc.cfg.Net == "unix" {
 					// write cleartext auth packet
 					err = mc.writeAuthSwitchPacket(append([]byte(mc.cfg.Passwd), 0))
 					if err != nil {

--- a/auth_test.go
+++ b/auth_test.go
@@ -291,7 +291,7 @@ func TestAuthFastCachingSHA256PasswordFullSecure(t *testing.T) {
 
 	// Hack to make the caching_sha2_password plugin believe that the connection
 	// is secure
-	mc.cfg.tls = &tls.Config{InsecureSkipVerify: true}
+	mc.cfg.TLS = &tls.Config{InsecureSkipVerify: true}
 
 	// check written auth response
 	authRespStart := 4 + 4 + 4 + 1 + 23 + len(mc.cfg.User) + 1
@@ -663,7 +663,7 @@ func TestAuthFastSHA256PasswordSecure(t *testing.T) {
 
 	// hack to make the caching_sha2_password plugin believe that the connection
 	// is secure
-	mc.cfg.tls = &tls.Config{InsecureSkipVerify: true}
+	mc.cfg.TLS = &tls.Config{InsecureSkipVerify: true}
 
 	authData := []byte{6, 81, 96, 114, 14, 42, 50, 30, 76, 47, 1, 95, 126, 81,
 		62, 94, 83, 80, 52, 85}
@@ -676,7 +676,7 @@ func TestAuthFastSHA256PasswordSecure(t *testing.T) {
 	}
 
 	// unset TLS config to prevent the actual establishment of a TLS wrapper
-	mc.cfg.tls = nil
+	mc.cfg.TLS = nil
 
 	err = mc.writeHandshakeResponsePacket(authResp, plugin)
 	if err != nil {
@@ -866,7 +866,7 @@ func TestAuthSwitchCachingSHA256PasswordFullSecure(t *testing.T) {
 
 	// Hack to make the caching_sha2_password plugin believe that the connection
 	// is secure
-	mc.cfg.tls = &tls.Config{InsecureSkipVerify: true}
+	mc.cfg.TLS = &tls.Config{InsecureSkipVerify: true}
 
 	// auth switch request
 	conn.data = []byte{44, 0, 0, 2, 254, 99, 97, 99, 104, 105, 110, 103, 95,
@@ -1299,7 +1299,7 @@ func TestAuthSwitchSHA256PasswordSecure(t *testing.T) {
 
 	// Hack to make the caching_sha2_password plugin believe that the connection
 	// is secure
-	mc.cfg.tls = &tls.Config{InsecureSkipVerify: true}
+	mc.cfg.TLS = &tls.Config{InsecureSkipVerify: true}
 
 	// auth switch request
 	conn.data = []byte{38, 0, 0, 2, 254, 115, 104, 97, 50, 53, 54, 95, 112, 97,

--- a/dsn.go
+++ b/dsn.go
@@ -47,7 +47,6 @@ type Config struct {
 	pubKey           *rsa.PublicKey    // Server public key
 	TLSConfig        string            // TLS configuration name
 	tls              *tls.Config       // TLS configuration
-	tlsIsPreferred   bool              // TLS is preferred, not a must
 	Timeout          time.Duration     // Dial timeout
 	ReadTimeout      time.Duration     // I/O read timeout
 	WriteTimeout     time.Duration     // I/O write timeout
@@ -125,13 +124,10 @@ func (cfg *Config) normalize() error {
 		// don't set anything
 	case "true":
 		cfg.tls = &tls.Config{}
-	case "skip-verify":
+	case "skip-verify", "preferred":
 		cfg.tls = &tls.Config{InsecureSkipVerify: true}
-	case "preferred":
-		cfg.tls = &tls.Config{InsecureSkipVerify: true}
-		cfg.tlsIsPreferred = true
 	default:
-		cfg.tls, cfg.tlsIsPreferred = getTLSConfigCloneAndPreferred(cfg.TLSConfig)
+		cfg.tls = getTLSConfigClone(cfg.TLSConfig)
 		if cfg.tls == nil {
 			return errors.New("invalid value / unknown config name: " + cfg.TLSConfig)
 		}

--- a/dsn.go
+++ b/dsn.go
@@ -51,18 +51,18 @@ type Config struct {
 	ReadTimeout      time.Duration     // I/O read timeout
 	WriteTimeout     time.Duration     // I/O write timeout
 
-	AllowAllFiles           bool // Allow all files to be used with LOAD DATA LOCAL INFILE
-	AllowCleartextPasswords bool // Allows the cleartext client side plugin
-	AllowFallbackToNoTLS    bool // Allows fallback to unencrypted connection if server does not support TLS
-	AllowNativePasswords    bool // Allows the native password authentication method
-	AllowOldPasswords       bool // Allows the old insecure password method
-	CheckConnLiveness       bool // Check connections for liveness before using them
-	ClientFoundRows         bool // Return number of matching rows instead of rows changed
-	ColumnsWithAlias        bool // Prepend table alias to column names
-	InterpolateParams       bool // Interpolate placeholders into query string
-	MultiStatements         bool // Allow multiple statements in one query
-	ParseTime               bool // Parse time values to time.Time
-	RejectReadOnly          bool // Reject read-only connections
+	AllowAllFiles            bool // Allow all files to be used with LOAD DATA LOCAL INFILE
+	AllowCleartextPasswords  bool // Allows the cleartext client side plugin
+	AllowFallbackToPlaintext bool // Allows fallback to unencrypted connection if server does not support TLS
+	AllowNativePasswords     bool // Allows the native password authentication method
+	AllowOldPasswords        bool // Allows the old insecure password method
+	CheckConnLiveness        bool // Check connections for liveness before using them
+	ClientFoundRows          bool // Return number of matching rows instead of rows changed
+	ColumnsWithAlias         bool // Prepend table alias to column names
+	InterpolateParams        bool // Interpolate placeholders into query string
+	MultiStatements          bool // Allow multiple statements in one query
+	ParseTime                bool // Parse time values to time.Time
+	RejectReadOnly           bool // Reject read-only connections
 }
 
 // NewConfig creates a new Config and sets default values.
@@ -130,7 +130,7 @@ func (cfg *Config) normalize() error {
 			cfg.TLS = &tls.Config{InsecureSkipVerify: true}
 		case "preferred":
 			cfg.TLS = &tls.Config{InsecureSkipVerify: true}
-			cfg.AllowFallbackToNoTLS = true
+			cfg.AllowFallbackToPlaintext = true
 		default:
 			cfg.TLS = getTLSConfigClone(cfg.TLSConfig)
 			if cfg.TLS == nil {
@@ -210,8 +210,8 @@ func (cfg *Config) FormatDSN() string {
 		writeDSNParam(&buf, &hasParam, "allowCleartextPasswords", "true")
 	}
 
-	if cfg.AllowFallbackToNoTLS {
-		writeDSNParam(&buf, &hasParam, "allowFallbackToNoTLS", "true")
+	if cfg.AllowFallbackToPlaintext {
+		writeDSNParam(&buf, &hasParam, "allowFallbackToPlaintext", "true")
 	}
 
 	if !cfg.AllowNativePasswords {
@@ -402,9 +402,9 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			}
 
 		// Allow fallback to unencrypted connection if server does not support TLS
-		case "allowFallbackToNoTLS":
+		case "allowFallbackToPlaintext":
 			var isBool bool
-			cfg.AllowFallbackToNoTLS, isBool = readBool(value)
+			cfg.AllowFallbackToPlaintext, isBool = readBool(value)
 			if !isBool {
 				return errors.New("invalid bool value: " + value)
 			}

--- a/dsn.go
+++ b/dsn.go
@@ -47,6 +47,7 @@ type Config struct {
 	pubKey           *rsa.PublicKey    // Server public key
 	TLSConfig        string            // TLS configuration name
 	tls              *tls.Config       // TLS configuration
+	tlsIsPreferred   bool              // TLS is preferred, not a must
 	Timeout          time.Duration     // Dial timeout
 	ReadTimeout      time.Duration     // I/O read timeout
 	WriteTimeout     time.Duration     // I/O write timeout
@@ -124,10 +125,13 @@ func (cfg *Config) normalize() error {
 		// don't set anything
 	case "true":
 		cfg.tls = &tls.Config{}
-	case "skip-verify", "preferred":
+	case "skip-verify":
 		cfg.tls = &tls.Config{InsecureSkipVerify: true}
+	case "preferred":
+		cfg.tls = &tls.Config{InsecureSkipVerify: true}
+		cfg.tlsIsPreferred = true
 	default:
-		cfg.tls = getTLSConfigClone(cfg.TLSConfig)
+		cfg.tls, cfg.tlsIsPreferred = getTLSConfigCloneAndPreferred(cfg.TLSConfig)
 		if cfg.tls == nil {
 			return errors.New("invalid value / unknown config name: " + cfg.TLSConfig)
 		}

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -42,8 +42,8 @@ var testDSNs = []struct {
 	"user:password@/dbname?loc=UTC&timeout=30s&readTimeout=1s&writeTimeout=1s&allowAllFiles=1&clientFoundRows=true&allowOldPasswords=TRUE&collation=utf8mb4_unicode_ci&maxAllowedPacket=16777216&tls=false&allowCleartextPasswords=true&parseTime=true&rejectReadOnly=true",
 	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Collation: "utf8mb4_unicode_ci", Loc: time.UTC, TLSConfig: "false", AllowCleartextPasswords: true, AllowNativePasswords: true, Timeout: 30 * time.Second, ReadTimeout: time.Second, WriteTimeout: time.Second, AllowAllFiles: true, AllowOldPasswords: true, CheckConnLiveness: true, ClientFoundRows: true, MaxAllowedPacket: 16777216, ParseTime: true, RejectReadOnly: true},
 }, {
-	"user:password@/dbname?allowNativePasswords=false&checkConnLiveness=false&maxAllowedPacket=0&allowFallbackToNoTLS=true",
-	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Collation: "utf8mb4_general_ci", Loc: time.UTC, MaxAllowedPacket: 0, AllowFallbackToNoTLS: true, AllowNativePasswords: false, CheckConnLiveness: false},
+	"user:password@/dbname?allowNativePasswords=false&checkConnLiveness=false&maxAllowedPacket=0&allowFallbackToPlaintext=true",
+	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Collation: "utf8mb4_general_ci", Loc: time.UTC, MaxAllowedPacket: 0, AllowFallbackToPlaintext: true, AllowNativePasswords: false, CheckConnLiveness: false},
 }, {
 	"user:p@ss(word)@tcp([de:ad:be:ef::ca:fe]:80)/dbname?loc=Local",
 	&Config{User: "user", Passwd: "p@ss(word)", Net: "tcp", Addr: "[de:ad:be:ef::ca:fe]:80", DBName: "dbname", Collation: "utf8mb4_general_ci", Loc: time.Local, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true, CheckConnLiveness: true},
@@ -100,6 +100,7 @@ func TestDSNParserInvalid(t *testing.T) {
 		"User:pass@tcp(1.2.3.4:3306)",           // no trailing slash
 		"net()/",                                // unknown default addr
 		"user:pass@tcp(127.0.0.1:3306)/db/name", // invalid dbname
+		"user:password@/dbname?allowFallbackToPlaintext=PREFERRED", // wrong bool flag
 		//"/dbname?arg=/some/unescaped/path",
 	}
 

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -221,6 +221,66 @@ func TestDSNWithCustomTLS(t *testing.T) {
 	}
 }
 
+func TestRegisterPreferredTLSConfig(t *testing.T) {
+	tlsMust := "tls-must"
+	tlsPreferred := "tls-preferred"
+	tlsCfg := tls.Config{ServerName: tlsMust}
+	tlsCfg2 := tls.Config{ServerName: tlsPreferred}
+
+	err := RegisterTLSConfig(tlsMust, &tlsCfg)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	defer DeregisterTLSConfig(tlsMust)
+	err = RegisterPreferredTLSConfig(tlsPreferred, &tlsCfg2)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	defer DeregisterTLSConfig(tlsPreferred)
+
+	checkCfgAndPreferred := func(key, expectedName string, expectedPreferred bool) {
+		cfg, preferred := getTLSConfigCloneAndPreferred(key)
+		if cfg.ServerName != expectedName {
+			t.Errorf("did not get the correct TLS ServerName (%s): %s.", expectedName, cfg.ServerName)
+		}
+		if expectedPreferred && !preferred {
+			t.Errorf("this should not be a preferred TLS config: %s", key)
+		}
+		if !expectedPreferred && preferred {
+			t.Errorf("this should be a preferred TLS config: %s", key)
+		}
+	}
+
+	checkCfgAndPreferred(tlsMust, tlsMust, false)
+	checkCfgAndPreferred(tlsPreferred, tlsPreferred, true)
+
+	// test RegisterTLSConfig overwrites existing config and preferred
+	tlsAnother := "tls-another"
+	tlsCfg3 := tls.Config{ServerName: tlsAnother}
+	// register the name tlsPreferred in non-preferred mode!
+	err = RegisterTLSConfig(tlsPreferred, &tlsCfg3)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	checkCfgAndPreferred(tlsPreferred, tlsAnother, false)
+
+	// overwrite it back to preferred
+	err = RegisterPreferredTLSConfig(tlsPreferred, &tlsCfg3)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	checkCfgAndPreferred(tlsPreferred, tlsAnother, true)
+
+	DeregisterTLSConfig(tlsPreferred)
+	cfg, preferred := getTLSConfigCloneAndPreferred(tlsPreferred)
+	if cfg != nil {
+		t.Error("found TLS config after deregister")
+	}
+	if preferred {
+		t.Error("preferred should be false after deregister")
+	}
+}
+
 func TestDSNTLSConfig(t *testing.T) {
 	expectedServerName := "example.com"
 	dsn := "tcp(example.com:1234)/?tls=true"

--- a/packets.go
+++ b/packets.go
@@ -223,7 +223,7 @@ func (mc *mysqlConn) readHandshakePacket() (data []byte, plugin string, err erro
 		return nil, "", ErrOldProtocol
 	}
 	if mc.flags&clientSSL == 0 && mc.cfg.TLS != nil {
-		if mc.cfg.AllowFallbackToNoTLS {
+		if mc.cfg.AllowFallbackToPlaintext {
 			mc.cfg.TLS = nil
 		} else {
 			return nil, "", ErrNoTLS

--- a/packets.go
+++ b/packets.go
@@ -222,9 +222,9 @@ func (mc *mysqlConn) readHandshakePacket() (data []byte, plugin string, err erro
 	if mc.flags&clientProtocol41 == 0 {
 		return nil, "", ErrOldProtocol
 	}
-	if mc.flags&clientSSL == 0 && mc.cfg.tls != nil {
-		if mc.cfg.TLSConfig == "preferred" {
-			mc.cfg.tls = nil
+	if mc.flags&clientSSL == 0 && mc.cfg.TLS != nil {
+		if mc.cfg.AllowFallbackToNoTLS {
+			mc.cfg.TLS = nil
 		} else {
 			return nil, "", ErrNoTLS
 		}
@@ -292,7 +292,7 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, plugin string
 	}
 
 	// To enable TLS / SSL
-	if mc.cfg.tls != nil {
+	if mc.cfg.TLS != nil {
 		clientFlags |= clientSSL
 	}
 
@@ -356,14 +356,14 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, plugin string
 
 	// SSL Connection Request Packet
 	// http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::SSLRequest
-	if mc.cfg.tls != nil {
+	if mc.cfg.TLS != nil {
 		// Send TLS / SSL request packet
 		if err := mc.writePacket(data[:(4+4+1+23)+4]); err != nil {
 			return err
 		}
 
 		// Switch to TLS
-		tlsConn := tls.Client(mc.netConn, mc.cfg.tls)
+		tlsConn := tls.Client(mc.netConn, mc.cfg.TLS)
 		if err := tlsConn.Handshake(); err != nil {
 			return err
 		}

--- a/packets.go
+++ b/packets.go
@@ -223,7 +223,7 @@ func (mc *mysqlConn) readHandshakePacket() (data []byte, plugin string, err erro
 		return nil, "", ErrOldProtocol
 	}
 	if mc.flags&clientSSL == 0 && mc.cfg.tls != nil {
-		if mc.cfg.TLSConfig == "preferred" {
+		if mc.cfg.tlsIsPreferred {
 			mc.cfg.tls = nil
 		} else {
 			return nil, "", ErrNoTLS

--- a/packets.go
+++ b/packets.go
@@ -223,7 +223,7 @@ func (mc *mysqlConn) readHandshakePacket() (data []byte, plugin string, err erro
 		return nil, "", ErrOldProtocol
 	}
 	if mc.flags&clientSSL == 0 && mc.cfg.tls != nil {
-		if mc.cfg.tlsIsPreferred {
+		if mc.cfg.TLSConfig == "preferred" {
 			mc.cfg.tls = nil
 		} else {
 			return nil, "", ErrNoTLS

--- a/utils.go
+++ b/utils.go
@@ -25,9 +25,8 @@ import (
 
 // Registry for custom tls.Configs
 var (
-	tlsConfigLock      sync.RWMutex
-	tlsConfigRegistry  map[string]*tls.Config
-	tlsConfigPreferred map[string]struct{}
+	tlsConfigLock     sync.RWMutex
+	tlsConfigRegistry map[string]*tls.Config
 )
 
 // RegisterTLSConfig registers a custom tls.Config to be used with sql.Open.
@@ -56,17 +55,6 @@ var (
 //	})
 //	db, err := sql.Open("mysql", "user@tcp(localhost:3306)/test?tls=custom")
 func RegisterTLSConfig(key string, config *tls.Config) error {
-	return registerTLSConfig(key, config, false)
-}
-
-// RegisterPreferredTLSConfig is like a RegisterTLSConfig, but when the MySQL
-// server does not support TLS the driver will try to connect without TLS.
-// It can be used as a customized "preferred" TLS configuration in the DSN.
-func RegisterPreferredTLSConfig(key string, config *tls.Config) error {
-	return registerTLSConfig(key, config, true)
-}
-
-func registerTLSConfig(key string, config *tls.Config, preferred bool) error {
 	if _, isBool := readBool(key); isBool || strings.ToLower(key) == "skip-verify" || strings.ToLower(key) == "preferred" {
 		return fmt.Errorf("key '%s' is reserved", key)
 	}
@@ -75,16 +63,8 @@ func registerTLSConfig(key string, config *tls.Config, preferred bool) error {
 	if tlsConfigRegistry == nil {
 		tlsConfigRegistry = make(map[string]*tls.Config)
 	}
-	tlsConfigRegistry[key] = config
 
-	if preferred {
-		if tlsConfigPreferred == nil {
-			tlsConfigPreferred = make(map[string]struct{})
-		}
-		tlsConfigPreferred[key] = struct{}{}
-	} else {
-		delete(tlsConfigPreferred, key)
-	}
+	tlsConfigRegistry[key] = config
 	tlsConfigLock.Unlock()
 	return nil
 }
@@ -95,18 +75,14 @@ func DeregisterTLSConfig(key string) {
 	if tlsConfigRegistry != nil {
 		delete(tlsConfigRegistry, key)
 	}
-	if tlsConfigPreferred != nil {
-		delete(tlsConfigPreferred, key)
-	}
 	tlsConfigLock.Unlock()
 }
 
-func getTLSConfigCloneAndPreferred(key string) (config *tls.Config, preferred bool) {
+func getTLSConfigClone(key string) (config *tls.Config) {
 	tlsConfigLock.RLock()
 	if v, ok := tlsConfigRegistry[key]; ok {
 		config = v.Clone()
 	}
-	_, preferred = tlsConfigPreferred[key]
 	tlsConfigLock.RUnlock()
 	return
 }


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

### Description

#### Problem

We use ["preferred" tls mode](https://github.com/go-sql-driver/mysql#tls) to encrypt MySQL connection when it's possible. After golang 1.18 [the default minimum TLS version is changed to v1.2](https://tip.golang.org/doc/go1.18#tls10), so it's no longer a valid value to connect to old MySQL servers, and according to the doc the only way to come back to old behaviour is setting `tls.Config.MinVersion` to `VersionTLS10`

#### New feature

In this PR I want to introduce(or update)

one new configuration:
- `AllowFallbackToNoTLS` which is a `bool` to indicate the TLS is preferred rather than a must. Its behaviour is same as the old ["preferred" tls mode](https://github.com/go-sql-driver/mysql#tls)  

one (optional) configuration field change:
- `TLS` which is a `*tls.Config` in Config. It's OK that we don't have this change and use old-style register + name reference, but I hope we can get rid of boring works (unique naming, register, deregister)

#### behaviour of configuration item combinations

(some of them are mentioned in the comments of this PR)

- [--tls-version=TLSv1.1](https://dev.mysql.com/doc/refman/8.0/en/mysql-command-options.html#option_mysql_tls-version) + --ssl-mode=PREFERRED as mysql client: If we set the tls.Config.MinVersion to v1.1 and use `AllowFallbackToNoTLS`, it should be the same as that
- `tlsConfig=preferred&tlsVersion=1.0` as an alternative: I think using `*tls.Config` and `AllowFallbackToNoTLS` are more flexible, for example, in `*tls.Config` I can set the minimun and maximun TLS version.
- `tlsConfig=skip-verify&tlsVersion=1.0` as an alternative: same as above, because in `*tls.Config` we can control `InsecureSkipVerify`. In addition to that, we can use `VerifyPeerCertificate` to perform more verification like [--ssl-mode=VERIFY_CA/VERIFY_IDENTITY](https://dev.mysql.com/doc/refman/5.7/en/connection-options.html#option_general_ssl-mode)

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
