### PR TITLE
allow for initial statements

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -78,6 +78,7 @@ Olivier Mengué <dolmen at cpan.org>
 oscarzhao <oscarzhaosl at gmail.com>
 Paul Bonser <misterpib at gmail.com>
 Peter Schultz <peter.schultz at classmarkets.com>
+Peyman Mortazavi <pey.mortazavi at gmail.com>
 Rebecca Chin <rchin at pivotal.io>
 Reed Allman <rdallman10 at gmail.com>
 Richard Wilkes <wilkes at me.com>

--- a/README.md
+++ b/README.md
@@ -492,6 +492,24 @@ However, many want to scan MySQL `DATE` and `DATETIME` values into `time.Time` v
 
 **Caution:** As of Go 1.1, this makes `time.Time` the only variable type you can scan `DATE` and `DATETIME` values into. This breaks for example [`sql.RawBytes` support](https://github.com/go-sql-driver/mysql/wiki/Examples#rawbytes).
 
+### Default/Initial Statements
+At times, there may be a need to define a set of statements that should get executed for every connection.
+
+You can set these on the `*mysql.Config` object.
+
+```go
+config, err := mysql.ParseDSN("connection string")
+if err != nil {
+  // handle error.
+}
+config.InitStatements = append(config.InitStatements, "SET aurora_replica_read_consistency=SESSION")
+connector, err := mysql.NewConnector(config)
+if err != nil {
+  // handle error.
+}
+db := sql.OpenDB(connector)
+```
+
 
 ### Unicode support
 Since version 1.5 Go-MySQL-Driver automatically uses the collation ` utf8mb4_general_ci` by default.

--- a/connector.go
+++ b/connector.go
@@ -136,6 +136,14 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 		return nil, err
 	}
 
+	for _, stmt := range c.cfg.InitStatements {
+		err = mc.exec(stmt)
+		if err != nil {
+			mc.Close()
+			return nil, err
+		}
+	}
+
 	return mc, nil
 }
 

--- a/dsn.go
+++ b/dsn.go
@@ -51,18 +51,19 @@ type Config struct {
 	ReadTimeout      time.Duration     // I/O read timeout
 	WriteTimeout     time.Duration     // I/O write timeout
 
-	AllowAllFiles            bool // Allow all files to be used with LOAD DATA LOCAL INFILE
-	AllowCleartextPasswords  bool // Allows the cleartext client side plugin
-	AllowFallbackToPlaintext bool // Allows fallback to unencrypted connection if server does not support TLS
-	AllowNativePasswords     bool // Allows the native password authentication method
-	AllowOldPasswords        bool // Allows the old insecure password method
-	CheckConnLiveness        bool // Check connections for liveness before using them
-	ClientFoundRows          bool // Return number of matching rows instead of rows changed
-	ColumnsWithAlias         bool // Prepend table alias to column names
-	InterpolateParams        bool // Interpolate placeholders into query string
-	MultiStatements          bool // Allow multiple statements in one query
-	ParseTime                bool // Parse time values to time.Time
-	RejectReadOnly           bool // Reject read-only connections
+	AllowAllFiles            bool     // Allow all files to be used with LOAD DATA LOCAL INFILE
+	AllowCleartextPasswords  bool     // Allows the cleartext client side plugin
+	AllowFallbackToPlaintext bool     // Allows fallback to unencrypted connection if server does not support TLS
+	AllowNativePasswords     bool     // Allows the native password authentication method
+	AllowOldPasswords        bool     // Allows the old insecure password method
+	CheckConnLiveness        bool     // Check connections for liveness before using them
+	ClientFoundRows          bool     // Return number of matching rows instead of rows changed
+	ColumnsWithAlias         bool     // Prepend table alias to column names
+	InterpolateParams        bool     // Interpolate placeholders into query string
+	MultiStatements          bool     // Allow multiple statements in one query
+	ParseTime                bool     // Parse time values to time.Time
+	RejectReadOnly           bool     // Reject read-only connections
+	InitStatements           []string // Statements to execute for each new connection
 }
 
 // NewConfig creates a new Config and sets default values.


### PR DESCRIPTION
### Description
There are times where you want to execute some statements in order to set values, enable/disable features per each connection. I use this package for work and we need to set the following on the reader nodes:

```
SET aurora_replica_read_consistency=SESSION
````

And it's not really easy to do so currently because new connections miss this statement. This PR adds ability for one to define these statements. It does mean that you'll have a less convenient way to create connections however.

````
config, err := mysql.ParseDSN("connection string")
// handle err
config.InitStatements = append(config.InitStatements, "SET aurora_replica_read_consistency=SESSION")
connector, err := mysql.NewConnector(config)
// handle err
db := sql.OpenDB(connector)
````


### Checklist
- [X] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [X] All tests passing
- [X] Extended the README / documentation, if necessary
- [X] Added myself / the copyright holder to the AUTHORS file
