### PR TITLE
fix some write error handling

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -230,8 +230,10 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 	buf, err := mc.buf.takeCompleteBuffer()
 	if err != nil {
 		// can not take the buffer. Something must be wrong with the connection
-		mc.log(err)
-		return "", ErrInvalidConn
+		mc.cleanup()
+		// interpolateParams would be called before sending any query.
+		// So its safe to retry.
+		return "", driver.ErrBadConn
 	}
 	buf = buf[:0]
 	argPos := 0

--- a/packets.go
+++ b/packets.go
@@ -117,6 +117,8 @@ func (mc *mysqlConn) writePacket(data []byte) error {
 		// Write packet
 		if mc.writeTimeout > 0 {
 			if err := mc.netConn.SetWriteDeadline(time.Now().Add(mc.writeTimeout)); err != nil {
+				mc.cleanup()
+				mc.log(err)
 				return err
 			}
 		}


### PR DESCRIPTION
### Description

interpolateParams() returned ErrInvalidConn without closing the connection.
Since database/sql doesn't understand ErrInvalidConn, there is a risk that database/sql reuse this connection and ErrInvalidConn is returned repeatedly.

This PR should be backported to 1.8.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling in connection management to ensure better resource cleanup and logging.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->