### PR TITLE
Make TimeTruncate functional option

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -251,7 +251,7 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 				buf = append(buf, "'0000-00-00'"...)
 			} else {
 				buf = append(buf, '\'')
-				buf, err = appendDateTime(buf, v.In(mc.cfg.Loc), mc.cfg.TimeTruncate)
+				buf, err = appendDateTime(buf, v.In(mc.cfg.Loc), mc.cfg.timeTruncate)
 				if err != nil {
 					return "", err
 				}

--- a/dsn.go
+++ b/dsn.go
@@ -92,6 +92,7 @@ func NewConfig() *Config {
 	return cfg
 }
 
+// Apply applies the given options to the Config object.
 func (c *Config) Apply(opts ...Option) error {
 	for _, opt := range opts {
 		err := opt(c)

--- a/dsn.go
+++ b/dsn.go
@@ -77,7 +77,7 @@ type Config struct {
 
 // Functional Options Pattern
 // https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
-type option func(*Config) error
+type Option func(*Config) error
 
 // NewConfig creates a new Config and sets default values.
 func NewConfig() *Config {
@@ -92,7 +92,7 @@ func NewConfig() *Config {
 	return cfg
 }
 
-func (c *Config) SetOptions(opts ...option) error {
+func (c *Config) Apply(opts ...Option) error {
 	for _, opt := range opts {
 		err := opt(c)
 		if err != nil {
@@ -104,7 +104,7 @@ func (c *Config) SetOptions(opts ...option) error {
 
 // TimeTruncate sets the time duration to truncate time.Time values in
 // query parameters.
-func TimeTruncate(d time.Duration) option {
+func TimeTruncate(d time.Duration) Option {
 	return func(cfg *Config) error {
 		cfg.timeTruncate = d
 		return nil

--- a/dsn.go
+++ b/dsn.go
@@ -80,7 +80,7 @@ type Config struct {
 type option func(*Config) error
 
 // NewConfig creates a new Config and sets default values.
-func NewConfig(opts ...option) *Config {
+func NewConfig() *Config {
 	cfg := &Config{
 		Loc:                  time.UTC,
 		MaxAllowedPacket:     defaultMaxAllowedPacket,
@@ -89,7 +89,6 @@ func NewConfig(opts ...option) *Config {
 		CheckConnLiveness:    true,
 	}
 
-	cfg.SetOptions(opts...)
 	return cfg
 }
 

--- a/dsn.go
+++ b/dsn.go
@@ -69,7 +69,7 @@ type Config struct {
 	ParseTime                bool // Parse time values to time.Time
 	RejectReadOnly           bool // Reject read-only connections
 
-	// private fields. new options should be come here
+	// unexported fields. new options should be come here
 
 	pubKey       *rsa.PublicKey // Server public key
 	timeTruncate time.Duration  // Truncate time.Time values to the specified duration

--- a/dsn.go
+++ b/dsn.go
@@ -100,6 +100,7 @@ func (c *Config) SetOptions(opts ...option) error {
 			return err
 		}
 	}
+	return nil
 }
 
 // TimeTruncate sets the time duration to truncate time.Time values in
@@ -543,7 +544,7 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 		case "timeTruncate":
 			cfg.timeTruncate, err = time.ParseDuration(value)
 			if err != nil {
-				return
+				return fmt.Errorf("invalid timeTruncate value: %v, error: %w", value, err)
 			}
 
 		// I/O read Timeout

--- a/dsn.go
+++ b/dsn.go
@@ -34,6 +34,8 @@ var (
 // If a new Config is created instead of being parsed from a DSN string,
 // the NewConfig function should be used, which sets default values.
 type Config struct {
+	// non boolean fields
+
 	User                 string            // Username
 	Passwd               string            // Password (requires User)
 	Net                  string            // Network (e.g. "tcp", "tcp6", "unix". default: "tcp")
@@ -45,14 +47,14 @@ type Config struct {
 	Loc                  *time.Location    // Location for time.Time values
 	MaxAllowedPacket     int               // Max packet size allowed
 	ServerPubKey         string            // Server public key name
-	pubKey               *rsa.PublicKey    // Server public key
 	TLSConfig            string            // TLS configuration name
 	TLS                  *tls.Config       // TLS configuration, its priority is higher than TLSConfig
-	TimeTruncate         time.Duration     // Truncate time.Time values to the specified duration
 	Timeout              time.Duration     // Dial timeout
 	ReadTimeout          time.Duration     // I/O read timeout
 	WriteTimeout         time.Duration     // I/O write timeout
 	Logger               Logger            // Logger
+
+	// boolean fields
 
 	AllowAllFiles            bool // Allow all files to be used with LOAD DATA LOCAL INFILE
 	AllowCleartextPasswords  bool // Allows the cleartext client side plugin
@@ -66,6 +68,11 @@ type Config struct {
 	MultiStatements          bool // Allow multiple statements in one query
 	ParseTime                bool // Parse time values to time.Time
 	RejectReadOnly           bool // Reject read-only connections
+
+	// private fields. new options should be come here
+
+	pubKey               *rsa.PublicKey    // Server public key
+	timeTruncate         time.Duration     // Truncate time.Time values to the specified duration
 }
 
 // NewConfig creates a new Config and sets default values.
@@ -263,8 +270,8 @@ func (cfg *Config) FormatDSN() string {
 		writeDSNParam(&buf, &hasParam, "parseTime", "true")
 	}
 
-	if cfg.TimeTruncate > 0 {
-		writeDSNParam(&buf, &hasParam, "timeTruncate", cfg.TimeTruncate.String())
+	if cfg.timeTruncate > 0 {
+		writeDSNParam(&buf, &hasParam, "timeTruncate", cfg.timeTruncate.String())
 	}
 
 	if cfg.ReadTimeout > 0 {
@@ -509,7 +516,7 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 
 		// time.Time truncation
 		case "timeTruncate":
-			cfg.TimeTruncate, err = time.ParseDuration(value)
+			cfg.timeTruncate, err = time.ParseDuration(value)
 			if err != nil {
 				return
 			}

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -76,7 +76,7 @@ var testDSNs = []struct {
 	&Config{Net: "tcp", Addr: "[de:ad:be:ef::ca:fe]:3306", DBName: "dbname", Loc: time.UTC, MaxAllowedPacket: defaultMaxAllowedPacket, Logger: defaultLogger, AllowNativePasswords: true, CheckConnLiveness: true},
 }, {
 	"user:password@/dbname?loc=UTC&timeout=30s&parseTime=true&timeTruncate=1h",
-	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Loc: time.UTC, Timeout: 30 * time.Second, ParseTime: true, MaxAllowedPacket: defaultMaxAllowedPacket, Logger: defaultLogger, AllowNativePasswords: true, CheckConnLiveness: true, TimeTruncate: time.Hour},
+	&Config{User: "user", Passwd: "password", Net: "tcp", Addr: "127.0.0.1:3306", DBName: "dbname", Loc: time.UTC, Timeout: 30 * time.Second, ParseTime: true, MaxAllowedPacket: defaultMaxAllowedPacket, Logger: defaultLogger, AllowNativePasswords: true, CheckConnLiveness: true, timeTruncate: time.Hour},
 },
 }
 

--- a/packets.go
+++ b/packets.go
@@ -1172,7 +1172,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 				if v.IsZero() {
 					b = append(b, "0000-00-00"...)
 				} else {
-					b, err = appendDateTime(b, v.In(mc.cfg.Loc), mc.cfg.TimeTruncate)
+					b, err = appendDateTime(b, v.In(mc.cfg.Loc), mc.cfg.timeTruncate)
 					if err != nil {
 						return err
 					}

--- a/result.go
+++ b/result.go
@@ -15,9 +15,8 @@ import "database/sql/driver"
 // This is accessible by executing statements using sql.Conn.Raw() and
 // downcasting the returned result:
 //
-//    res, err := rawConn.Exec(...)
-//    res.(mysql.Result).AllRowsAffected()
-//
+//	res, err := rawConn.Exec(...)
+//	res.(mysql.Result).AllRowsAffected()
 type Result interface {
 	driver.Result
 	// AllRowsAffected returns a slice containing the affected rows for each


### PR DESCRIPTION
### Description

`Config.TimeTruncate` just added 2 weeks ago and never released.
This PR make the struct field private and introduce "Functional Options Pattern" instead.

See https://github.com/go-sql-driver/mysql/discussions/1548 for background.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
    - Improved handling and configuration of date-time values in database connections.
- **Documentation**
    - Updated comments in the configuration structure for better clarity.
- **New Features**
    - Introduced a method to apply functional options for database configuration, including time truncation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->