### PR TITLE
fix race condition when context is canceled

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -439,7 +439,13 @@ func (mc *mysqlConn) getSystemVar(name string) ([]byte, error) {
 // finish is called when the query has canceled.
 func (mc *mysqlConn) cancel(err error) {
 	mc.canceled.Set(err)
-	mc.cleanup()
+	nc := mc.netConn
+	if nc != nil {
+		_ = nc.SetDeadline(time.Now()) // wake up pending reads/writes
+		// Ignore error because:
+		// - If the connection is already closed, thats fine.
+		// - If the connection return error other reasons, we can not do anything about it.
+	}
 }
 
 // finish is called when the query has succeeded.


### PR DESCRIPTION
### Description

Fix #1559.

This PR should be backported to 1.8.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved error handling in database connections by adding a check before setting deadlines on operations.
	- Enhanced readability of the `cleanup` method in the `mysqlConn` struct for clarity.
	- Clarified comments on the idempotent nature of cleanup and deferred `mc.clearResult()` for potential concurrent calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->