### PR TITLE
go.mod: fix go version format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/go-sql-driver/mysql
 
-go 1.21
+go 1.21.0
 
 require filippo.io/edwards25519 v1.1.0


### PR DESCRIPTION
As of Go 1.21, toolchain versions must use the 1.N.P syntax. https://go.dev/doc/toolchain#version

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the internal language version specification for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->