### PR TITLE
fix some write error handling (#1595)

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -217,8 +217,10 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 	buf, err := mc.buf.takeCompleteBuffer()
 	if err != nil {
 		// can not take the buffer. Something must be wrong with the connection
-		mc.log(err)
-		return "", ErrInvalidConn
+		mc.cleanup()
+		// interpolateParams would be called before sending any query.
+		// So its safe to retry.
+		return "", driver.ErrBadConn
 	}
 	buf = buf[:0]
 	argPos := 0

--- a/packets.go
+++ b/packets.go
@@ -116,6 +116,8 @@ func (mc *mysqlConn) writePacket(data []byte) error {
 		// Write packet
 		if mc.writeTimeout > 0 {
 			if err := mc.netConn.SetWriteDeadline(time.Now().Add(mc.writeTimeout)); err != nil {
+				mc.cleanup()
+				mc.log(err)
 				return err
 			}
 		}


### PR DESCRIPTION
interpolateParams() returned ErrInvalidConn without closing the connection.

Since database/sql doesn't understand ErrInvalidConn, there is a risk that database/sql reuse this connection and ErrInvalidConn is returned repeatedly.

This PR is backport of #1595.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
