### PR TITLE
Make use of strings.Cut

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -38,13 +38,12 @@ func encodeConnectionAttributes(textAttributes string) string {
 
 	// user-defined connection attributes
 	for _, connAttr := range strings.Split(textAttributes, ",") {
-		attr := strings.SplitN(connAttr, ":", 2)
-		if len(attr) != 2 {
+		k, v, found := strings.Cut(connAttr, ":")
+		if !found {
 			continue
 		}
-		for _, v := range attr {
-			connAttrsBuf = appendLengthEncodedString(connAttrsBuf, v)
-		}
+		connAttrsBuf = appendLengthEncodedString(connAttrsBuf, k)
+		connAttrsBuf = appendLengthEncodedString(connAttrsBuf, v)
 	}
 
 	return string(connAttrsBuf)

--- a/dsn.go
+++ b/dsn.go
@@ -390,13 +390,13 @@ func ParseDSN(dsn string) (cfg *Config, err error) {
 // Values must be url.QueryEscape'ed
 func parseDSNParams(cfg *Config, params string) (err error) {
 	for _, v := range strings.Split(params, "&") {
-		param := strings.SplitN(v, "=", 2)
-		if len(param) != 2 {
+		key, value, found := strings.Cut(v, "=")
+		if !found {
 			continue
 		}
 
 		// cfg params
-		switch value := param[1]; param[0] {
+		switch key {
 		// Disable INFILE allowlist / enable all files
 		case "allowAllFiles":
 			var isBool bool
@@ -577,7 +577,7 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 				cfg.Params = make(map[string]string)
 			}
 
-			if cfg.Params[param[0]], err = url.QueryUnescape(value); err != nil {
+			if cfg.Params[key], err = url.QueryUnescape(value); err != nil {
 				return
 			}
 		}


### PR DESCRIPTION
### Description
Not in hot code paths, but reduces allocations and makes the code arguably clearer.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
