### PR TITLE
fix bigint unsigned null column scan to err type int64

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -120,6 +120,7 @@ Zhang Xiang <angwerzx at 126.com>
 Zhenye Xie <xiezhenye at gmail.com>
 Zhixin Wen <john.wenzhixin at gmail.com>
 Ziheng Lyu <zihenglv at gmail.com>
+Jiabin Zhang <jiabin.z at qq.com>
 
 # Organizations
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -18,8 +18,8 @@ Alex Snast <alexsn at fb.com>
 Alexey Palazhchenko <alexey.palazhchenko at gmail.com>
 Andrew Reid <andrew.reid at tixtrack.com>
 Animesh Ray <mail.rayanimesh at gmail.com>
-Arne Hormann <arnehormann at gmail.com>
 Ariel Mashraki <ariel at mashraki.co.il>
+Arne Hormann <arnehormann at gmail.com>
 Artur Melanchyk <artur.melanchyk@gmail.com>
 Asta Xie <xiemengjun at gmail.com>
 B Lamarche <blam413 at gmail.com>
@@ -62,6 +62,7 @@ Jeff Hodges <jeff at somethingsimilar.com>
 Jeffrey Charles <jeffreycharles at gmail.com>
 Jennifer Purevsuren <jennifer at dolthub.com>
 Jerome Meyer <jxmeyer at gmail.com>
+Jiabin Zhang <jiabin.z at qq.com>
 Jiajia Zhong <zhong2plus at gmail.com>
 Jian Zhen <zhenjl at gmail.com>
 Joe Mann <contact at joemann.co.uk>
@@ -81,10 +82,11 @@ Linh Tran Tuan <linhduonggnu at gmail.com>
 Lion Yang <lion at aosc.xyz>
 Luca Looz <luca.looz92 at gmail.com>
 Lucas Liu <extrafliu at gmail.com>
-Lunny Xiao <xiaolunwen at gmail.com>
 Luke Scott <luke at webconnex.com>
+Lunny Xiao <xiaolunwen at gmail.com>
 Maciej Zimnoch <maciej.zimnoch at codilime.com>
 Michael Woolnough <michael.woolnough at gmail.com>
+Minh Quang <minhquang4334 at gmail.com>
 Nao Yokotsuka <yokotukanao at gmail.com>
 Nathanial Murphy <nathanial.murphy at gmail.com>
 Nicola Peduzzi <thenikso at gmail.com>
@@ -95,7 +97,6 @@ Paul Bonser <misterpib at gmail.com>
 Paulius Lozys <pauliuslozys at gmail.com>
 Peter Schultz <peter.schultz at classmarkets.com>
 Phil Porada <philporada at gmail.com>
-Minh Quang <minhquang4334 at gmail.com>
 Rebecca Chin <rchin at pivotal.io>
 Reed Allman <rdallman10 at gmail.com>
 Richard Wilkes <wilkes at me.com>
@@ -126,7 +127,6 @@ Zhang Xiang <angwerzx at 126.com>
 Zhenye Xie <xiezhenye at gmail.com>
 Zhixin Wen <john.wenzhixin at gmail.com>
 Ziheng Lyu <zihenglv at gmail.com>
-Jiabin Zhang <jiabin.z at qq.com>
 
 # Organizations
 

