### PR TITLE
fix missing skip test when no DB is available (#1594)

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -3539,6 +3539,9 @@ func TestConnectionAttributes(t *testing.T) {
 }
 
 func TestErrorInMultiResult(t *testing.T) {
+	if !available {
+		t.Skipf("MySQL server not running on %s", netAddr)
+	}
 	// https://github.com/go-sql-driver/mysql/issues/1361
 	var db *sql.DB
 	if _, err := ParseDSN(dsn); err != errInvalidDSNUnsafeCollation {


### PR DESCRIPTION
Fix `go test` fails when no DB is set up.

(cherry picked from commit 9b8d28eff68e1b0dec9d45e9868796e7f7a9af49)