### PR TITLE
TestDSNReformat: add more roundtrip checks

### DIFF
--- a/dsn_test.go
+++ b/dsn_test.go
@@ -130,6 +130,11 @@ func TestDSNReformat(t *testing.T) {
 			res1 := fmt.Sprintf("%+v", cfg1)
 
 			dsn2 := cfg1.FormatDSN()
+			if dsn2 != dsn1 {
+				// Just log
+				t.Logf("%d. %q reformated as %q", i, dsn1, dsn2)
+			}
+
 			cfg2, err := ParseDSN(dsn2)
 			if err != nil {
 				t.Error(err.Error())
@@ -140,6 +145,11 @@ func TestDSNReformat(t *testing.T) {
 
 			if res1 != res2 {
 				t.Errorf("%d. %q does not match %q", i, res2, res1)
+			}
+
+			dsn3 := cfg2.FormatDSN()
+			if dsn3 != dsn2 {
+				t.Errorf("%d. %q does not match %q", i, dsn2, dsn3)
 			}
 		})
 	}


### PR DESCRIPTION
### Description
Add more roundtrip checks for ParseDSN/FormatDSN.

New output:
```console
$ go test -v -run TestDSNReformat
=== RUN   TestDSNReformat
=== RUN   TestDSNReformat/username:password@protocol(address)/dbname?param=value
=== RUN   TestDSNReformat/username:password@protocol(address)/dbname?param=value&columnsWithAlias=true
    dsn_test.go:135: 1. "username:password@protocol(address)/dbname?param=value&columnsWithAlias=true" reformated as "username:password@protocol(address)/dbname?columnsWithAlias=true&param=value"
=== RUN   TestDSNReformat/username:password@protocol(address)/dbname?param=value&columnsWithAlias=true&multiStatements=true
    dsn_test.go:135: 2. "username:password@protocol(address)/dbname?param=value&columnsWithAlias=true&multiStatements=true" reformated as "username:password@protocol(address)/dbname?columnsWithAlias=true&multiStatements=true&param=value"
=== RUN   TestDSNReformat/user@unix(/path/to/socket)/dbname?charset=utf8
=== RUN   TestDSNReformat/user:password@tcp(localhost:5555)/dbname?charset=utf8&tls=true
    dsn_test.go:135: 4. "user:password@tcp(localhost:5555)/dbname?charset=utf8&tls=true" reformated as "user:password@tcp(localhost:5555)/dbname?tls=true&charset=utf8"
=== RUN   TestDSNReformat/user:password@tcp(localhost:5555)/dbname?charset=utf8mb4,utf8&tls=skip-verify
    dsn_test.go:135: 5. "user:password@tcp(localhost:5555)/dbname?charset=utf8mb4,utf8&tls=skip-verify" reformated as "user:password@tcp(localhost:5555)/dbname?tls=skip-verify&charset=utf8mb4%2Cutf8"
=== RUN   TestDSNReformat/user:password@/dbname?loc=UTC&timeout=30s&readTimeout=1s&writeTimeout=1s&allowAllFiles=1&clientFoundRows=true&allowOldPasswords=TRUE&collation=utf8mb4_unicode_ci&maxAllowedPacket=16777216&tls=false&allowCleartextPasswords=true&parseTime=true&rejectReadOnly=true
    dsn_test.go:135: 6. "user:password@/dbname?loc=UTC&timeout=30s&readTimeout=1s&writeTimeout=1s&allowAllFiles=1&clientFoundRows=true&allowOldPasswords=TRUE&collation=utf8mb4_unicode_ci&maxAllowedPacket=16777216&tls=false&allowCleartextPasswords=true&parseTime=true&rejectReadOnly=true" reformated as "user:password@tcp(127.0.0.1:3306)/dbname?allowAllFiles=true&allowCleartextPasswords=true&allowOldPasswords=true&clientFoundRows=true&collation=utf8mb4_unicode_ci&parseTime=true&readTimeout=1s&rejectReadOnly=true&timeout=30s&tls=false&writeTimeout=1s&maxAllowedPacket=16777216"
=== RUN   TestDSNReformat/user:password@/dbname?allowNativePasswords=false&checkConnLiveness=false&maxAllowedPacket=0&allowFallbackToPlaintext=true
    dsn_test.go:135: 7. "user:password@/dbname?allowNativePasswords=false&checkConnLiveness=false&maxAllowedPacket=0&allowFallbackToPlaintext=true" reformated as "user:password@tcp(127.0.0.1:3306)/dbname?allowFallbackToPlaintext=true&allowNativePasswords=false&checkConnLiveness=false&maxAllowedPacket=0"
=== RUN   TestDSNReformat/user:p@ss(word)@tcp([de:ad:be:ef::ca:fe]:80)/dbname?loc=Local
=== RUN   TestDSNReformat//dbname
    dsn_test.go:135: 9. "/dbname" reformated as "tcp(127.0.0.1:3306)/dbname"
=== RUN   TestDSNReformat//dbname%2Fwithslash
    dsn_test.go:135: 10. "/dbname%2Fwithslash" reformated as "tcp(127.0.0.1:3306)/dbname%2Fwithslash"
=== RUN   TestDSNReformat/@/
    dsn_test.go:135: 11. "@/" reformated as "tcp(127.0.0.1:3306)/"
=== RUN   TestDSNReformat//
    dsn_test.go:135: 12. "/" reformated as "tcp(127.0.0.1:3306)/"
=== RUN   TestDSNReformat/#00
    dsn_test.go:135: 13. "" reformated as "tcp(127.0.0.1:3306)/"
=== RUN   TestDSNReformat/user:p@/ssword@/
    dsn_test.go:135: 14. "user:p@/ssword@/" reformated as "user:p@/ssword@tcp(127.0.0.1:3306)/"
=== RUN   TestDSNReformat/unix/?arg=%2Fsome%2Fpath.ext
    dsn_test.go:135: 15. "unix/?arg=%2Fsome%2Fpath.ext" reformated as "unix(/tmp/mysql.sock)/?arg=%2Fsome%2Fpath.ext"
=== RUN   TestDSNReformat/tcp(127.0.0.1)/dbname
    dsn_test.go:135: 16. "tcp(127.0.0.1)/dbname" reformated as "tcp(127.0.0.1:3306)/dbname"
=== RUN   TestDSNReformat/tcp(de:ad:be:ef::ca:fe)/dbname
    dsn_test.go:135: 17. "tcp(de:ad:be:ef::ca:fe)/dbname" reformated as "tcp([de:ad:be:ef::ca:fe]:3306)/dbname"
--- PASS: TestDSNReformat (0.00s)
    --- PASS: TestDSNReformat/username:password@protocol(address)/dbname?param=value (0.00s)
    --- PASS: TestDSNReformat/username:password@protocol(address)/dbname?param=value&columnsWithAlias=true (0.00s)
    --- PASS: TestDSNReformat/username:password@protocol(address)/dbname?param=value&columnsWithAlias=true&multiStatements=true (0.00s)
    --- PASS: TestDSNReformat/user@unix(/path/to/socket)/dbname?charset=utf8 (0.00s)
    --- PASS: TestDSNReformat/user:password@tcp(localhost:5555)/dbname?charset=utf8&tls=true (0.00s)
    --- PASS: TestDSNReformat/user:password@tcp(localhost:5555)/dbname?charset=utf8mb4,utf8&tls=skip-verify (0.00s)
    --- PASS: TestDSNReformat/user:password@/dbname?loc=UTC&timeout=30s&readTimeout=1s&writeTimeout=1s&allowAllFiles=1&clientFoundRows=true&allowOldPasswords=TRUE&collation=utf8mb4_unicode_ci&maxAllowedPacket=16777216&tls=false&allowCleartextPasswords=true&parseTime=true&rejectReadOnly=true (0.00s)
    --- PASS: TestDSNReformat/user:password@/dbname?allowNativePasswords=false&checkConnLiveness=false&maxAllowedPacket=0&allowFallbackToPlaintext=true (0.00s)
    --- PASS: TestDSNReformat/user:p@ss(word)@tcp([de:ad:be:ef::ca:fe]:80)/dbname?loc=Local (0.00s)
    --- PASS: TestDSNReformat//dbname (0.00s)
    --- PASS: TestDSNReformat//dbname%2Fwithslash (0.00s)
    --- PASS: TestDSNReformat/@/ (0.00s)
    --- PASS: TestDSNReformat// (0.00s)
    --- PASS: TestDSNReformat/#00 (0.00s)
    --- PASS: TestDSNReformat/user:p@/ssword@/ (0.00s)
    --- PASS: TestDSNReformat/unix/?arg=%2Fsome%2Fpath.ext (0.00s)
    --- PASS: TestDSNReformat/tcp(127.0.0.1)/dbname (0.00s)
    --- PASS: TestDSNReformat/tcp(de:ad:be:ef::ca:fe)/dbname (0.00s)
PASS
ok  	github.com/go-sql-driver/mysql	0.224s
```


### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Added myself / the copyright holder to the AUTHORS file
