### PR TITLE
Allow for url encoded dbname in dsn

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,6 +61,7 @@ Kamil Dziedzic <kamil at klecza.pl>
 Kei Kamikawa <x00.x7f.x86 at gmail.com>
 Kevin Malachowski <kevin at chowski.com>
 Kieron Woodhouse <kieron.woodhouse at infosum.com>
+Lachlan Orr <lorr at gaen.org>
 Lance Tian <lance6716 at gmail.com>
 Lennart Rudolph <lrudolph at hmc.edu>
 Leonardo YongUk Kim <dalinaum at gmail.com>

--- a/dsn.go
+++ b/dsn.go
@@ -196,7 +196,7 @@ func (cfg *Config) FormatDSN() string {
 
 	// /dbname
 	buf.WriteByte('/')
-	buf.WriteString(cfg.DBName)
+	buf.WriteString(url.QueryEscape(cfg.DBName))
 
 	// [?param1=value1&...&paramN=valueN]
 	hasParam := false
@@ -358,7 +358,9 @@ func ParseDSN(dsn string) (cfg *Config, err error) {
 					break
 				}
 			}
-			cfg.DBName = dsn[i+1 : j]
+			if cfg.DBName, err = url.QueryUnescape(dsn[i+1 : j]); err != nil {
+				return nil, fmt.Errorf("invalid DSN: failed to unescape database name: %v", err)
+			}
 
 			break
 		}

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -71,6 +71,18 @@ var testDSNs = []struct {
 }, {
 	"tcp(de:ad:be:ef::ca:fe)/dbname",
 	&Config{Net: "tcp", Addr: "[de:ad:be:ef::ca:fe]:3306", DBName: "dbname", Collation: "utf8mb4_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true, CheckConnLiveness: true},
+}, {
+	"user@tcp(localhost:3306)/db%2Fdevelopment?parseTime=true",
+	&Config{User: "user", Net: "tcp", Addr: "localhost:3306", DBName: "db/development", Collation: "utf8mb4_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true, CheckConnLiveness: true, ParseTime: true},
+}, {
+	"user:password@/dbname%2F?allowNativePasswords=false&checkConnLiveness=false&maxAllowedPacket=0&allowFallbackToPlaintext=true",
+	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname/", Collation: "utf8mb4_general_ci", Loc: time.UTC, MaxAllowedPacket: 0, AllowFallbackToPlaintext: true, AllowNativePasswords: false, CheckConnLiveness: false},
+}, {
+	"/dbname%2Fsuffix",
+	&Config{Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname/suffix", Collation: "utf8mb4_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true, CheckConnLiveness: true},
+}, {
+	"user:password@/%2Fdbname?loc=UTC&timeout=30s&readTimeout=1s&writeTimeout=1s&allowAllFiles=1&clientFoundRows=true&allowOldPasswords=TRUE&collation=utf8mb4_unicode_ci&maxAllowedPacket=16777216&tls=false&allowCleartextPasswords=true&parseTime=true&rejectReadOnly=true",
+	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "/dbname", Collation: "utf8mb4_unicode_ci", Loc: time.UTC, TLSConfig: "false", AllowCleartextPasswords: true, AllowNativePasswords: true, Timeout: 30 * time.Second, ReadTimeout: time.Second, WriteTimeout: time.Second, AllowAllFiles: true, AllowOldPasswords: true, CheckConnLiveness: true, ClientFoundRows: true, MaxAllowedPacket: 16777216, ParseTime: true, RejectReadOnly: true},
 },
 }
 


### PR DESCRIPTION
- Support for dbnames containing special characters, in particular '/' which can occur in legacy rails databases (e.g. db/development or db/production)

### Description
I've been using this project to connect to some legacy RoR mysql databases. There is a prevalent naming convention in these databases such as 'db/development' or 'db/production'. I tried a few different approaches but couldn't figure out how to use this project with database names that contain '/' characters. In a few places in dsn.go you are using url QueryEscape and QueryUnescape, so I applied the same principal to dbname in cases where there are special characters in the dbname that break the parser.

### Checklist
- [ X ] Code compiles correctly
- [ X ] Created tests which fail without the change (if possible)
- [ X ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ X ] Added myself / the copyright holder to the AUTHORS file
