### PR TITLE
Reduce "busy buffer" logs

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -43,6 +43,11 @@ func newBuffer(nc net.Conn) buffer {
 	}
 }
 
+// busy retruns true if the buffer contains some read data.
+func (b *buffer) busy() bool {
+	return b.length > 0
+}
+
 // flip replaces the active buffer with the background buffer
 // this is a delayed flip that simply increases the buffer counter;
 // the actual flip will be performed the next time we call `buffer.fill`

--- a/buffer.go
+++ b/buffer.go
@@ -43,7 +43,7 @@ func newBuffer(nc net.Conn) buffer {
 	}
 }
 
-// busy retruns true if the buffer contains some read data.
+// busy returns true if the buffer contains some read data.
 func (b *buffer) busy() bool {
 	return b.length > 0
 }

--- a/connection.go
+++ b/connection.go
@@ -125,7 +125,7 @@ func (mc *mysqlConn) Close() (err error) {
 	return
 }
 
-// close closes the network connection and cleare results without sending COM_QUIT.
+// close closes the network connection and clear results without sending COM_QUIT.
 func (mc *mysqlConn) close() {
 	mc.cleanup()
 	mc.clearResult()


### PR DESCRIPTION
### Description

Reduce the use of `errBadConnNoWrite` to improve maintainability.

ResetSession() and IsValid() checks if the buffer is busy. This reduces the risk of busy buffer error during connection in use. In principle, the risk of this is zero. So I removed errBadConnNoWrite when checking the busy buffer.

After this change, only `writePacke()` returns errBadConnNoWrite.

Additionally, I do not send COM_QUIT when readPacket() encounter read error.
It caused "busy buffer" error too and hide real errors.


### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to check if the buffer is busy, enhancing state management.
	- Added a method for safely closing MySQL connections without sending a termination command.

- **Improvements**
	- Enhanced error handling and connection management for MySQL operations, streamlining the process and improving reliability.
	- Updated validation and session reset logic to account for the buffer's state.

- **Bug Fixes**
	- Simplified error handling in packet processing methods, reducing redundancy and improving readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->