### PR TITLE
conncheck: use unix.Poll instead of syscall.Read

### DIFF
--- a/conncheck.go
+++ b/conncheck.go
@@ -12,15 +12,12 @@
 package mysql
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"syscall"
 
 	"golang.org/x/sys/unix"
 )
-
-var errUnexpectedEvent = errors.New("recieved unexpected event")
 
 func connCheck(conn net.Conn) error {
 	sysConn, ok := conn.(syscall.Conn)

--- a/conncheck.go
+++ b/conncheck.go
@@ -13,16 +13,16 @@ package mysql
 
 import (
 	"errors"
-	"io"
+	"fmt"
 	"net"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
-var errUnexpectedRead = errors.New("unexpected read from socket")
+var errUnexpectedEvent = errors.New("recieved unexpected event")
 
 func connCheck(conn net.Conn) error {
-	var sysErr error
-
 	sysConn, ok := conn.(syscall.Conn)
 	if !ok {
 		return nil
@@ -32,24 +32,22 @@ func connCheck(conn net.Conn) error {
 		return err
 	}
 
-	err = rawConn.Read(func(fd uintptr) bool {
-		var buf [1]byte
-		n, err := syscall.Read(int(fd), buf[:])
-		switch {
-		case n == 0 && err == nil:
-			sysErr = io.EOF
-		case n > 0:
-			sysErr = errUnexpectedRead
-		case err == syscall.EAGAIN || err == syscall.EWOULDBLOCK:
-			sysErr = nil
-		default:
-			sysErr = err
+	var pollErr error
+	err = rawConn.Control(func(fd uintptr) {
+		fds := []unix.PollFd{
+			{Fd: int32(fd), Events: unix.POLLIN | unix.POLLERR},
 		}
-		return true
+		n, err := unix.Poll(fds, 0)
+		if err != nil {
+			pollErr = fmt.Errorf("poll: %w", err)
+		}
+		if n > 0 {
+			// fmt.Errorf("poll: %v", fds[0].Revents)
+			pollErr = errUnexpectedEvent
+		}
 	})
 	if err != nil {
 		return err
 	}
-
-	return sysErr
+	return pollErr
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/go-sql-driver/mysql
 
 go 1.18
+
+require golang.org/x/sys v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/packets.go
+++ b/packets.go
@@ -14,6 +14,7 @@ import (
 	"database/sql/driver"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -100,6 +101,9 @@ func (mc *mysqlConn) readPacket() ([]byte, error) {
 		prevData = append(prevData, data...)
 	}
 }
+
+// used in conncheck.go
+var errUnexpectedEvent = errors.New("recieved unexpected event")
 
 // Write packet buffer 'data'
 func (mc *mysqlConn) writePacket(data []byte) error {


### PR DESCRIPTION
### Description

connCheck() now uses Poll() to check netConn readability.
When some event is happened, try reading from the connection and log error as much as possible.

Fix #1392

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
