### PR TITLE
use binary.LittleEndian

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -502,19 +502,6 @@ func getUint24(data []byte) int {
 	return int(data[2])<<16 | int(data[1])<<8 | int(data[0])
 }
 
-func uint64ToBytes(n uint64) []byte {
-	return []byte{
-		byte(n),
-		byte(n >> 8),
-		byte(n >> 16),
-		byte(n >> 24),
-		byte(n >> 32),
-		byte(n >> 40),
-		byte(n >> 48),
-		byte(n >> 56),
-	}
-}
-
 func uint64ToString(n uint64) []byte {
 	var a [20]byte
 	i := 20
@@ -598,18 +585,15 @@ func readLengthEncodedInteger(b []byte) (uint64, bool, int) {
 
 	// 252: value of following 2
 	case 0xfc:
-		return uint64(b[1]) | uint64(b[2])<<8, false, 3
+		return uint64(binary.LittleEndian.Uint16(b[1:])), false, 3
 
 	// 253: value of following 3
 	case 0xfd:
-		return uint64(b[1]) | uint64(b[2])<<8 | uint64(b[3])<<16, false, 4
+		return uint64(getUint24(b[1:])), false, 4
 
 	// 254: value of following 8
 	case 0xfe:
-		return uint64(b[1]) | uint64(b[2])<<8 | uint64(b[3])<<16 |
-				uint64(b[4])<<24 | uint64(b[5])<<32 | uint64(b[6])<<40 |
-				uint64(b[7])<<48 | uint64(b[8])<<56,
-			false, 9
+		return uint64(binary.LittleEndian.Uint64(b[1:])), false, 9
 	}
 
 	// 0-250: value of first byte
@@ -623,13 +607,14 @@ func appendLengthEncodedInteger(b []byte, n uint64) []byte {
 		return append(b, byte(n))
 
 	case n <= 0xffff:
-		return append(b, 0xfc, byte(n), byte(n>>8))
+		b = append(b, 0xfc)
+		return binary.LittleEndian.AppendUint16(b, uint16(n))
 
 	case n <= 0xffffff:
 		return append(b, 0xfd, byte(n), byte(n>>8), byte(n>>16))
 	}
-	return append(b, 0xfe, byte(n), byte(n>>8), byte(n>>16), byte(n>>24),
-		byte(n>>32), byte(n>>40), byte(n>>48), byte(n>>56))
+	b = append(b, 0xfe)
+	return binary.LittleEndian.AppendUint64(b, n)
 }
 
 func appendLengthEncodedString(b []byte, s string) []byte {


### PR DESCRIPTION
### Description

Recent Go inlining functions well.
Using `LittleEndian.Put*` would better for readability and minimize bound check.

Additionally, Go 1.19 introduced `LittleEndian.Append*`. It reduce more code.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of packet data and length-encoded integers for improved performance and clarity.
  
- **Bug Fixes**
	- Refined error handling for reading length-encoded integers to ensure accurate value identification.

- **Documentation**
	- Minor adjustments made to comments for better clarity regarding updated logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->