### PR TITLE
fix(driver.go): modify `go build -ldflags` command comment

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -88,7 +88,7 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 }
 
 // This variable can be replaced with -ldflags like below:
-// go build "-ldflags=-X github.com/go-sql-driver/mysql.driverName=custom"
+// go build -ldflags="-X github.com/go-sql-driver/mysql.driverName=custom"
 var driverName = "mysql"
 
 func init() {

--- a/driver_test.go
+++ b/driver_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 // This variable can be replaced with -ldflags like below:
-// go test "-ldflags=-X github.com/go-sql-driver/mysql.driverNameTest=custom"
+// go test -ldflags="-X github.com/go-sql-driver/mysql.driverNameTest=custom"
 var driverNameTest string
 
 func init() {


### PR DESCRIPTION
### Description
go bu comment error
```diff
- go build "-ldflags=-X github.com/go-sql-driver/mysql.driverName=custom"
+ go build -ldflags="-X github.com/go-sql-driver/mysql.driverName=custom"
```

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
