### PR TITLE
stmt.Close() returns nil when double close

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -24,11 +24,12 @@ type mysqlStmt struct {
 
 func (stmt *mysqlStmt) Close() error {
 	if stmt.mc == nil || stmt.mc.closed.Load() {
-		// driver.Stmt.Close can be called more than once, thus this function
-		// has to be idempotent.
-		// See also Issue #450 and golang/go#16019.
-		//errLog.Print(ErrInvalidConn)
-		return driver.ErrBadConn
+		// driver.Stmt.Close could be called more than once, thus this function
+		// had to be idempotent. See also Issue #450 and golang/go#16019.
+		// This bug has been fixed in Go 1.8.
+		// https://github.com/golang/go/commit/90b8a0ca2d0b565c7c7199ffcf77b15ea6b6db3a
+		// But we keep this function idempotent because it is safer.
+		return nil
 	}
 
 	err := stmt.mc.writeCommandPacketUint32(comStmtClose, stmt.id)


### PR DESCRIPTION
### Description

ErrBadConn needs special care to ensure it is safe to retry.
To improve maintenance, I don't want to use the error where I don't have to.

Additionally, update the old comment about Go's bug that had been fixed long time ago.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the connection closing process, ensuring that multiple calls to close the connection do not result in errors.
  
- **Documentation**
	- Updated comments to clarify the idempotency of the `Close` method and its behavior in relation to connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->