### PR TITLE
Introduce `timeTruncate` parameter for `time.Time` arguments

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -86,6 +86,7 @@ Oliver Bone <owbone at github.com>
 Olivier Mengué <dolmen at cpan.org>
 oscarzhao <oscarzhaosl at gmail.com>
 Paul Bonser <misterpib at gmail.com>
+Paulius Lozys <pauliuslozys at gmail.com>
 Peter Schultz <peter.schultz at classmarkets.com>
 Phil Porada <philporada at gmail.com>
 Rebecca Chin <rchin at pivotal.io>

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Type:           duration
 Default:        0
 ```
 
-Truncate time values to the specified duration. The value must be a decimal number with a unit suffix (*"ms"*, *"s"*, *"m"*, *"h"*), such as *"30s"*, *"0.5m"* or *"1m30s"*.
+[Truncate time values](https://pkg.go.dev/time#Duration.Truncate) to the specified duration. The value must be a decimal number with a unit suffix (*"ms"*, *"s"*, *"m"*, *"h"*), such as *"30s"*, *"0.5m"* or *"1m30s"*.
 
 ##### `maxAllowedPacket`
 ```

--- a/README.md
+++ b/README.md
@@ -285,6 +285,15 @@ Note that this sets the location for time.Time values but does not change MySQL'
 
 Please keep in mind, that param values must be [url.QueryEscape](https://golang.org/pkg/net/url/#QueryEscape)'ed. Alternatively you can manually replace the `/` with `%2F`. For example `US/Pacific` would be `loc=US%2FPacific`.
 
+##### `timeTruncate`
+
+```
+Type:           duration
+Default:        0
+```
+
+Truncate time values to the specified duration. The value must be a decimal number with a unit suffix (*"ms"*, *"s"*, *"m"*, *"h"*), such as *"30s"*, *"0.5m"* or *"1m30s"*.
+
 ##### `maxAllowedPacket`
 ```
 Type:          decimal number

--- a/connection.go
+++ b/connection.go
@@ -251,7 +251,7 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 				buf = append(buf, "'0000-00-00'"...)
 			} else {
 				buf = append(buf, '\'')
-				buf, err = appendDateTime(buf, v.In(mc.cfg.Loc))
+				buf, err = appendDateTime(buf, v.In(mc.cfg.Loc), mc.cfg.TimeTruncate)
 				if err != nil {
 					return "", err
 				}

--- a/dsn.go
+++ b/dsn.go
@@ -48,6 +48,7 @@ type Config struct {
 	pubKey               *rsa.PublicKey    // Server public key
 	TLSConfig            string            // TLS configuration name
 	TLS                  *tls.Config       // TLS configuration, its priority is higher than TLSConfig
+	TimeTruncate         time.Duration     // Truncate time.Time values to the specified duration
 	Timeout              time.Duration     // Dial timeout
 	ReadTimeout          time.Duration     // I/O read timeout
 	WriteTimeout         time.Duration     // I/O write timeout
@@ -260,6 +261,10 @@ func (cfg *Config) FormatDSN() string {
 
 	if cfg.ParseTime {
 		writeDSNParam(&buf, &hasParam, "parseTime", "true")
+	}
+
+	if cfg.TimeTruncate > 0 {
+		writeDSNParam(&buf, &hasParam, "timeTruncate", cfg.TimeTruncate.String())
 	}
 
 	if cfg.ReadTimeout > 0 {
@@ -500,6 +505,13 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			cfg.ParseTime, isBool = readBool(value)
 			if !isBool {
 				return errors.New("invalid bool value: " + value)
+			}
+
+		// time.Time truncation
+		case "timeTruncate":
+			cfg.TimeTruncate, err = time.ParseDuration(value)
+			if err != nil {
+				return
 			}
 
 		// I/O read Timeout

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -76,7 +76,7 @@ var testDSNs = []struct {
 	&Config{Net: "tcp", Addr: "[de:ad:be:ef::ca:fe]:3306", DBName: "dbname", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, Logger: defaultLogger, AllowNativePasswords: true, CheckConnLiveness: true},
 }, {
 	"user:password@/dbname?loc=UTC&timeout=30s&parseTime=true&timeTruncate=1h",
-	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Loc: time.UTC, Timeout: 30 * time.Second, ParseTime: true, TimeTruncate: time.Hour},
+	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Loc: time.UTC, Timeout: 30 * time.Second, ParseTime: true, MaxAllowedPacket: defaultMaxAllowedPacket, Logger: defaultLogger, AllowNativePasswords: true, CheckConnLiveness: true, TimeTruncate: time.Hour},
 },
 }
 

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -74,6 +74,9 @@ var testDSNs = []struct {
 }, {
 	"tcp(de:ad:be:ef::ca:fe)/dbname",
 	&Config{Net: "tcp", Addr: "[de:ad:be:ef::ca:fe]:3306", DBName: "dbname", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, Logger: defaultLogger, AllowNativePasswords: true, CheckConnLiveness: true},
+}, {
+	"user:password@/dbname?loc=UTC&timeout=30s&parseTime=true&timeTruncate=1h",
+	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Loc: time.UTC, Timeout: 30 * time.Second, ParseTime: true, TimeTruncate: time.Hour},
 },
 }
 

--- a/packets.go
+++ b/packets.go
@@ -1172,7 +1172,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 				if v.IsZero() {
 					b = append(b, "0000-00-00"...)
 				} else {
-					b, err = appendDateTime(b, v.In(mc.cfg.Loc))
+					b, err = appendDateTime(b, v.In(mc.cfg.Loc), mc.cfg.TimeTruncate)
 					if err != nil {
 						return err
 					}

--- a/utils.go
+++ b/utils.go
@@ -265,7 +265,11 @@ func parseBinaryDateTime(num uint64, data []byte, loc *time.Location) (driver.Va
 	return nil, fmt.Errorf("invalid DATETIME packet length %d", num)
 }
 
-func appendDateTime(buf []byte, t time.Time) ([]byte, error) {
+func appendDateTime(buf []byte, t time.Time, timeTruncate time.Duration) ([]byte, error) {
+	if timeTruncate > 0 {
+		t = t.Truncate(timeTruncate)
+	}
+
 	year, month, day := t.Date()
 	hour, min, sec := t.Clock()
 	nsec := t.Nanosecond()

--- a/utils_test.go
+++ b/utils_test.go
@@ -240,6 +240,7 @@ func TestAppendDateTime(t *testing.T) {
 		t            time.Time
 		str          string
 		timeTruncate time.Duration
+		expectedErr  bool
 	}{
 		{
 			t:   time.Date(1234, 5, 6, 0, 0, 0, 0, time.UTC),
@@ -323,32 +324,27 @@ func TestAppendDateTime(t *testing.T) {
 			str:          "0001-01-01",
 			timeTruncate: 365 * 24 * time.Hour,
 		},
+		// year out of range
+		{
+			t:           time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC),
+			expectedErr: true,
+		},
+		{
+			t:           time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC),
+			expectedErr: true,
+		},
 	}
 	for _, v := range tests {
 		buf := make([]byte, 0, 32)
-		buf, _ = appendDateTime(buf, v.t, v.timeTruncate)
+		buf, err := appendDateTime(buf, v.t, v.timeTruncate)
+		if err != nil {
+			if !v.expectedErr {
+				t.Errorf("appendDateTime(%v) returned an errror: %v", v.t, err)
+			}
+			continue
+		}
 		if str := string(buf); str != v.str {
 			t.Errorf("appendDateTime(%v), have: %s, want: %s", v.t, str, v.str)
-		}
-	}
-
-	// year out of range
-	{
-		v := time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC)
-		buf := make([]byte, 0, 32)
-		_, err := appendDateTime(buf, v, 0)
-		if err == nil {
-			t.Error("want an error")
-			return
-		}
-	}
-	{
-		v := time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC)
-		buf := make([]byte, 0, 32)
-		_, err := appendDateTime(buf, v, 0)
-		if err == nil {
-			t.Error("want an error")
-			return
 		}
 	}
 }


### PR DESCRIPTION
### Description
This introduces `timeTruncate` parameter that will truncate `time.Time` values in query arguments.

After https://github.com/go-sql-driver/mysql/issues/1121, `Timestamp` and `Datetime` indexes in `MariaDB` broke due to nanoseconds now being present in `time.Time` https://github.com/go-sql-driver/mysql/issues/1121#issuecomment-852920526. 

**Query without nanoseconds part:**
On MariaDB v11.2.2
![image](https://github.com/go-sql-driver/mysql/assets/42966213/aa44a399-76d1-4f6a-b80c-b0e4f9725986)

Same query on MySQL v8.3.0
![image](https://github.com/go-sql-driver/mysql/assets/42966213/16c01ec6-57c6-4011-b640-2c092244d016)

**Query with nanosecond part:**
On MariaDB v11.2.2
![image](https://github.com/go-sql-driver/mysql/assets/42966213/19fe2b19-cc7a-4176-9ad8-ab5aeda7f23f)

On MySQL v8.3.0
![image](https://github.com/go-sql-driver/mysql/assets/42966213/fe2bf662-d483-49d6-b36f-8e513979c348)

Currently, to have correct timestamp/datetime index usage is to either use `time.Truncate(time.Microsecond)` or `time.Round(time.Microsecond)`. This can be very repetitive and is very likely to be forgotten when writing the query.
Having a parameter that would truncate incoming `time.Time` values in the driver would prove useful and would remove the need to write `time.Truncate` methods every time a time value needs to be bound to an argument for MariaDB databases.



### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `timeTruncate` configuration option allowing users to truncate time values to a specified duration.
- **Documentation**
	- Updated `README.md` and `AUTHORS` files with new configuration options and contributor details.
- **Tests**
	- Added and modified tests to cover the new time truncation functionality.
- **Refactor**
	- Modified internal logic to support time value truncation based on the new `timeTruncate` configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->