### PR TITLE
 symbol removed from installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A MySQL-Driver for Go's [database/sql](https://golang.org/pkg/database/sql/) pac
 ## Installation
 Simple install the package to your [$GOPATH](https://github.com/golang/go/wiki/GOPATH "GOPATH") with the [go tool](https://golang.org/cmd/go/ "go command") from shell:
 ```bash
-$ go get -u github.com/go-sql-driver/mysql
+go get -u github.com/go-sql-driver/mysql
 ```
 Make sure [Git is installed](https://git-scm.com/downloads) on your machine and in your system's `PATH`.
 


### PR DESCRIPTION
### Description
closes https://github.com/go-sql-driver/mysql/issues/1509
Additional "$" symbol in installation command which is copied so command fails. It does not affect installation or any part of code.
