### PR TITLE
fix fragile test

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -117,6 +117,8 @@ func runTestsWithMultiStatement(t *testing.T, dsn string, tests ...func(dbt *DBT
 		}
 		defer db.Close()
 	}
+	// Previous test may be skipped without dropping the test table
+	db.Exec("DROP TABLE IF EXISTS test")
 
 	dbt := &DBTest{t, db}
 	for _, test := range tests {
@@ -136,6 +138,7 @@ func runTests(t *testing.T, dsn string, tests ...func(dbt *DBTest)) {
 	}
 	defer db.Close()
 
+	// Previous test may be skipped without dropping the test table
 	db.Exec("DROP TABLE IF EXISTS test")
 
 	dsn2 := dsn + "&interpolateParams=true"


### PR DESCRIPTION
### Description

CI randomely fails like this:

```
driver_test.go:2573: error on exec CREATE TABLE test (v INTEGER): Error 1050 (42S01): Table 'test' already exists
```

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved test scripts with additional comments and pre-test cleanup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->