### PR TITLE
Return ErrBadCon when buffer is in wrong state during interpolation

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -209,8 +209,9 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 	buf, err := mc.buf.takeCompleteBuffer()
 	if err != nil {
 		// can not take the buffer. Something must be wrong with the connection
+		// is safe to retry and will help to recycle the TCP. So we can return ErrBadConn here
 		mc.cfg.Logger.Print(err)
-		return "", ErrInvalidConn
+		return "", driver.ErrBadConn
 	}
 	buf = buf[:0]
 	argPos := 0


### PR DESCRIPTION
### Description

We are trying to address the bug reported here https://github.com/go-sql-driver/mysql/issues/1542 where we explicitly mark the connection in invalid state which should trigger two events, the removal of the connection from the pool and having another one created, and if configured a retry.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved error handling for connection issues by shifting to a more standardized error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->