### PR TITLE
Avoid panic in TestRowsColumnTypes

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -2945,7 +2945,7 @@ func TestRowsColumnTypes(t *testing.T) {
 				continue
 			}
 		}
-		//Avoid：values is nil
+		// Avoid panic caused by nil scantype.
 		if t.Failed() {
 			return
 		}

--- a/driver_test.go
+++ b/driver_test.go
@@ -2945,7 +2945,10 @@ func TestRowsColumnTypes(t *testing.T) {
 				continue
 			}
 		}
-
+		//Avoid：values is nil
+		if t.Failed() {
+			return
+		}
 		values := make([]interface{}, len(tt))
 		for i := range values {
 			values[i] = reflect.New(types[i]).Interface()


### PR DESCRIPTION
### Description
Please explain the changes you made here.
When running the TestRowsColumnTypes unit test on OceanBase, I encountered a panic and the test progress was forced to exit.
![image](https://user-images.githubusercontent.com/35394786/236594847-c30a7c48-6d84-4264-a55e-32043fc08750.png)

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
