### PR TITLE
Transaction Commit/Rollback returns conn's cached error, if present

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,6 +25,7 @@ Asta Xie <xiemengjun at gmail.com>
 B Lamarche <blam413 at gmail.com>
 Bes Dollma <bdollma@thousandeyes.com>
 Bogdan Constantinescu <bog.con.bc at gmail.com>
+Brad Higgins <brad at defined.net>
 Brian Hendriks <brian at dolthub.com>
 Bulat Gaifullin <gaifullinbf at gmail.com>
 Caine Jette <jette at alum.mit.edu>
@@ -133,6 +134,7 @@ Ziheng Lyu <zihenglv at gmail.com>
 
 Barracuda Networks, Inc.
 Counting Ltd.
+Defined Networking Inc.
 DigitalOcean Inc.
 Dolthub Inc.
 dyves labs AG

--- a/transaction.go
+++ b/transaction.go
@@ -13,8 +13,15 @@ type mysqlTx struct {
 }
 
 func (tx *mysqlTx) Commit() (err error) {
-	if tx.mc == nil || tx.mc.closed.Load() {
+	if tx.mc == nil {
 		return ErrInvalidConn
+	}
+	if tx.mc.closed.Load() {
+		err = tx.mc.error()
+		if err == nil {
+			err = ErrInvalidConn
+		}
+		return
 	}
 	err = tx.mc.exec("COMMIT")
 	tx.mc = nil
@@ -22,8 +29,15 @@ func (tx *mysqlTx) Commit() (err error) {
 }
 
 func (tx *mysqlTx) Rollback() (err error) {
-	if tx.mc == nil || tx.mc.closed.Load() {
+	if tx.mc == nil {
 		return ErrInvalidConn
+	}
+	if tx.mc.closed.Load() {
+		err = tx.mc.error()
+		if err == nil {
+			err = ErrInvalidConn
+		}
+		return
 	}
 	err = tx.mc.exec("ROLLBACK")
 	tx.mc = nil


### PR DESCRIPTION
### Description
Fix #1690, if a transaction connection has a cached error, return it instead of ErrInvalidConn during Commit/Rollback operations.

### Checklist
- [ x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible) (The condition is a race which can be difficult to duplicate in tests)
- [x ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the contributor list with a new individual and organization, ensuring the recognition remains organized.

- **Bug Fixes**
  - Improved error reporting during transactional operations to deliver clearer, more specific feedback when connection issues arise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->