### PR TITLE
testing: expose testing.TB in DBTest instead of full *testing.T

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -82,7 +82,7 @@ func init() {
 }
 
 type DBTest struct {
-	*testing.T
+	testing.TB
 	db *sql.DB
 }
 


### PR DESCRIPTION
We don't need the full `testing.T` methods when running a test with DBTest.

So let's reduce the methods exposed by DBTest to the subset of [`testing.T`](https://pkg.go.dev/testing#T) exposed in the [`testing.TB`](https://pkg.go.dev/testing#TB) interface.

### Description
DBTest is now a wrapper of `testing.TB` instead of `*testing.T`.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Added myself / the copyright holder to the AUTHORS file
