### PR TITLE
Expose a MySQLConn interface for use with database/sql.Conn.Raw()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,6 +54,7 @@ Jeffrey Charles <jeffreycharles at gmail.com>
 Jerome Meyer <jxmeyer at gmail.com>
 Jiajia Zhong <zhong2plus at gmail.com>
 Jian Zhen <zhenjl at gmail.com>
+Jille Timmermans <jille at quis.cx>
 Joshua Prunier <joshua.prunier at gmail.com>
 Julien Lefevre <julien.lefevr at gmail.com>
 Julien Schmidt <go-sql-driver at julienschmidt.com>

--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,21 @@
+package mysql
+
+import (
+	"time"
+)
+
+// MySQLConn exposes the usable methods on driverConn given to database/sql.Conn.Raw.
+type MySQLConn interface {
+	// Prevent other modules from implementing this interface so we can keep adding methods.
+	isMySQLConn()
+
+	// Location gets the Config.Loc of this connection. (This may differ from `time_zone` connection variable.)
+	Location() *time.Location
+}
+
+func (mc *mysqlConn) isMySQLConn() {
+}
+
+func (mc *mysqlConn) Location() *time.Location {
+	return mc.cfg.Loc
+}

--- a/interface_test.go
+++ b/interface_test.go
@@ -1,0 +1,22 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+var _ MySQLConn = &mysqlConn{}
+
+func ExampleMySQLConn() {
+	db, _ := sql.Open("mysql", "root:pw@unix(/tmp/mysql.sock)/myDatabase?parseTime=true&loc=Europe%2FAmsterdam")
+	conn, _ := db.Conn(context.Background())
+	var location *time.Location
+	conn.Raw(func(dc any) error {
+		mc := dc.(MySQLConn)
+		location = mc.Location()
+		return nil
+	})
+	fmt.Println(location)
+}


### PR DESCRIPTION
Based on the design of @methane

We can later add a LoadLocalInfile() method instead of the Register...() functions.

for issue #1416

### Description
Please explain the changes you made here.

### Checklist
- [X] Code compiles correctly
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing
- [X] Extended the README / documentation, if necessary
- [X] Added myself / the copyright holder to the AUTHORS file
