### PR TITLE
Increase default maxAllowedPacket size.

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Please keep in mind, that param values must be [url.QueryEscape](https://golang.
 ##### `maxAllowedPacket`
 ```
 Type:          decimal number
-Default:       4194304
+Default:       64*1024*1024
 ```
 
 Max packet size allowed in bytes. The default value is 4 MiB and should be adjusted to match the server settings. `maxAllowedPacket=0` can be used to automatically fetch the `max_allowed_packet` variable from server *on every connection*.

--- a/const.go
+++ b/const.go
@@ -10,7 +10,7 @@ package mysql
 
 const (
 	defaultAuthPlugin       = "mysql_native_password"
-	defaultMaxAllowedPacket = 4 << 20 // 4 MiB
+	defaultMaxAllowedPacket = 64 << 20 // 64 MiB. See https://github.com/go-sql-driver/mysql/issues/1355
 	minProtocolVersion      = 10
 	maxPacketSize           = 1<<24 - 1
 	timeFormat              = "2006-01-02 15:04:05.999999"

--- a/errors.go
+++ b/errors.go
@@ -27,7 +27,7 @@ var (
 	ErrOldProtocol       = errors.New("MySQL server does not support required protocol 41+")
 	ErrPktSync           = errors.New("commands out of sync. You can't run this command now")
 	ErrPktSyncMul        = errors.New("commands out of sync. Did you run multiple statements at once?")
-	ErrPktTooLarge       = errors.New("packet for query is too large. Try adjusting the 'max_allowed_packet' variable on the server")
+	ErrPktTooLarge       = errors.New("packet for query is too large. Try adjusting the `Config.MaxAllowedPacket`")
 	ErrBusyBuffer        = errors.New("busy buffer")
 
 	// errBadConnNoWrite is used for connection errors where nothing was sent to the database yet.


### PR DESCRIPTION
### Description

* Increase default maxAllowedPacket as MySQL default.
* ErrPacketTooLarge message mention client config rather than server config.

Fixes #1355.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
