### PR TITLE
Fix context cancelling without sending COMM_QUIT for authenticated connection

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -169,6 +169,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 		mc.cleanup()
 		return nil, err
 	}
+	mc.authed = true
 
 	if mc.cfg.MaxAllowedPacket > 0 {
 		mc.maxAllowedPacket = mc.cfg.MaxAllowedPacket


### PR DESCRIPTION
### Description
Fix #1648 

Currently, I don't know how to detect whether the connection is successful, so I added the 'authed' variable to mysqlConn. If you have a better approach, please share it with me.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an authentication tracking feature for database connections.
	- Enhanced error handling during connection cancellation and cleanup processes.

- **Bug Fixes**
	- Improved robustness of connection management logic related to authentication state.

- **Documentation**
	- Updated method signatures and field declarations for clarity on authentication handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->