### PR TITLE
MySQL 9.0 and MariaDB 11.4 are released

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,14 +37,16 @@ jobs:
               '1.20',
           ]
           mysql = [
+              '9.0',
+              '8.4', # LTS
               '8.0',
-              '8.3',
               '5.7',
-              'mariadb-11.3',
+              'mariadb-11.4',   # LTS
+              'mariadb-11.2',
               'mariadb-11.1',
               'mariadb-10.11',  # LTS
               'mariadb-10.6',   # LTS
-              'mariadb-10.5',
+              'mariadb-10.5',   # LTS
           ]
 
           includes = []


### PR DESCRIPTION
### Description
update MySQL and MariaDB versions for testing.

- Add MySQL 9.0, MySQL 8.4 (LTS) and MariaDB 11.4 (LTS)
- Remove MySQL 8.3 and MariaDB 11.3. they end their life.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated MySQL and MariaDB versions used in workflows, including the addition of new versions and marking certain versions as LTS (Long-Term Support).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->