### PR TITLE
Add go1.20 and mariadb10.11 to the testing matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,9 @@ jobs:
           import os
           go = [
               # Keep the most recent production release at the top
-              '1.19',
+              '1.20',
               # Older production releases
+              '1.19',
               '1.18',
               '1.17',
               '1.16',
@@ -36,6 +37,7 @@ jobs:
               '8.0',
               '5.7',
               '5.6',
+              'mariadb-10.11',
               'mariadb-10.6',
               'mariadb-10.5',
               'mariadb-10.4',

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
-      - uses: shogo82148/actions-setup-mysql@v1
+      - uses: shogo82148/actions-setup-mysql@v1.15.0
         with:
           mysql-version: ${{ matrix.mysql }}
           user: ${{ env.MYSQL_TEST_USER }}

--- a/AUTHORS
+++ b/AUTHORS
@@ -78,6 +78,7 @@ Olivier Mengué <dolmen at cpan.org>
 oscarzhao <oscarzhaosl at gmail.com>
 Paul Bonser <misterpib at gmail.com>
 Peter Schultz <peter.schultz at classmarkets.com>
+Phil Porada <philporada at gmail.com>
 Rebecca Chin <rchin at pivotal.io>
 Reed Allman <rdallman10 at gmail.com>
 Richard Wilkes <wilkes at me.com>


### PR DESCRIPTION
Add go1.20 and mariadb10.11 to the testing matrix. Per [MariaDB docs](https://mariadb.com/kb/en/changes-improvements-in-mariadb-1011/), MariaDB 10.11 is the next long term supprt (LTS) version.

Fixes https://github.com/go-sql-driver/mysql/issues/1395
