### PR TITLE
Check mysqlConnector.canceled.Value when failed to TLS handshake

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -81,6 +81,7 @@ Lunny Xiao <xiaolunwen at gmail.com>
 Luke Scott <luke at webconnex.com>
 Maciej Zimnoch <maciej.zimnoch at codilime.com>
 Michael Woolnough <michael.woolnough at gmail.com>
+Nao Yokotsuka <yokotukanao at gmail.com>
 Nathanial Murphy <nathanial.murphy at gmail.com>
 Nicola Peduzzi <thenikso at gmail.com>
 Oliver Bone <owbone at github.com>

--- a/packets.go
+++ b/packets.go
@@ -352,6 +352,9 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, plugin string
 		// Switch to TLS
 		tlsConn := tls.Client(mc.netConn, mc.cfg.TLS)
 		if err := tlsConn.Handshake(); err != nil {
+			if cerr := mc.canceled.Value(); cerr != nil {
+				return cerr
+			}
 			return err
 		}
 		mc.netConn = tlsConn


### PR DESCRIPTION
### Description
Check if the context is canceled when failed to TLS handshake.

fix: #1614

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added Nao Yokotsuka to the contributors list for improved project documentation.
  
- **Bug Fixes**
	- Enhanced error handling in the TLS handshake process to better manage cancellation requests, improving connection responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->