### PR TITLE
PathEscape dbname in DSN.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -106,6 +106,7 @@ Xuehong Chan <chanxuehong at gmail.com>
 Zhenye Xie <xiezhenye at gmail.com>
 Zhixin Wen <john.wenzhixin at gmail.com>
 Ziheng Lyu <zihenglv at gmail.com>
+Brian Hendriks <brian at dolthub.com>
 
 # Organizations
 
@@ -123,3 +124,4 @@ Percona LLC
 Pivotal Inc.
 Stripe Inc.
 Zendesk Inc.
+Dolthub Inc.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ This has the same effect as an empty DSN string:
 
 ```
 
+If your database name includes a slash, use the [URL encoding](https://en.wikipedia.org/wiki/Percent-encoding) `%2F`:
+```
+/dbname%2Fwithslash
+```
+
 Alternatively, [Config.FormatDSN](https://godoc.org/github.com/go-sql-driver/mysql#Config.FormatDSN) can be used to create a DSN string by filling a struct.
 
 #### Password

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ This has the same effect as an empty DSN string:
 
 ```
 
-If your database name includes a slash, use the [URL encoding](https://en.wikipedia.org/wiki/Percent-encoding) `%2F`:
+`dbname` is escaped by [PathEscape()]()https://pkg.go.dev/net/url#PathEscape) since v1.8.0. If your database name is `dbname/withslash`, it becomes:
+
 ```
 /dbname%2Fwithslash
 ```

--- a/dsn.go
+++ b/dsn.go
@@ -202,8 +202,7 @@ func (cfg *Config) FormatDSN() string {
 
 	// /dbname
 	buf.WriteByte('/')
-	dbNameEncoded := url.QueryEscape(cfg.DBName)
-	buf.WriteString(dbNameEncoded)
+	buf.WriteString(url.PathEscape(cfg.DBName))
 
 	// [?param1=value1&...&paramN=valueN]
 	hasParam := false
@@ -366,9 +365,9 @@ func ParseDSN(dsn string) (cfg *Config, err error) {
 				}
 			}
 
-			dbName := dsn[i+1 : j]
-			if cfg.DBName, err = url.QueryUnescape(dbName); err != nil {
-				return nil, fmt.Errorf("invalid dbname '%s': %w", dbName, err)
+			dbname := dsn[i+1 : j]
+			if cfg.DBName, err = url.PathUnescape(dbname); err != nil {
+				return nil, fmt.Errorf("invalid dbname %q: %w", dbname, err)
 			}
 
 			break

--- a/dsn.go
+++ b/dsn.go
@@ -196,7 +196,8 @@ func (cfg *Config) FormatDSN() string {
 
 	// /dbname
 	buf.WriteByte('/')
-	buf.WriteString(cfg.DBName)
+	dbNameEncoded := url.QueryEscape(cfg.DBName)
+	buf.WriteString(dbNameEncoded)
 
 	// [?param1=value1&...&paramN=valueN]
 	hasParam := false
@@ -358,7 +359,11 @@ func ParseDSN(dsn string) (cfg *Config, err error) {
 					break
 				}
 			}
-			cfg.DBName = dsn[i+1 : j]
+
+			dbName := dsn[i+1 : j]
+			if cfg.DBName, err = url.QueryUnescape(dbName); err != nil {
+				return nil, fmt.Errorf("invalid dbname '%s': %w", dbName, err)
+			}
 
 			break
 		}

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -52,7 +52,7 @@ var testDSNs = []struct {
 	&Config{Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Collation: "utf8mb4_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, Logger: defaultLogger, AllowNativePasswords: true, CheckConnLiveness: true},
 }, {
 	"/dbname%2Fwithslash",
-	&Config{Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname/withslash", Collation: "utf8mb4_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, AllowNativePasswords: true, CheckConnLiveness: true},
+	&Config{Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname/withslash", Collation: "utf8mb4_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, Logger: defaultLogger, AllowNativePasswords: true, CheckConnLiveness: true},
 }, {
 	"@/",
 	&Config{Net: "tcp", Addr: "127.0.0.1:3306", Collation: "utf8mb4_general_ci", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, Logger: defaultLogger, AllowNativePasswords: true, CheckConnLiveness: true},

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -98,13 +98,14 @@ func TestDSNParser(t *testing.T) {
 
 func TestDSNParserInvalid(t *testing.T) {
 	var invalidDSNs = []string{
-		"@net(addr/",                  // no closing brace
-		"@tcp(/",                      // no closing brace
-		"tcp(/",                       // no closing brace
-		"(/",                          // no closing brace
-		"net(addr)//",                 // unescaped
-		"User:pass@tcp(1.2.3.4:3306)", // no trailing slash
-		"net()/",                      // unknown default addr
+		"@net(addr/",                            // no closing brace
+		"@tcp(/",                                // no closing brace
+		"tcp(/",                                 // no closing brace
+		"(/",                                    // no closing brace
+		"net(addr)//",                           // unescaped
+		"User:pass@tcp(1.2.3.4:3306)",           // no trailing slash
+		"net()/",                                // unknown default addr
+		"user:pass@tcp(127.0.0.1:3306)/db/name", // invalid dbname
 		"user:password@/dbname?allowFallbackToPlaintext=PREFERRED", // wrong bool flag
 		//"/dbname?arg=/some/unescaped/path",
 	}


### PR DESCRIPTION
### Description

This pull request is based on #1406, but uses PathEscape instead of QueryEscape to minimize backward incompatibility.

This PR allows '/' in dbName. On the other hand, '%' in DNS is treated as percent-encoding. So this is a breaking change. I hope this breakage is small enough for minor version (v1.8).

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
