### PR TITLE
log: add "filename:line" prefix by ourself

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -13,8 +13,10 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -47,7 +49,17 @@ type mysqlConn struct {
 
 // Helper function to call per-connection logger.
 func (mc *mysqlConn) log(v ...any) {
-	mc.cfg.Logger.Print(v...)
+	_, filename, lineno, ok := runtime.Caller(1)
+	prefix := ""
+	if ok {
+		pos = strings.LastIndexByte(filename, '/')
+		if pos != -1 {
+			filename = filename[pos+1:]
+		}
+		prefix = fmt.Sprintf("%s:%d: ", filename, lineno)
+	}
+
+	mc.cfg.Logger.Print(prefix, v...)
 }
 
 // Handles parameters set in DSN after the connection is established

--- a/connection.go
+++ b/connection.go
@@ -50,16 +50,16 @@ type mysqlConn struct {
 // Helper function to call per-connection logger.
 func (mc *mysqlConn) log(v ...any) {
 	_, filename, lineno, ok := runtime.Caller(1)
-	prefix := ""
 	if ok {
-		pos = strings.LastIndexByte(filename, '/')
+		pos := strings.LastIndexByte(filename, '/')
 		if pos != -1 {
 			filename = filename[pos+1:]
 		}
-		prefix = fmt.Sprintf("%s:%d: ", filename, lineno)
+		prefix := fmt.Sprintf("%s:%d ", filename, lineno)
+		v = append([]any{prefix}, v...)
 	}
 
-	mc.cfg.Logger.Print(prefix, v...)
+	mc.cfg.Logger.Print(v...)
 }
 
 // Handles parameters set in DSN after the connection is established

--- a/errors.go
+++ b/errors.go
@@ -37,7 +37,7 @@ var (
 	errBadConnNoWrite = errors.New("bad connection")
 )
 
-var defaultLogger = Logger(log.New(os.Stderr, "[mysql] ", log.Ldate|log.Ltime|log.Lshortfile))
+var defaultLogger = Logger(log.New(os.Stderr, "[mysql] ", log.Ldate|log.Ltime))
 
 // Logger is used to log critical error messages.
 type Logger interface {


### PR DESCRIPTION
go-sql-driver/mysql#1563 broke the filename:lineno prefix in the log message by introducing a helper function.
This commit adds the "filename:line" prefix in the helper function instead of log.Lshortfile option to show correct filename:lineno.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
