### PR TITLE
add Go 1.24 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,10 @@ jobs:
           import os
           go = [
               # Keep the most recent production release at the top
-              '1.23',
+              '1.24',
               # Older production releases
+              '1.23',
               '1.22',
-              '1.21',
           ]
           mysql = [
               '9.0',

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A MySQL-Driver for Go's [database/sql](https://golang.org/pkg/database/sql/) pac
 
 ## Requirements
 
-* Go 1.21 or higher. We aim to support the 3 latest versions of Go.
+* Go 1.22 or higher. We aim to support the 3 latest versions of Go.
 * MySQL (5.7+) and MariaDB (10.5+) are supported.
 * [TiDB](https://github.com/pingcap/tidb) is supported by PingCAP.
   * Do not ask questions about TiDB in our issue tracker or forum.

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/go-sql-driver/mysql
 
-go 1.21.0
+go 1.22.0
 
 require filippo.io/edwards25519 v1.1.0


### PR DESCRIPTION
### Description
add Go 1.24 to the test matrix.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
