### PR TITLE
Use SET syntax as specified in the MySQL documentation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -83,6 +83,7 @@ Reed Allman <rdallman10 at gmail.com>
 Richard Wilkes <wilkes at me.com>
 Robert Russell <robert at rrbrussell.com>
 Runrioter Wung <runrioter at gmail.com>
+Samantha Frank <hello at entropy.cat>
 Santhosh Kumar Tekuri <santhosh.tekuri at gmail.com>
 Sho Iizuka <sho.i518 at gmail.com>
 Sho Ikeda <suicaicoca at gmail.com>

--- a/connection.go
+++ b/connection.go
@@ -71,10 +71,10 @@ func (mc *mysqlConn) handleParams() (err error) {
 				cmdSet.Grow(4 + len(param) + 1 + len(val) + 30*(len(mc.cfg.Params)-1))
 				cmdSet.WriteString("SET ")
 			} else {
-				cmdSet.WriteByte(',')
+				cmdSet.WriteString(", ")
 			}
 			cmdSet.WriteString(param)
-			cmdSet.WriteByte('=')
+			cmdSet.WriteString(" = ")
 			cmdSet.WriteString(val)
 		}
 	}


### PR DESCRIPTION
### Description
PR #1099 was able save on round-trip-time by `SET`ting multiple variables in a single transaction. However, the syntax used is out of alignment with both the MySQL and MariaDB docs. Specifically there are missing spaces around the equals (`=`) sign and after each comma (`,`).

Syntax output by go-sql-driver/mysql:
> `SET variable=expr[,variable=expr]...`

Syntax as specified in the [MySQL 8.0 documentation](https://dev.mysql.com/doc/refman/8.0/en/set-variable.html).
> `SET variable = expr [, variable = expr] ...`

Syntax as specified in the [MariaDB documentation](https://mariadb.com/kb/en/set/):
> ```
> SET variable_assignment [, variable_assignment] ...
> 
> variable_assignment:
>       user_var_name = expr
>     | [GLOBAL | SESSION] system_var_name = expr
>     | [@@global. | @@session. | @@]system_var_name = expr
> ```

The `SET` syntax output by go-sql-driver/mysql is accepted by recent versions of MariaDB in our testing. Unfortunately we've encountered significant issues when these statements are parsed by [ProxySQL](https://github.com/sysown/proxysql), a tool we use for efficient routing of queries to our various MariaDB servers.

### Checklist
- [X] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
- [X] Added myself / the copyright holder to the AUTHORS file
