### PR TITLE
mark fail, mustExec and mustQuery as test helpers

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -165,6 +165,7 @@ func runTests(t *testing.T, dsn string, tests ...func(dbt *DBTest)) {
 }
 
 func (dbt *DBTest) fail(method, query string, err error) {
+	dbt.Helper()
 	if len(query) > 300 {
 		query = "[query too large to print]"
 	}
@@ -172,6 +173,7 @@ func (dbt *DBTest) fail(method, query string, err error) {
 }
 
 func (dbt *DBTest) mustExec(query string, args ...interface{}) (res sql.Result) {
+	dbt.Helper()
 	res, err := dbt.db.Exec(query, args...)
 	if err != nil {
 		dbt.fail("exec", query, err)
@@ -180,6 +182,7 @@ func (dbt *DBTest) mustExec(query string, args ...interface{}) (res sql.Result) 
 }
 
 func (dbt *DBTest) mustQuery(query string, args ...interface{}) (rows *sql.Rows) {
+	dbt.Helper()
 	rows, err := dbt.db.Query(query, args...)
 	if err != nil {
 		dbt.fail("query", query, err)


### PR DESCRIPTION
### Description

If an error occurs, `fail`, `mustExec`, and `mustQuery` report the line in the `fail` method where the error occurred.
For example, here is a broken test:

```diff
diff --git a/driver_test.go b/driver_test.go
index dd3d731..f7fab0d 100644
--- a/driver_test.go
+++ b/driver_test.go
@@ -198,6 +198,15 @@ func maybeSkip(t *testing.T, err error, skipErrno uint16) {
 	}
 }
 
+func TestMustFail(t *testing.T) {
+	runTests(t, dsn, func(dbt *DBTest) {
+		rows := dbt.mustQuery("WRONG QUERY")
+		defer rows.Close()
+		for rows.Next() {
+		}
+	})
+}
+
 func TestEmptyQuery(t *testing.T) {
 	runTests(t, dsn, func(dbt *DBTest) {
 		// just a comment, no query
```

The result of `go test` is:

```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestMustFail$ github.com/go-sql-driver/mysql -v -count=1 -race

=== RUN   TestMustFail
=== RUN   TestMustFail/default
    /Users/shogo/src/github.com/go-sql-driver/mysql/driver_test.go:171: error on query WRONG QUERY: Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'WRONG QUERY' at line 1
=== RUN   TestMustFail/interpolateParams
    /Users/shogo/src/github.com/go-sql-driver/mysql/driver_test.go:171: error on query WRONG QUERY: Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'WRONG QUERY' at line 1
--- FAIL: TestMustFail (0.03s)
    --- FAIL: TestMustFail/default (0.00s)
    --- FAIL: TestMustFail/interpolateParams (0.00s)
FAIL
FAIL	github.com/go-sql-driver/mysql	0.193s
```

`go test` reports `driver_test.go:171`. `driver_test.go:171` is here:

```go
func (dbt *DBTest) fail(method, query string, err error) {
	dbt.Helper()
	if len(query) > 300 {
		query = "[query too large to print]"
	}
	dbt.Fatalf("error on %s %s: %s", method, query, err.Error()) // <- go test reports this position.
}
```

By adding `dbt.Helper()`, the result of `go test` becomes:

```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestMustFail$ github.com/go-sql-driver/mysql -v -count=1 -race

=== RUN   TestMustFail
=== RUN   TestMustFail/default
    /Users/shogo/src/github.com/go-sql-driver/mysql/driver_test.go:206: error on query WRONG QUERY: Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'WRONG QUERY' at line 1
=== RUN   TestMustFail/interpolateParams
    /Users/shogo/src/github.com/go-sql-driver/mysql/driver_test.go:206: error on query WRONG QUERY: Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'WRONG QUERY' at line 1
--- FAIL: TestMustFail (0.03s)
    --- FAIL: TestMustFail/default (0.00s)
    --- FAIL: TestMustFail/interpolateParams (0.01s)
FAIL
FAIL	github.com/go-sql-driver/mysql	0.204s
```

```go
func TestMustFail(t *testing.T) {
	runTests(t, dsn, func(dbt *DBTest) {
		rows := dbt.mustQuery("WRONG QUERY") // <- go test reports this position.
		defer rows.Close()
		for rows.Next() {
		}
	})
}
```

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
