### PR TITLE
Specify a custom dial function per config

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -87,20 +87,30 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 	mc.parseTime = mc.cfg.ParseTime
 
 	// Connect to Server
-	dialsLock.RLock()
-	dial, ok := dials[mc.cfg.Net]
-	dialsLock.RUnlock()
-	if ok {
+	if c.cfg.DialFunc != nil {
 		dctx := ctx
 		if mc.cfg.Timeout > 0 {
 			var cancel context.CancelFunc
 			dctx, cancel = context.WithTimeout(ctx, c.cfg.Timeout)
 			defer cancel()
 		}
-		mc.netConn, err = dial(dctx, mc.cfg.Addr)
+		mc.netConn, err = c.cfg.DialFunc(dctx, mc.cfg.Net, mc.cfg.Addr)
 	} else {
-		nd := net.Dialer{Timeout: mc.cfg.Timeout}
-		mc.netConn, err = nd.DialContext(ctx, mc.cfg.Net, mc.cfg.Addr)
+		dialsLock.RLock()
+		dial, ok := dials[mc.cfg.Net]
+		dialsLock.RUnlock()
+		if ok {
+			dctx := ctx
+			if mc.cfg.Timeout > 0 {
+				var cancel context.CancelFunc
+				dctx, cancel = context.WithTimeout(ctx, c.cfg.Timeout)
+				defer cancel()
+			}
+			mc.netConn, err = dial(dctx, mc.cfg.Addr)
+		} else {
+			nd := net.Dialer{Timeout: mc.cfg.Timeout}
+			mc.netConn, err = nd.DialContext(ctx, mc.cfg.Net, mc.cfg.Addr)
+		}
 	}
 	if err != nil {
 		return nil, err

--- a/connector.go
+++ b/connector.go
@@ -87,29 +87,24 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 	mc.parseTime = mc.cfg.ParseTime
 
 	// Connect to Server
+	dctx := ctx
+	if mc.cfg.Timeout > 0 {
+		var cancel context.CancelFunc
+		dctx, cancel = context.WithTimeout(ctx, c.cfg.Timeout)
+		defer cancel()
+	}
+
 	if c.cfg.DialFunc != nil {
-		dctx := ctx
-		if mc.cfg.Timeout > 0 {
-			var cancel context.CancelFunc
-			dctx, cancel = context.WithTimeout(ctx, c.cfg.Timeout)
-			defer cancel()
-		}
 		mc.netConn, err = c.cfg.DialFunc(dctx, mc.cfg.Net, mc.cfg.Addr)
 	} else {
 		dialsLock.RLock()
 		dial, ok := dials[mc.cfg.Net]
 		dialsLock.RUnlock()
 		if ok {
-			dctx := ctx
-			if mc.cfg.Timeout > 0 {
-				var cancel context.CancelFunc
-				dctx, cancel = context.WithTimeout(ctx, c.cfg.Timeout)
-				defer cancel()
-			}
 			mc.netConn, err = dial(dctx, mc.cfg.Addr)
 		} else {
-			nd := net.Dialer{Timeout: mc.cfg.Timeout}
-			mc.netConn, err = nd.DialContext(ctx, mc.cfg.Net, mc.cfg.Addr)
+			nd := net.Dialer{}
+			mc.netConn, err = nd.DialContext(dctx, mc.cfg.Net, mc.cfg.Addr)
 		}
 	}
 	if err != nil {

--- a/dsn.go
+++ b/dsn.go
@@ -37,25 +37,26 @@ var (
 type Config struct {
 	// non boolean fields
 
-	User                 string                                                            // Username
-	Passwd               string                                                            // Password (requires User)
-	Net                  string                                                            // Network (e.g. "tcp", "tcp6", "unix". default: "tcp")
-	Addr                 string                                                            // Address (default: "127.0.0.1:3306" for "tcp" and "/tmp/mysql.sock" for "unix")
-	DBName               string                                                            // Database name
-	Params               map[string]string                                                 // Connection parameters
-	ConnectionAttributes string                                                            // Connection Attributes, comma-delimited string of user-defined "key:value" pairs
-	charsets             []string                                                          // Connection charset. When set, this will be set in SET NAMES <charset> query
-	Collation            string                                                            // Connection collation. When set, this will be set in SET NAMES <charset> COLLATE <collation> query
-	Loc                  *time.Location                                                    // Location for time.Time values
-	MaxAllowedPacket     int                                                               // Max packet size allowed
-	ServerPubKey         string                                                            // Server public key name
-	TLSConfig            string                                                            // TLS configuration name
-	TLS                  *tls.Config                                                       // TLS configuration, its priority is higher than TLSConfig
-	Timeout              time.Duration                                                     // Dial timeout
-	ReadTimeout          time.Duration                                                     // I/O read timeout
-	WriteTimeout         time.Duration                                                     // I/O write timeout
-	Logger               Logger                                                            // Logger
-	DialFunc             func(ctx context.Context, network, addr string) (net.Conn, error) // Specifies the dial function for creating connections
+	User                 string            // Username
+	Passwd               string            // Password (requires User)
+	Net                  string            // Network (e.g. "tcp", "tcp6", "unix". default: "tcp")
+	Addr                 string            // Address (default: "127.0.0.1:3306" for "tcp" and "/tmp/mysql.sock" for "unix")
+	DBName               string            // Database name
+	Params               map[string]string // Connection parameters
+	ConnectionAttributes string            // Connection Attributes, comma-delimited string of user-defined "key:value" pairs
+	charsets             []string          // Connection charset. When set, this will be set in SET NAMES <charset> query
+	Collation            string            // Connection collation. When set, this will be set in SET NAMES <charset> COLLATE <collation> query
+	Loc                  *time.Location    // Location for time.Time values
+	MaxAllowedPacket     int               // Max packet size allowed
+	ServerPubKey         string            // Server public key name
+	TLSConfig            string            // TLS configuration name
+	TLS                  *tls.Config       // TLS configuration, its priority is higher than TLSConfig
+	Timeout              time.Duration     // Dial timeout
+	ReadTimeout          time.Duration     // I/O read timeout
+	WriteTimeout         time.Duration     // I/O write timeout
+	Logger               Logger            // Logger
+	// DialFunc specifies the dial function for creating connections
+	DialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
 
 	// boolean fields
 

--- a/dsn.go
+++ b/dsn.go
@@ -37,24 +37,25 @@ var (
 type Config struct {
 	// non boolean fields
 
-	User                 string            // Username
-	Passwd               string            // Password (requires User)
-	Net                  string            // Network (e.g. "tcp", "tcp6", "unix". default: "tcp")
-	Addr                 string            // Address (default: "127.0.0.1:3306" for "tcp" and "/tmp/mysql.sock" for "unix")
-	DBName               string            // Database name
-	Params               map[string]string // Connection parameters
-	ConnectionAttributes string            // Connection Attributes, comma-delimited string of user-defined "key:value" pairs
-	charsets             []string          // Connection charset. When set, this will be set in SET NAMES <charset> query
-	Collation            string            // Connection collation. When set, this will be set in SET NAMES <charset> COLLATE <collation> query
-	Loc                  *time.Location    // Location for time.Time values
-	MaxAllowedPacket     int               // Max packet size allowed
-	ServerPubKey         string            // Server public key name
-	TLSConfig            string            // TLS configuration name
-	TLS                  *tls.Config       // TLS configuration, its priority is higher than TLSConfig
-	Timeout              time.Duration     // Dial timeout
-	ReadTimeout          time.Duration     // I/O read timeout
-	WriteTimeout         time.Duration     // I/O write timeout
-	Logger               Logger            // Logger
+	User                 string                                                            // Username
+	Passwd               string                                                            // Password (requires User)
+	Net                  string                                                            // Network (e.g. "tcp", "tcp6", "unix". default: "tcp")
+	Addr                 string                                                            // Address (default: "127.0.0.1:3306" for "tcp" and "/tmp/mysql.sock" for "unix")
+	DBName               string                                                            // Database name
+	Params               map[string]string                                                 // Connection parameters
+	ConnectionAttributes string                                                            // Connection Attributes, comma-delimited string of user-defined "key:value" pairs
+	charsets             []string                                                          // Connection charset. When set, this will be set in SET NAMES <charset> query
+	Collation            string                                                            // Connection collation. When set, this will be set in SET NAMES <charset> COLLATE <collation> query
+	Loc                  *time.Location                                                    // Location for time.Time values
+	MaxAllowedPacket     int                                                               // Max packet size allowed
+	ServerPubKey         string                                                            // Server public key name
+	TLSConfig            string                                                            // TLS configuration name
+	TLS                  *tls.Config                                                       // TLS configuration, its priority is higher than TLSConfig
+	Timeout              time.Duration                                                     // Dial timeout
+	ReadTimeout          time.Duration                                                     // I/O read timeout
+	WriteTimeout         time.Duration                                                     // I/O write timeout
+	Logger               Logger                                                            // Logger
+	DialFunc             func(ctx context.Context, network, addr string) (net.Conn, error) // Specifies the dial function for creating connections
 
 	// boolean fields
 


### PR DESCRIPTION
### Description
Specify a custom dial function per config instead of using RegisterDialContext. It's hard to bind different state infomation for dialing with `RegisterDialContext`. Like SSH tunneling, if we want to use diffrent SSH connections, unique `net` for RegisterDialContext is required If I'm not wrong.

Use cases:
1. SSH tunneling per `Config`/`dsn`

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a configurable network connection handling feature, allowing users to specify custom methods for establishing network connections.
	- Added a new `DialFunc` field in the `Config` struct for enhanced control over connection establishment.
- **Bug Fixes**
	- Improved error handling during connection attempts, ensuring consistent timeout application across different dialing methods.
- **Documentation**
	- Updated `Config` struct documentation to reflect the addition of the `DialFunc` field, enabling more controlled connection processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->