### PR TITLE
Add default connection attribute '_server_host'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,6 +49,7 @@ INADA Naoki <songofacandy at gmail.com>
 Jacek Szwec <szwec.jacek at gmail.com>
 James Harr <james.harr at gmail.com>
 Janek Vedock <janekvedock at comcast.net>
+Jason Ng <oblitorum at gmail.com>
 Jean-Yves Pellé <jy at pelle.link>
 Jeff Hodges <jeff at somethingsimilar.com>
 Jeffrey Charles <jeffreycharles at gmail.com>
@@ -128,6 +129,7 @@ Keybase Inc.
 Multiplay Ltd.
 Percona LLC
 Pivotal Inc.
+Shattered Silicon Ltd.
 Stripe Inc.
 Zendesk Inc.
 Dolthub Inc.

--- a/connector.go
+++ b/connector.go
@@ -22,7 +22,7 @@ type connector struct {
 	encodedAttributes string  // Encoded connection attributes.
 }
 
-func encodeConnectionAttributes(textAttributes string) string {
+func encodeConnectionAttributes(cfg *Config) string {
 	connAttrsBuf := make([]byte, 0)
 
 	// default connection attributes
@@ -34,9 +34,12 @@ func encodeConnectionAttributes(textAttributes string) string {
 	connAttrsBuf = appendLengthEncodedString(connAttrsBuf, connAttrPlatformValue)
 	connAttrsBuf = appendLengthEncodedString(connAttrsBuf, connAttrPid)
 	connAttrsBuf = appendLengthEncodedString(connAttrsBuf, strconv.Itoa(os.Getpid()))
+	connAttrsBuf = appendLengthEncodedString(connAttrsBuf, connAttrServerHost)
+	serverHost, _, _ := net.SplitHostPort(cfg.Addr)
+	connAttrsBuf = appendLengthEncodedString(connAttrsBuf, serverHost)
 
 	// user-defined connection attributes
-	for _, connAttr := range strings.Split(textAttributes, ",") {
+	for _, connAttr := range strings.Split(cfg.ConnectionAttributes, ",") {
 		k, v, found := strings.Cut(connAttr, ":")
 		if !found {
 			continue
@@ -49,7 +52,7 @@ func encodeConnectionAttributes(textAttributes string) string {
 }
 
 func newConnector(cfg *Config) *connector {
-	encodedAttributes := encodeConnectionAttributes(cfg.ConnectionAttributes)
+	encodedAttributes := encodeConnectionAttributes(cfg)
 	return &connector{
 		cfg:               cfg,
 		encodedAttributes: encodedAttributes,

--- a/connector.go
+++ b/connector.go
@@ -34,9 +34,11 @@ func encodeConnectionAttributes(cfg *Config) string {
 	connAttrsBuf = appendLengthEncodedString(connAttrsBuf, connAttrPlatformValue)
 	connAttrsBuf = appendLengthEncodedString(connAttrsBuf, connAttrPid)
 	connAttrsBuf = appendLengthEncodedString(connAttrsBuf, strconv.Itoa(os.Getpid()))
-	connAttrsBuf = appendLengthEncodedString(connAttrsBuf, connAttrServerHost)
 	serverHost, _, _ := net.SplitHostPort(cfg.Addr)
-	connAttrsBuf = appendLengthEncodedString(connAttrsBuf, serverHost)
+	if serverHost != "" {
+		connAttrsBuf = appendLengthEncodedString(connAttrsBuf, connAttrServerHost)
+		connAttrsBuf = appendLengthEncodedString(connAttrsBuf, serverHost)
+	}
 
 	// user-defined connection attributes
 	for _, connAttr := range strings.Split(cfg.ConnectionAttributes, ",") {

--- a/connector.go
+++ b/connector.go
@@ -11,7 +11,6 @@ package mysql
 import (
 	"context"
 	"database/sql/driver"
-	"fmt"
 	"net"
 	"os"
 	"strconv"
@@ -24,7 +23,7 @@ type connector struct {
 }
 
 func encodeConnectionAttributes(textAttributes string) string {
-	connAttrsBuf := make([]byte, 0, 251)
+	connAttrsBuf := make([]byte, 0)
 
 	// default connection attributes
 	connAttrsBuf = appendLengthEncodedString(connAttrsBuf, connAttrClientName)
@@ -49,15 +48,12 @@ func encodeConnectionAttributes(textAttributes string) string {
 	return string(connAttrsBuf)
 }
 
-func newConnector(cfg *Config) (*connector, error) {
+func newConnector(cfg *Config) *connector {
 	encodedAttributes := encodeConnectionAttributes(cfg.ConnectionAttributes)
-	if len(encodedAttributes) > 250 {
-		return nil, fmt.Errorf("connection attributes are longer than 250 bytes: %dbytes (%q)", len(encodedAttributes), cfg.ConnectionAttributes)
-	}
 	return &connector{
 		cfg:               cfg,
 		encodedAttributes: encodedAttributes,
-	}, nil
+	}
 }
 
 // Connect implements driver.Connector interface.

--- a/connector_test.go
+++ b/connector_test.go
@@ -8,16 +8,13 @@ import (
 )
 
 func TestConnectorReturnsTimeout(t *testing.T) {
-	connector, err := newConnector(&Config{
+	connector := newConnector(&Config{
 		Net:     "tcp",
 		Addr:    "1.1.1.1:1234",
 		Timeout: 10 * time.Millisecond,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	_, err = connector.Connect(context.Background())
+	_, err := connector.Connect(context.Background())
 	if err == nil {
 		t.Fatal("error expected")
 	}

--- a/const.go
+++ b/const.go
@@ -26,6 +26,7 @@ const (
 	connAttrPlatform        = "_platform"
 	connAttrPlatformValue   = runtime.GOARCH
 	connAttrPid             = "_pid"
+	connAttrServerHost      = "_server_host"
 )
 
 // MySQL constants documentation:

--- a/driver.go
+++ b/driver.go
@@ -83,10 +83,7 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	c, err := newConnector(cfg)
-	if err != nil {
-		return nil, err
-	}
+	c := newConnector(cfg)
 	return c.Connect(context.Background())
 }
 
@@ -108,7 +105,7 @@ func NewConnector(cfg *Config) (driver.Connector, error) {
 	if err := cfg.normalize(); err != nil {
 		return nil, err
 	}
-	return newConnector(cfg)
+	return newConnector(cfg), nil
 }
 
 // OpenConnector implements driver.DriverContext.
@@ -117,5 +114,5 @@ func (d MySQLDriver) OpenConnector(dsn string) (driver.Connector, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newConnector(cfg)
+	return newConnector(cfg), nil
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -3377,11 +3378,31 @@ func TestConnectionAttributes(t *testing.T) {
 		t.Skipf("MySQL server not running on %s", netAddr)
 	}
 
-	attr1 := "attr1"
-	value1 := "value1"
-	attr2 := "foo"
-	value2 := "boo"
-	dsn += fmt.Sprintf("&connectionAttributes=%s:%s,%s:%s", attr1, value1, attr2, value2)
+	defaultAttrs := []string{
+		connAttrClientName,
+		connAttrOS,
+		connAttrPlatform,
+		connAttrPid,
+		connAttrServerHost,
+	}
+	host, _, _ := net.SplitHostPort(addr)
+	defaultAttrValues := []string{
+		connAttrClientNameValue,
+		connAttrOSValue,
+		connAttrPlatformValue,
+		strconv.Itoa(os.Getpid()),
+		host,
+	}
+
+	customAttrs := []string{"attr1", "attr2"}
+	customAttrValues := []string{"foo", "bar"}
+
+	customAttrStrs := make([]string, len(customAttrs))
+	for i := range customAttrs {
+		customAttrStrs[i] = fmt.Sprintf("%s:%s", customAttrs[i], customAttrValues[i])
+	}
+
+	dsn += fmt.Sprintf("&connectionAttributes=%s", strings.Join(customAttrStrs, ","))
 
 	var db *sql.DB
 	if _, err := ParseDSN(dsn); err != errInvalidDSNUnsafeCollation {
@@ -3394,27 +3415,22 @@ func TestConnectionAttributes(t *testing.T) {
 
 	dbt := &DBTest{t, db}
 
-	var attrValue string
-	queryString := "SELECT ATTR_VALUE FROM performance_schema.session_account_connect_attrs WHERE PROCESSLIST_ID = CONNECTION_ID() and ATTR_NAME = ?"
-	rows := dbt.mustQuery(queryString, connAttrClientName)
-	if rows.Next() {
-		rows.Scan(&attrValue)
-		if attrValue != connAttrClientNameValue {
-			dbt.Errorf("expected %q, got %q", connAttrClientNameValue, attrValue)
-		}
-	} else {
-		dbt.Errorf("no data")
-	}
-	rows.Close()
+	queryString := "SELECT ATTR_NAME, ATTR_VALUE FROM performance_schema.session_account_connect_attrs WHERE PROCESSLIST_ID = CONNECTION_ID()"
+	rows := dbt.mustQuery(queryString)
+	defer rows.Close()
 
-	rows = dbt.mustQuery(queryString, attr2)
-	if rows.Next() {
-		rows.Scan(&attrValue)
-		if attrValue != value2 {
-			dbt.Errorf("expected %q, got %q", value2, attrValue)
-		}
-	} else {
-		dbt.Errorf("no data")
+	rowsMap := make(map[string]string)
+	for rows.Next() {
+		var attrName, attrValue string
+		rows.Scan(&attrName, &attrValue)
+		rowsMap[attrName] = attrValue
 	}
-	rows.Close()
+
+	connAttrs := append(append([]string{}, defaultAttrs...), customAttrs...)
+	expectedAttrValues := append(append([]string{}, defaultAttrValues...), customAttrValues...)
+	for i := range connAttrs {
+		if gotValue := rowsMap[connAttrs[i]]; gotValue != expectedAttrValues[i] {
+			dbt.Errorf("expected %s, got %s", expectedAttrValues[i], gotValue)
+		}
+	}
 }

--- a/packets_test.go
+++ b/packets_test.go
@@ -96,10 +96,7 @@ var _ net.Conn = new(mockConn)
 
 func newRWMockConn(sequence uint8) (*mockConn, *mysqlConn) {
 	conn := new(mockConn)
-	connector, err := newConnector(NewConfig())
-	if err != nil {
-		panic(err)
-	}
+	connector := newConnector(NewConfig())
 	mc := &mysqlConn{
 		buf:              newBuffer(conn),
 		cfg:              connector.cfg,


### PR DESCRIPTION
### Description

This PR refers to #1389 @Daemonxiao 

The mainly 2 changes in this PR are:

- Add support for length coded connection attributes, previously it only support 250 bytes connection attributes at maxmium.
- Add default connection attribute `_server_host` (the hostname of the server it's connecting to)

The `_server_host` connection attribute is supported in MariaDB (Connector/C) -> https://mariadb.com/kb/en/mysql_optionsv/#connection-attribute-options , and their official Connectors:

- Connector/J -> https://github.com/mariadb-corporation/mariadb-connector-j/blob/master/src/main/java/org/mariadb/jdbc/message/client/HandshakeResponse.java#L29

- Connector/nodejs -> https://github.com/mariadb-corporation/mariadb-connector-nodejs/blob/25655d9f58eec6baf0e0cf272a7da8987ecad85c/lib/cmd/handshake/auth/handshake.js#L140

- Connector/r2dbc -> https://github.com/mariadb-corporation/mariadb-connector-r2dbc/blob/4f9385fd9cabcab4557c1f228cfdafa4a3a27ce2/src/main/java/org/mariadb/r2dbc/message/client/HandshakeResponse.java#L173

The reason it would be nice to have this connection attribute by default is that I found some DBaaS (Database-as-a-Service) platforms are already taking advantage of it, well, at lease [Azure Database for MariaDB](https://azure.microsoft.com/en-us/products/mariadb)

For example, after you create a database instance on those platforms, they will assign a domain to that instance, e.g. `ssm-dev.mariadb.database.azure.com`, so you can connect to the database server with:

```shell
mysql -h ssm-dev.mariadb.database.azure.com ...
```

but the ip resolved from that domain could be common used for other domains, they need to know which database instance you are connecting to, so you have to sepecify the instance name (servername) with the database user in this format `username@servername`, as describe in https://learn.microsoft.com/en-us/azure/mariadb/howto-connection-string. Which is not very user-friendly for both developers or end-users.

But if your mysql/mariadb client/connector sends the `_server_host` connection attribute, they could know which database instance you are connecting to from there, so you don't need to enter the database user as `username@servername` anymore.

For that I believe a default connection attribute '_server_host' is really helpful.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file

@gordan-bobic