### PR TITLE
Implement GTID tracking.

### DIFF
--- a/const.go
+++ b/const.go
@@ -188,3 +188,12 @@ const (
 	cachingSha2PasswordFastAuthSuccess           = 3
 	cachingSha2PasswordPerformFullAuthentication = 4
 )
+
+const (
+	sessionTrackSystemVariables = iota
+	sessionTrackSchema
+	sessionTrackStateChange
+	sessionTrackGtids
+	sessionTrackTransactionCharacteristics
+	sessionTrackTransactionState
+)

--- a/dsn.go
+++ b/dsn.go
@@ -70,6 +70,7 @@ type Config struct {
 	MultiStatements          bool // Allow multiple statements in one query
 	ParseTime                bool // Parse time values to time.Time
 	RejectReadOnly           bool // Reject read-only connections
+	TrackSessionState        bool // Enable session state tracking (e.g. GTID values)
 
 	// unexported fields. new options should be come here
 
@@ -577,6 +578,13 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 		case "rejectReadOnly":
 			var isBool bool
 			cfg.RejectReadOnly, isBool = readBool(value)
+			if !isBool {
+				return errors.New("invalid bool value: " + value)
+			}
+
+		case "trackSessionState":
+			var isBool bool
+			cfg.TrackSessionState, isBool = readBool(value)
 			if !isBool {
 				return errors.New("invalid bool value: " + value)
 			}

--- a/result.go
+++ b/result.go
@@ -19,9 +19,17 @@ import "database/sql/driver"
 //	res.(mysql.Result).AllRowsAffected()
 type Result interface {
 	driver.Result
+
+	// LastGTID returns the GTID of the last result, if available.
+	LastGTID() (string, error)
+
+	// AllLastGTIDs returns a slice containing
+	AllLastGTIDs() []string
+
 	// AllRowsAffected returns a slice containing the affected rows for each
 	// executed statement.
 	AllRowsAffected() []int64
+
 	// AllLastInsertIds returns a slice containing the last inserted ID for each
 	// executed statement.
 	AllLastInsertIds() []int64
@@ -31,6 +39,7 @@ type mysqlResult struct {
 	// One entry in both slices is created for every executed statement result.
 	affectedRows []int64
 	insertIds    []int64
+	gtids        []string
 }
 
 func (res *mysqlResult) LastInsertId() (int64, error) {
@@ -41,10 +50,18 @@ func (res *mysqlResult) RowsAffected() (int64, error) {
 	return res.affectedRows[len(res.affectedRows)-1], nil
 }
 
+func (res *mysqlResult) LastGTID() (string, error) {
+	return res.gtids[len(res.gtids)-1], nil
+}
+
 func (res *mysqlResult) AllLastInsertIds() []int64 {
 	return append([]int64{}, res.insertIds...) // defensive copy
 }
 
 func (res *mysqlResult) AllRowsAffected() []int64 {
 	return append([]int64{}, res.affectedRows...) // defensive copy
+}
+
+func (res *mysqlResult) AllLastGTIDs() []string {
+	return append([]string{}, res.gtids...)
 }


### PR DESCRIPTION
### Description

This implements GTID tracking when GTID mode is enabled on the server, `TrackSessionState` connection config is enabled, and `session_track_gtids` is set to either `ALL_GTIDS` or `OWN_GTID`.

To access the GTID, `sql.Conn.Raw()` has to be used like this:

```go
conn, _ := db.Conn(ctx)
conn.Raw(func(conn any) error {
  ex := conn.(driver.Execer)
  res, err := ex.Exec(`UPDATE point SET x = 1 WHERE y = 2`, nil)
  log.Print(res.(mysql.Result).LastGTID())
})
```

There's also `AllLastGTIDs` on `mysql.Result` for use with multi-statement queries.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
