### PR TITLE
log: add "filename:line" prefix by ourself (#1589)

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -13,8 +13,10 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -46,6 +48,16 @@ type mysqlConn struct {
 
 // Helper function to call per-connection logger.
 func (mc *mysqlConn) log(v ...any) {
+	_, filename, lineno, ok := runtime.Caller(1)
+	if ok {
+		pos := strings.LastIndexByte(filename, '/')
+		if pos != -1 {
+			filename = filename[pos+1:]
+		}
+		prefix := fmt.Sprintf("%s:%d ", filename, lineno)
+		v = append([]any{prefix}, v...)
+	}
+
 	mc.cfg.Logger.Print(v...)
 }
 

--- a/errors.go
+++ b/errors.go
@@ -37,7 +37,7 @@ var (
 	errBadConnNoWrite = errors.New("bad connection")
 )
 
-var defaultLogger = Logger(log.New(os.Stderr, "[mysql] ", log.Ldate|log.Ltime|log.Lshortfile))
+var defaultLogger = Logger(log.New(os.Stderr, "[mysql] ", log.Ldate|log.Ltime))
 
 // Logger is used to log critical error messages.
 type Logger interface {


### PR DESCRIPTION
go-sql-driver/mysql#1563 broke the filename:lineno prefix in the log message by introducing a helper function.
This commit adds the "filename:line" prefix in the helper function instead of log.Lshortfile option to show correct filename:lineno.

(cherry picked from commit 2f7015e5c48d361a7dd188c01ae95379c7b9f6f9)