### PR TITLE
Allow Connecting to Databases with Slashes in the Name via Url Escaping

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -106,6 +106,7 @@ Xuehong Chan <chanxuehong at gmail.com>
 Zhenye Xie <xiezhenye at gmail.com>
 Zhixin Wen <john.wenzhixin at gmail.com>
 Ziheng Lyu <zihenglv at gmail.com>
+Brian Hendriks <brian at dolthub.com>
 
 # Organizations
 
@@ -123,3 +124,4 @@ Percona LLC
 Pivotal Inc.
 Stripe Inc.
 Zendesk Inc.
+Dolthub Inc.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ This has the same effect as an empty DSN string:
 
 ```
 
+If your database name includes a slash, use the [URL encoding](https://en.wikipedia.org/wiki/Percent-encoding) `%2F`:
+```
+/dbname%2Fwithslash
+```
+
 Alternatively, [Config.FormatDSN](https://godoc.org/github.com/go-sql-driver/mysql#Config.FormatDSN) can be used to create a DSN string by filling a struct.
 
 #### Password

--- a/dsn.go
+++ b/dsn.go
@@ -196,7 +196,8 @@ func (cfg *Config) FormatDSN() string {
 
 	// /dbname
 	buf.WriteByte('/')
-	buf.WriteString(cfg.DBName)
+	dbNameEncoded := url.QueryEscape(cfg.DBName)
+	buf.WriteString(dbNameEncoded)
 
 	// [?param1=value1&...&paramN=valueN]
 	hasParam := false
@@ -358,7 +359,11 @@ func ParseDSN(dsn string) (cfg *Config, err error) {
 					break
 				}
 			}
-			cfg.DBName = dsn[i+1 : j]
+
+			dbName := dsn[i+1 : j]
+			if cfg.DBName, err = url.QueryUnescape(dbName); err != nil {
+				return nil, fmt.Errorf("invalid dbname '%s': %w", dbName, err)
+			}
 
 			break
 		}

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -98,13 +98,14 @@ func TestDSNParser(t *testing.T) {
 
 func TestDSNParserInvalid(t *testing.T) {
 	var invalidDSNs = []string{
-		"@net(addr/",                  // no closing brace
-		"@tcp(/",                      // no closing brace
-		"tcp(/",                       // no closing brace
-		"(/",                          // no closing brace
-		"net(addr)//",                 // unescaped
-		"User:pass@tcp(1.2.3.4:3306)", // no trailing slash
-		"net()/",                      // unknown default addr
+		"@net(addr/",                            // no closing brace
+		"@tcp(/",                                // no closing brace
+		"tcp(/",                                 // no closing brace
+		"(/",                                    // no closing brace
+		"net(addr)//",                           // unescaped
+		"User:pass@tcp(1.2.3.4:3306)",           // no trailing slash
+		"net()/",                                // unknown default addr
+		"user:pass@tcp(127.0.0.1:3306)/db/name", // invalid dbname
 		"user:password@/dbname?allowFallbackToPlaintext=PREFERRED", // wrong bool flag
 		//"/dbname?arg=/some/unescaped/path",
 	}


### PR DESCRIPTION
### Description
Currently mysql will allow you to create a database with slashes in the name, however this driver does not provide any support for connecting to such databases.  This change allows you to use url escaping to include slashes in your database name.

Pic showing mysql allows forward slashes in creation if backtick escaped:
<img width="1082" alt="Screen Shot 2023-03-16 at 11 00 33 AM" src="https://user-images.githubusercontent.com/6110485/225713243-c608646c-371c-4210-ada2-088dde0795a4.png">

### Checklist
- [ X ] Code compiles correctly
- [ X ] Created tests which fail without the change (if possible)
- [ X ] All tests passing
- [ X ] Extended the README / documentation, if necessary
- [ X ] Added myself / the copyright holder to the AUTHORS file