### PR TITLE
doc: add link to NewConnector from FormatDSN

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -177,6 +177,8 @@ func writeDSNParam(buf *bytes.Buffer, hasParam *bool, name, value string) {
 
 // FormatDSN formats the given Config into a DSN string which can be passed to
 // the driver.
+//
+// Note: use [NewConnector] and [database/sql.OpenDB] to open a connection from a [*Config].
 func (cfg *Config) FormatDSN() string {
 	var buf bytes.Buffer
 


### PR DESCRIPTION
### Description

Improve documentation of FormatDSN: advise to use NewConnector instead of FormatDSN

This is because roundtripping is known to not work well. See https://github.com/go-sql-driver/mysql/issues/1410#issuecomment-1510866931

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Added myself / the copyright holder to the AUTHORS file
