### PR TITLE
unify short name for mysqlConn in connection_test

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -117,8 +117,8 @@ func TestInterpolateParamsUint64(t *testing.T) {
 
 func TestCheckNamedValue(t *testing.T) {
 	value := driver.NamedValue{Value: ^uint64(0)}
-	x := &mysqlConn{}
-	err := x.CheckNamedValue(&value)
+	mc := &mysqlConn{}
+	err := mc.CheckNamedValue(&value)
 
 	if err != nil {
 		t.Fatal("uint64 high-bit not convertible", err)
@@ -159,13 +159,13 @@ func TestCleanCancel(t *testing.T) {
 
 func TestPingMarkBadConnection(t *testing.T) {
 	nc := badConnection{err: errors.New("boom")}
-	ms := &mysqlConn{
+	mc := &mysqlConn{
 		netConn:          nc,
 		buf:              newBuffer(nc),
 		maxAllowedPacket: defaultMaxAllowedPacket,
 	}
 
-	err := ms.Ping(context.Background())
+	err := mc.Ping(context.Background())
 
 	if err != driver.ErrBadConn {
 		t.Errorf("expected driver.ErrBadConn, got  %#v", err)
@@ -174,7 +174,7 @@ func TestPingMarkBadConnection(t *testing.T) {
 
 func TestPingErrInvalidConn(t *testing.T) {
 	nc := badConnection{err: errors.New("failed to write"), n: 10}
-	ms := &mysqlConn{
+	mc := &mysqlConn{
 		netConn:          nc,
 		buf:              newBuffer(nc),
 		maxAllowedPacket: defaultMaxAllowedPacket,
@@ -182,7 +182,7 @@ func TestPingErrInvalidConn(t *testing.T) {
 		cfg:              NewConfig(),
 	}
 
-	err := ms.Ping(context.Background())
+	err := mc.Ping(context.Background())
 
 	if err != ErrInvalidConn {
 		t.Errorf("expected ErrInvalidConn, got  %#v", err)


### PR DESCRIPTION
### Description

There were `mc`, `ms`, and `x`.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
