### PR TITLE
Remove SQL injection warning for multiStatement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Valid Values:   true, false
 Default:        false
 ```
 
-Allow multiple statements in one query. While this allows batch queries, it also greatly increases the risk of SQL injections. Only the result of the first query is returned, all other results are silently discarded.
+Allow multiple statements in one query. While this allows batch queries. Only the result of the first query is returned, all other results are silently discarded.
 
 When `multiStatements` is used, `?` parameters must only be used in the first statement.
 


### PR DESCRIPTION
I can't really find any reference to the risk of SQL injections. This sets the clientMultiStatements flag (or CLIENT_MULTI_STATEMENTS in the C API).

This comment was added in #411, but without much explanation, and I can't find anything in e.g. #66 or other issues either.

The documentation for MySQL[1] or MariaDB[2] doesn't warn for SQL injections, and after some internet searching the only reference I found was in the PHP Docs[3]:

	The API functions mysqli::query() and mysqli::real_query() do
	not set a connection flag necessary for activating multi queries
	in the server. An extra API call is used for multiple statements
	to reduce the damage of accidental SQL injection attacks. An
	attacker may try to add statements such as ; DROP DATABASE mysql
	or ; SELECT SLEEP(999).

So I assume this is what this comment refers to.

This removes the comment, as discussed in #1206.

[1]: https://dev.mysql.com/doc/c-api/8.0/en/c-api-multiple-queries.html
[2]: https://mariadb.com/kb/en/mysql_real_connect/
[3]: https://www.php.net/manual/de/mysqli.quickstart.multiple-statement.php

### Description
Please explain the changes you made here.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
