### PR TITLE
[Docs] clarify connection close behavior of context

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,8 @@ This driver supports the [`ColumnType` interface](https://golang.org/pkg/databas
 Go 1.8 added `database/sql` support for `context.Context`. This driver supports query timeouts and cancellation via contexts.
 See [context support in the database/sql package](https://golang.org/doc/go1.8#database_sql) for more details.
 
-Importantly, the `SelectContext`, `ExecContext`, etc. variants provided by `database/sql` will cause the connection to be closed if the provided context is cancelled or timed out before the result is received by the driver.
+> [!IMPORTANT]
+> The `QueryContext`, `ExecContext`, etc. variants provided by `database/sql` will cause the connection to be closed if the provided context is cancelled or timed out before the result is received by the driver.
 
 
 ### `LOAD DATA LOCAL INFILE` support

--- a/README.md
+++ b/README.md
@@ -519,6 +519,8 @@ This driver supports the [`ColumnType` interface](https://golang.org/pkg/databas
 Go 1.8 added `database/sql` support for `context.Context`. This driver supports query timeouts and cancellation via contexts.
 See [context support in the database/sql package](https://golang.org/doc/go1.8#database_sql) for more details.
 
+Importantly, the `SelectContext`, `ExecContext`, etc. variants provided by `database/sql` will cause the connection to be closed if the provided context is cancelled or timed out before the result is received by the driver.
+
 
 ### `LOAD DATA LOCAL INFILE` support
 For this feature you need direct access to the package. Therefore you must change the import path (no `_`):


### PR DESCRIPTION
### Description
Updates the README to make it clear that `go-sql-driver/mysql` closes the current connection if the `context.Context` provided to `ExecContext`, `SelectContext`, etc. is cancelled or times out prior to the query returning.

As is, that behavior is not clearly documented.
### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced support for context cancellation in database operations, enhancing connection management.
- **Documentation**
	- Updated README to clarify the effects of context cancellation, improving guidance on using context-aware methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->