--- a/fields.go
+++ b/fields.go
@@ -128,7 +128,7 @@ var (
 	scanTypeInt64      = reflect.TypeOf(int64(0))
 	scanTypeNullFloat  = reflect.TypeOf(sql.NullFloat64{})
 	scanTypeNullInt    = reflect.TypeOf(sql.NullInt64{})
-	scanTypeNullUint   = reflect.TypeOf(sql.NullString{}) // reflect.TypeOf(sql.Null[uint64]{}) // support in go 1.22
+	scanTypeNullUint   = reflect.TypeOf(sql.Null[uint64]{})
 	scanTypeNullTime   = reflect.TypeOf(sql.NullTime{})
 	scanTypeUint8      = reflect.TypeOf(uint8(0))
 	scanTypeUint16     = reflect.TypeOf(uint16(0))

--- a/fields.go
+++ b/fields.go
@@ -128,7 +128,7 @@ var (
 	scanTypeInt64      = reflect.TypeOf(int64(0))
 	scanTypeNullFloat  = reflect.TypeOf(sql.NullFloat64{})
 	scanTypeNullInt    = reflect.TypeOf(sql.NullInt64{})
-	scanTypeNullUInt   = reflect.TypeOf(sql.Null[uint64]{})
+	scanTypeNullUint   = reflect.TypeOf(sql.NullString{}) // reflect.TypeOf(sql.Null[uint64]{}) // support in go 1.22
 	scanTypeNullTime   = reflect.TypeOf(sql.NullTime{})
 	scanTypeUint8      = reflect.TypeOf(uint8(0))
 	scanTypeUint16     = reflect.TypeOf(uint16(0))
@@ -187,7 +187,7 @@ func (mf *mysqlField) scanType() reflect.Type {
 			return scanTypeInt64
 		}
 		if mf.flags&flagUnsigned != 0 {
-			return scanTypeNullUInt
+			return scanTypeNullUint
 		}
 		return scanTypeNullInt
 

--- a/fields.go
+++ b/fields.go
@@ -128,6 +128,7 @@ var (
 	scanTypeInt64      = reflect.TypeOf(int64(0))
 	scanTypeNullFloat  = reflect.TypeOf(sql.NullFloat64{})
 	scanTypeNullInt    = reflect.TypeOf(sql.NullInt64{})
+	scanTypeNullUInt   = reflect.TypeOf(sql.Null[uint64]{})
 	scanTypeNullTime   = reflect.TypeOf(sql.NullTime{})
 	scanTypeUint8      = reflect.TypeOf(uint8(0))
 	scanTypeUint16     = reflect.TypeOf(uint16(0))
@@ -184,6 +185,9 @@ func (mf *mysqlField) scanType() reflect.Type {
 				return scanTypeUint64
 			}
 			return scanTypeInt64
+		}
+		if mf.flags&flagUnsigned != 0 {
+			return scanTypeNullUInt
 		}
 		return scanTypeNullInt
 


### PR DESCRIPTION
### Description

when i use gorm scan sql rows to map[string]any, i got an error (out of range).
gorm scan `sql.Rows` to `map[string]any`  by   `ScanRows` 
there has three step:
1. prepare values ​​according to column type. https://github.com/go-gorm/gorm/blob/master/scan.go#L25, 
```
columnTypes, _ := rows.ColumnTypes()
prepareValues(values, db, columnTypes, columns)
```
2. rows.Scan(...any)
```
rows.Scan(values...)
```
3. assign column name and value to map
```
scanIntoMap(mapValue, values, columns)
```

in step 2, when occur number(tiny int short long longlong )null column, this type will be all set to `scanTypeNullInt`,

```
scanTypeNullInt    = reflect.TypeOf(sql.NullInt64{})

# "database/sql"#L210
// NullInt64 represents an int64 that may be null.
// NullInt64 implements the [Scanner] interface so
// it can be used as a scan destination, similar to [NullString].
type NullInt64 struct {
    Int64 int64
    Valid bool // Valid is true if Int64 is not NULL
}
```

tiny int short long type will be ok, its Maximum value will not out of range int64
but unsigned longlong may be out of range.
int64:-9223372036854775808 ~9223372036854775807,
uint64:0 ~ 18446744073709551615

**a uint64 assign to NullInt64 will be out of range, because the value store into int64**

### so to fix it

Must add a new scan type NullUint64 to represent unsigned bigint null column.
and though flag to judge unsigned or not. 
 
Dur to `database/sql` support  generics Null[T] type, it will be easy to support NullUint64.
```
scanTypeNullUInt   = reflect.TypeOf(sql.Null[uint64]{})
```

### Reproduce the problem

table example
```
CREATE TABLE `tbl_name` (
  `id` int NOT NULL COMMENT '',
  `ubigint` bigint unsigned DEFAULT NULL COMMENT '9223372036854775808',
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8;
INSERT INTO `tbl_name` (`id`, `ubigint`) VALUES (1, 9223372036854775808);
```

code
```
func main() {
	// connect to db
	db, err := sql.Open("mysql", "dsn")
	if err != nil {
		log.Fatal(err)
	}
	defer func() { _ = db.Close() }()

	gormDB, err := gorm.Open(gormMysql.New(gormMysql.Config{
		Conn: db,
	}), &gorm.Config{})
	var result map[string]any
	if err := gormDB.Raw("select * from tbl_name where id = 1").Scan(&result).Error; err != nil {
		log.Fatal(err)
	}
	// print type and value
	fmt.Printf("Type: %v\n", reflect.TypeOf(result))
	fmt.Printf("Value: %v\n", result)
}
```
Env
```
go version
go version go1.22.3 darwin/arm64
```

Error log
```
sql: Scan error on column index 1, name "ubigint": converting driver.Value type uint64 ("9223372036854775808") to a int64: value out of range
[9.744ms] [rows:1] select * from tbl_name where id = 1
2024/07/26 19:36:29 sql: Scan error on column index 1, name "ubigint": converting driver.Value type uint64 ("9223372036854775808") to a int64: value out of range

```
### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the contributors list to include Jiabin Zhang and Minh Quang.

- **Enhancements**
	- Improved handling of unsigned integer types in MySQL data scanning for more accurate type recognition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->