### PR TITLE
Correct maxAllowedPacket default value mentioned in docs to match the…

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Type:          decimal number
 Default:       64*1024*1024
 ```
 
-Max packet size allowed in bytes. The default value is 4 MiB and should be adjusted to match the server settings. `maxAllowedPacket=0` can be used to automatically fetch the `max_allowed_packet` variable from server *on every connection*.
+Max packet size allowed in bytes. The default value is 64 MiB and should be adjusted to match the server settings. `maxAllowedPacket=0` can be used to automatically fetch the `max_allowed_packet` variable from server *on every connection*.
 
 ##### `multiStatements`
 


### PR DESCRIPTION
### Description

Fix a minor change in the docs where the size of the new `maxAllowedPacket` size was not updated to match the code change.

### Checklist
- [ ] Code compiles correctly - no change in code
- [ ] Created tests which fail without the change (if possible) - no change in tests
- [ ] All tests passing - N/A
- [X] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file - already present
