### PR TITLE
all: replace ioutil pkg to new package

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -33,7 +33,7 @@ var (
 // Note: The provided rsa.PublicKey instance is exclusively owned by the driver
 // after registering it and may not be modified.
 //
-//	data, err := ioutil.ReadFile("mykey.pem")
+//	data, err := os.ReadFile("mykey.pem")
 //	if err != nil {
 //		log.Fatal(err)
 //	}

--- a/driver_test.go
+++ b/driver_test.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math"
 	"net"
@@ -1245,7 +1244,7 @@ func TestLoadData(t *testing.T) {
 		dbt.mustExec("CREATE TABLE test (id INT NOT NULL PRIMARY KEY, value TEXT NOT NULL) CHARACTER SET utf8")
 
 		// Local File
-		file, err := ioutil.TempFile("", "gotest")
+		file, err := os.CreateTemp("", "gotest")
 		defer os.Remove(file.Name())
 		if err != nil {
 			dbt.Fatal(err)

--- a/utils.go
+++ b/utils.go
@@ -36,7 +36,7 @@ var (
 // registering it.
 //
 //	rootCertPool := x509.NewCertPool()
-//	pem, err := ioutil.ReadFile("/path/ca-cert.pem")
+//	pem, err := os.ReadFile("/path/ca-cert.pem")
 //	if err != nil {
 //	    log.Fatal(err)
 //	}


### PR DESCRIPTION
### Description
Removed use of `ioutil` package. 
ioutil has been deprecated since Go 1.16 (https://go.dev/doc/go1.16#ioutil)

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
