### PR TITLE
fix unnecesssary allocation in infile.go

### DIFF
--- a/infile.go
+++ b/infile.go
@@ -95,7 +95,6 @@ const defaultPacketSize = 16 * 1024 // 16KB is small enough for disk readahead a
 
 func (mc *okHandler) handleInFileRequest(name string) (err error) {
 	var rdr io.Reader
-	var data []byte
 	packetSize := defaultPacketSize
 	if mc.maxWriteSize < packetSize {
 		packetSize = mc.maxWriteSize
@@ -147,9 +146,11 @@ func (mc *okHandler) handleInFileRequest(name string) (err error) {
 	}
 
 	// send content packets
+	var data []byte
+
 	// if packetSize == 0, the Reader contains no data
 	if err == nil && packetSize > 0 {
-		data := make([]byte, 4+packetSize)
+		data = make([]byte, 4+packetSize)
 		var n int
 		for err == nil {
 			n, err = rdr.Read(data[4:])


### PR DESCRIPTION
### Description

There is a code `if data == nil` to avoid allocation when sending empty packet in `handleInFileRequest()`.
But it didn't work because previous allocation happend inner block as `data := make(...)`.
VSCode warns that `if data == nil` is tautology.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->



<!-- end of auto-generated comment: release notes by coderabbit.ai -->