### PR TITLE
Check if MySQL supports CLIENT_CONNECT_ATTRS before sending client attributes.

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -210,12 +210,13 @@ func (mc *mysqlConn) readHandshakePacket() (data []byte, plugin string, err erro
 	if len(data) > pos {
 		// character set [1 byte]
 		// status flags [2 bytes]
-		pos += 1 + 2
+		pos += 3
 		// capability flags (upper 2 bytes) [2 bytes]
 		mc.flags |= clientFlag(binary.LittleEndian.Uint16(data[pos:pos+2])) << 16
+		pos += 2
 		// length of auth-plugin-data [1 byte]
 		// reserved (all [00]) [10 bytes]
-		pos += 2 + 1 + 10
+		pos += 11
 
 		// second part of the password cipher [minimum 13 bytes],
 		// where len=MAX(13, length of auth-plugin-data - 8)
@@ -266,7 +267,7 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, plugin string
 		mc.flags&clientConnectAttrs |
 		mc.flags&clientLongFlag
 
-	serverSupportClientConnectAttrs := mc.flags&clientConnectAttrs != 0
+	sendConnectAttrs := mc.flags&clientConnectAttrs != 0
 
 	if mc.cfg.ClientFoundRows {
 		clientFlags |= clientFoundRows
@@ -299,9 +300,9 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, plugin string
 		pktLen += n + 1
 	}
 
-	var connAttrsLEI []byte
 	// encode length of the connection attributes
-	if serverSupportClientConnectAttrs {
+	var connAttrsLEI []byte
+	if sendConnectAttrs {
 		var connAttrsLEIBuf [9]byte
 		connAttrsLen := len(mc.connector.encodedAttributes)
 		connAttrsLEI = appendLengthEncodedInteger(connAttrsLEIBuf[:0], uint64(connAttrsLen))
@@ -389,7 +390,7 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, plugin string
 	pos++
 
 	// Connection Attributes
-	if serverSupportClientConnectAttrs {
+	if sendConnectAttrs {
 		pos += copy(data[pos:], connAttrsLEI)
 		pos += copy(data[pos:], []byte(mc.connector.encodedAttributes))
 	}


### PR DESCRIPTION
### Description
Check if MySQL supports CLIENT_CONNECT_ATTRS before sending client attributes.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of MySQL connection packets, enhancing the handshake process.
	- Conditional inclusion of connection attributes based on server capabilities.

- **Bug Fixes**
	- Enhanced error handling for connection errors and malformed packets, improving robustness in connection management.

These changes ensure better compliance with MySQL protocol specifications and enhance overall performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->