### PR TITLE
Adding DeregisterDialContext to prevent memory leaks with dialers we don't need anymore

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,6 +47,7 @@ INADA Naoki <songofacandy at gmail.com>
 Jacek Szwec <szwec.jacek at gmail.com>
 James Harr <james.harr at gmail.com>
 Janek Vedock <janekvedock at comcast.net>
+Jean-Yves Pellé <jy at pelle.link>
 Jeff Hodges <jeff at somethingsimilar.com>
 Jeffrey Charles <jeffreycharles at gmail.com>
 Jerome Meyer <jxmeyer at gmail.com>

--- a/driver.go
+++ b/driver.go
@@ -55,6 +55,17 @@ func RegisterDialContext(net string, dial DialContextFunc) {
 	dials[net] = dial
 }
 
+// UnregisterDialContext unregisters a custom dial function to free ressources.
+func UnregisterDialContext(net string) {
+	dialsLock.Lock()
+	defer dialsLock.Unlock()
+	if dials != nil {
+		if _, ok := dials[net]; ok {
+			delete(dials, net)
+		}
+	}
+}
+
 // RegisterDial registers a custom dial function. It can then be used by the
 // network address mynet(addr), where mynet is the registered new network.
 // addr is passed as a parameter to the dial function.

--- a/driver.go
+++ b/driver.go
@@ -55,8 +55,8 @@ func RegisterDialContext(net string, dial DialContextFunc) {
 	dials[net] = dial
 }
 
-// UnregisterDialContext unregisters a custom dial function to free ressources.
-func UnregisterDialContext(net string) {
+// DeregisterDialContext removes the custom dial function registered with the given net.
+func DeregisterDialContext(net string) {
 	dialsLock.Lock()
 	defer dialsLock.Unlock()
 	if dials != nil {


### PR DESCRIPTION
### Description

Adding the DeregisterDialContext function to prevent memory leaks when using temporary custom dialers extensively (for example, temporary connection to a MySQL database via SSH => when the connection is terminated, the SSH dialer is still present in the `dials` map).

### Checklist
- [X] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [] Extended the README / documentation, if necessary
- [X ] Added myself / the copyright holder to the AUTHORS file
