### PR TITLE
ci: update Go and staticcheck versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dominikh/staticcheck-action@v1.3.0
-        with:
-          version: "2023.1.6"
+      - uses: dominikh/staticcheck-action@v1.3.1
 
   list:
     runs-on: ubuntu-latest
@@ -31,10 +29,10 @@ jobs:
           import os
           go = [
               # Keep the most recent production release at the top
-              '1.22',
+              '1.23',
               # Older production releases
+              '1.22',
               '1.21',
-              '1.20',
           ]
           mysql = [
               '9.0',

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A MySQL-Driver for Go's [database/sql](https://golang.org/pkg/database/sql/) pac
 
 ## Requirements
 
-* Go 1.20 or higher. We aim to support the 3 latest versions of Go.
+* Go 1.21 or higher. We aim to support the 3 latest versions of Go.
 * MySQL (5.7+) and MariaDB (10.5+) are supported.
 * [TiDB](https://github.com/pingcap/tidb) is supported by PingCAP.
   * Do not ask questions about TiDB in our issue tracker or forum.

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/go-sql-driver/mysql
 
-go 1.20
+go 1.21
 
 require filippo.io/edwards25519 v1.1.0


### PR DESCRIPTION
### Description

- Add Go 1.23 support
- Remove Go 1.20 support
- Update staticcheck action

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated Go version requirement in the README to "Go 1.21 or higher."

- **Chores**
	- Updated the version of the static check action in the workflow configuration.
	- Modified Go version array for compatibility in the testing workflow.
	- Updated Go version requirement in `go.mod` to 1.21.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->