### PR TITLE
fix missing skip test when there is no DB available

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -3539,6 +3539,9 @@ func TestConnectionAttributes(t *testing.T) {
 }
 
 func TestErrorInMultiResult(t *testing.T) {
+	if !available {
+		t.Skipf("MySQL server not running on %s", netAddr)
+	}
 	// https://github.com/go-sql-driver/mysql/issues/1361
 	var db *sql.DB
 	if _, err := ParseDSN(dsn); err != errInvalidDSNUnsafeCollation {


### PR DESCRIPTION
### Description

Fix `go test` fails when no DB is set up.
Needs backport to 1.8

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a conditional check to skip tests if a MySQL server is not available, with a corresponding message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->