### PR TITLE
better max_allowed_packet parsing

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -11,6 +11,7 @@ package mysql
 import (
 	"context"
 	"database/sql/driver"
+	"fmt"
 	"net"
 	"os"
 	"strconv"
@@ -179,7 +180,12 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 			mc.Close()
 			return nil, err
 		}
-		mc.maxAllowedPacket = stringToInt(maxap) - 1
+		n, err := strconv.Atoi(string(maxap))
+		if err != nil {
+			mc.Close()
+			return nil, fmt.Errorf("invalid max_allowed_packet value (%q): %w", maxap, err)
+		}
+		mc.maxAllowedPacket = n - 1
 	}
 	if mc.maxAllowedPacket < maxPacketSize {
 		mc.maxWriteSize = mc.maxAllowedPacket

--- a/utils.go
+++ b/utils.go
@@ -524,16 +524,6 @@ func uint64ToString(n uint64) []byte {
 	return a[i:]
 }
 
-// treats string value as unsigned integer representation
-func stringToInt(b []byte) int {
-	val := 0
-	for i := range b {
-		val *= 10
-		val += int(b[i] - 0x30)
-	}
-	return val
-}
-
 // returns the string read as a bytes slice, whether the value is NULL,
 // the number of bytes read and an error, in case the string is longer than
 // the input slice


### PR DESCRIPTION
### Description

Remove `stringToInt()` and use `strconv.Atoi` instead.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for `max_allowed_packet` configuration conversion
  - Enhanced error reporting when invalid integer values are encountered

- **Refactor**
  - Replaced custom string-to-integer conversion with standard library method
  - Removed custom conversion utility function

<!-- end of auto-generated comment: release notes by coderabbit.ai -->