### PR TITLE
add BenchmarkReceive10kRowsCompress

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,10 @@ jobs:
         run: |
           go test -v '-race' '-covermode=atomic' '-coverprofile=coverage.out' -parallel 10
 
+      - name: benchmark
+        run: |
+          go test -run '^$' -bench .
+
       - name: Send coverage
         uses: shogo82148/actions-goveralls@v1
         with:


### PR DESCRIPTION
### Description
* Rename BenchmarkReceiveMassiveRows to BenchmarkReceive10kRows
* Add BenchmarkReceive10kRowsCompress that run BenchmarkReceiveMassiveRows with compression
* Other tiny benchmark improvements.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved and expanded Go benchmark tests for database operations, including new benchmarks for compressed and uncompressed scenarios.
  - Enhanced efficiency and clarity of benchmark setup and execution.
  - Updated naming conventions for benchmark functions for better consistency.
- **Chores**
  - Added an automated benchmark step to the continuous integration workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->