### PR TITLE
remove unnecessary logs

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -32,7 +32,7 @@ var (
 
 	// errBadConnNoWrite is used for connection errors where nothing was sent to the database yet.
 	// If this happens first in a function starting a database interaction, it should be replaced by driver.ErrBadConn
-	// to trigger a resend.
+	// to trigger a resend. Use mc.markBadConn(err) to do this.
 	// See https://github.com/go-sql-driver/mysql/pull/302
 	errBadConnNoWrite = errors.New("bad connection")
 )

--- a/statement.go
+++ b/statement.go
@@ -51,7 +51,6 @@ func (stmt *mysqlStmt) CheckNamedValue(nv *driver.NamedValue) (err error) {
 
 func (stmt *mysqlStmt) Exec(args []driver.Value) (driver.Result, error) {
 	if stmt.mc.closed.Load() {
-		stmt.mc.log(ErrInvalidConn)
 		return nil, driver.ErrBadConn
 	}
 	// Send command
@@ -95,7 +94,6 @@ func (stmt *mysqlStmt) Query(args []driver.Value) (driver.Rows, error) {
 
 func (stmt *mysqlStmt) query(args []driver.Value) (*binaryRows, error) {
 	if stmt.mc.closed.Load() {
-		stmt.mc.log(ErrInvalidConn)
 		return nil, driver.ErrBadConn
 	}
 	// Send command


### PR DESCRIPTION
### Description

Logging ErrInvalidConn when the connection already closed doesn't provide any help to users.

Additonally, database/sql now uses Validator() to check connection liveness before calling query methods.
So stop using `mc.log(ErrInvalidConn)` idiom.

This PR includes some cleanup and documentation relating to `mc.markBadConn()`.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved connection error handling to conditionally return errors, reducing unnecessary error logs.
  - Enhanced interface declarations for better type safety and functionality clarity.

- **Documentation**
  - Updated comments to provide clearer guidance on handling connection errors.

This update aims to streamline error management for a more efficient and cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->