### PR TITLE
Fix auth errors when username/password are too long (#1482)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,6 +51,7 @@ ICHINOSE Shogo <shogo82148 at gmail.com>
 Ilia Cimpoes <ichimpoesh at gmail.com>
 INADA Naoki <songofacandy at gmail.com>
 Jacek Szwec <szwec.jacek at gmail.com>
+Jakub Adamus <kratky at zobak.cz>
 James Harr <james.harr at gmail.com>
 Janek Vedock <janekvedock at comcast.net>
 Jason Ng <oblitorum at gmail.com>

--- a/packets.go
+++ b/packets.go
@@ -394,7 +394,7 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, plugin string
 // http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::AuthSwitchResponse
 func (mc *mysqlConn) writeAuthSwitchPacket(authData []byte) error {
 	pktLen := 4 + len(authData)
-	data, err := mc.buf.takeSmallBuffer(pktLen)
+	data, err := mc.buf.takeBuffer(pktLen)
 	if err != nil {
 		// cannot take the buffer. Something must be wrong with the connection
 		mc.log(err)


### PR DESCRIPTION
### Description
Targets issue in #1482. When username/password (JWT token usually) are too long, there are unable to fit into buffer, which has only 4k at connection startup. Using takeBuffer (which autogrows) instead of takeSmallBuffer should work in this case.

I did not find any "better" solution to this problem as checking length of packet before choosing buffer would be practicaly the same logic and conditions, what takeBuffer does. If there is need to use takeSmallBuffer for perfomrance reasons, there can be takeSmallBuffer kept and takeBuffer called only after failure, which seems to be ugliest solution.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible) - change in internal method, should be tested already
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary - should not be needed
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added Jakub Adamus as a contributor in the `AUTHORS` file to acknowledge contributions.
  
- **Improvements**
	- Enhanced buffer handling in the authentication process, potentially improving memory management for larger data packets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->