### PR TITLE
Add client_ed25519 authentication

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,6 +39,7 @@ Evan Elias <evan at skeema.net>
 Evan Shaw <evan at vendhq.com>
 Frederick Mayle <frederickmayle at gmail.com>
 Gustavo Kristic <gkristic at gmail.com>
+Gusted <postmaster at gusted.xyz>
 Hajime Nakagami <nakagami at gmail.com>
 Hanno Braun <mail at hannobraun.com>
 Henri Yandell <flamefew at gmail.com>

--- a/driver_test.go
+++ b/driver_test.go
@@ -3181,14 +3181,14 @@ func TestRawBytesAreNotModified(t *testing.T) {
 
 				rows, err := dbt.db.QueryContext(ctx, `SELECT id, value FROM test`)
 				if err != nil {
-					t.Fatal(err)
+					dbt.Fatal(err)
 				}
 
 				var b int
 				var raw sql.RawBytes
 				for rows.Next() {
 					if err := rows.Scan(&b, &raw); err != nil {
-						t.Fatal(err)
+						dbt.Fatal(err)
 					}
 
 					before := string(raw)
@@ -3198,7 +3198,7 @@ func TestRawBytesAreNotModified(t *testing.T) {
 					after := string(raw)
 
 					if before != after {
-						t.Fatalf("the backing storage for sql.RawBytes has been modified (i=%v)", i)
+						dbt.Fatalf("the backing storage for sql.RawBytes has been modified (i=%v)", i)
 					}
 				}
 				rows.Close()

--- a/driver_test.go
+++ b/driver_test.go
@@ -165,14 +165,14 @@ func runTests(t *testing.T, dsn string, tests ...func(dbt *DBTest)) {
 	for _, test := range tests {
 		t.Run("default", func(t *testing.T) {
 			dbt := &DBTest{t, db}
+			defer dbt.db.Exec("DROP TABLE IF EXISTS test")
 			test(dbt)
-			dbt.db.Exec("DROP TABLE IF EXISTS test")
 		})
 		if db2 != nil {
 			t.Run("interpolateParams", func(t *testing.T) {
 				dbt2 := &DBTest{t, db2}
+				defer dbt2.db.Exec("DROP TABLE IF EXISTS test")
 				test(dbt2)
-				dbt2.db.Exec("DROP TABLE IF EXISTS test")
 			})
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/go-sql-driver/mysql
 
 go 1.18
+
+require filippo.io/edwards25519 v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=


### PR DESCRIPTION

### Description
Implements the necessary client code for [ed25519 authentication](https://mariadb.com/kb/en/authentication-plugin-ed25519/). A continuation of https://github.com/go-sql-driver/mysql/pull/1220, but doesn't use CGO. This patch uses https://filippo.io/edwards25519 to implement the crypto bits. The standard library `crypto/ed25519` cannot be used as MariaDB chose a scheme that is simply not compatible with what the standard library provides. 

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Implemented support for "client_ed25519" authentication plugin to enhance security.

- **Bug Fixes**
  - Improved error handling in test functions for more accurate error reporting.

- **Tests**
  - Added new test cases for Ed25519 authentication process.

- **Documentation**
  - Updated the `AUTHORS` file to acknowledge a new contributor.

- **Refactor**
  - Replaced `doEd25519Auth` function with a more robust `authEd25519` function.
  - Streamlined cleanup process in tests with deferred table drop execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->