### PR TITLE
fix race condition of TestConcurrent

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -1872,7 +1872,6 @@ func TestConcurrent(t *testing.T) {
 				defer wg.Done()
 
 				tx, err := dbt.db.Begin()
-				atomic.AddInt32(&remaining, -1)
 
 				if err != nil {
 					if err.Error() != "Error 1040: Too many connections" {
@@ -1882,7 +1881,7 @@ func TestConcurrent(t *testing.T) {
 				}
 
 				// keep the connection busy until all connections are open
-				for remaining > 0 {
+				for atomic.AddInt32(&remaining, -1) > 0 {
 					if _, err = tx.Exec("DO 1"); err != nil {
 						fatalf("error on conn %d: %s", id, err.Error())
 						return


### PR DESCRIPTION
### Description

`TestConcurrent` fails with `-race` option:

```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestConcurrent$ github.com/go-sql-driver/mysql -v -count=1 -race

=== RUN   TestConcurrent
=== RUN   TestConcurrent/default
    /Users/shogo/src/github.com/go-sql-driver/mysql/driver_test.go:1855: testing up to 151 concurrent connections
==================
WARNING: DATA RACE
Write at 0x00c0001322dc by goroutine 34:
  ??()
      -:0 +0x102747724
  sync/atomic.AddInt32()
      <autogenerated>:1 +0x14
  github.com/go-sql-driver/mysql.TestConcurrent.func1.3()
      /Users/shogo/src/github.com/go-sql-driver/mysql/driver_test.go:1899 +0x44

Previous read at 0x00c0001322dc by goroutine 68:
  github.com/go-sql-driver/mysql.TestConcurrent.func1.2()
      /Users/shogo/src/github.com/go-sql-driver/mysql/driver_test.go:1885 +0x220
  github.com/go-sql-driver/mysql.TestConcurrent.func1.3()
      /Users/shogo/src/github.com/go-sql-driver/mysql/driver_test.go:1899 +0x44

Goroutine 34 (running) created at:
  github.com/go-sql-driver/mysql.TestConcurrent.func1()
      /Users/shogo/src/github.com/go-sql-driver/mysql/driver_test.go:1871 +0x300
  github.com/go-sql-driver/mysql.runTests.func1()
      /Users/shogo/src/github.com/go-sql-driver/mysql/driver_test.go:154 +0xd4
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1648 +0x40

Goroutine 68 (running) created at:
  github.com/go-sql-driver/mysql.TestConcurrent.func1()
      /Users/shogo/src/github.com/go-sql-driver/mysql/driver_test.go:1871 +0x300
  github.com/go-sql-driver/mysql.runTests.func1()
      /Users/shogo/src/github.com/go-sql-driver/mysql/driver_test.go:154 +0xd4
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1648 +0x40
==================
    /Users/shogo/src/github.com/go-sql-driver/mysql/driver_test.go:1909: reached 151 concurrent connections
    /Users/shogo/src/github.com/go-sql-driver/mysql/testing.go:1465: race detected during execution of test
=== RUN   TestConcurrent/interpolateParams
    /Users/shogo/src/github.com/go-sql-driver/mysql/driver_test.go:1855: testing up to 151 concurrent connections
    /Users/shogo/src/github.com/go-sql-driver/mysql/driver_test.go:1909: reached 150 concurrent connections
    /Users/shogo/src/github.com/go-sql-driver/mysql/testing.go:1465: race detected during execution of test
--- FAIL: TestConcurrent (0.21s)
    --- FAIL: TestConcurrent/default (0.11s)
    --- PASS: TestConcurrent/interpolateParams (0.06s)
    /Users/shogo/src/github.com/go-sql-driver/mysql/testing.go:1465: race detected during execution of test
FAIL
FAIL	github.com/go-sql-driver/mysql	0.669s
```

This pull request fixes it.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
