### PR TITLE
MariaDB Metadata skipping and DEPRECATE_EOF

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -89,7 +89,7 @@ func TestAuthFastCachingSHA256PasswordCached(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestAuthFastCachingSHA256PasswordEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,7 +176,7 @@ func TestAuthFastCachingSHA256PasswordFullRSA(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -232,7 +232,7 @@ func TestAuthFastCachingSHA256PasswordFullRSAWithKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -284,7 +284,7 @@ func TestAuthFastCachingSHA256PasswordFullSecure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,7 +357,7 @@ func TestAuthFastCleartextPassword(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,7 +400,7 @@ func TestAuthFastCleartextPasswordEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -459,7 +459,7 @@ func TestAuthFastNativePassword(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -502,7 +502,7 @@ func TestAuthFastNativePasswordEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -544,7 +544,7 @@ func TestAuthFastSHA256PasswordEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -592,7 +592,7 @@ func TestAuthFastSHA256PasswordRSA(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -641,7 +641,7 @@ func TestAuthFastSHA256PasswordRSAWithKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -678,7 +678,7 @@ func TestAuthFastSHA256PasswordSecure(t *testing.T) {
 	// unset TLS config to prevent the actual establishment of a TLS wrapper
 	mc.cfg.TLS = nil
 
-	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1343,7 +1343,7 @@ func TestEd25519Auth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/auth_test.go
+++ b/auth_test.go
@@ -89,7 +89,7 @@ func TestAuthFastCachingSHA256PasswordCached(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestAuthFastCachingSHA256PasswordEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,7 +176,7 @@ func TestAuthFastCachingSHA256PasswordFullRSA(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -232,7 +232,7 @@ func TestAuthFastCachingSHA256PasswordFullRSAWithKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -284,7 +284,7 @@ func TestAuthFastCachingSHA256PasswordFullSecure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,7 +357,7 @@ func TestAuthFastCleartextPassword(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,7 +400,7 @@ func TestAuthFastCleartextPasswordEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -459,7 +459,7 @@ func TestAuthFastNativePassword(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -502,7 +502,7 @@ func TestAuthFastNativePasswordEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -544,7 +544,7 @@ func TestAuthFastSHA256PasswordEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -592,7 +592,7 @@ func TestAuthFastSHA256PasswordRSA(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -641,7 +641,7 @@ func TestAuthFastSHA256PasswordRSAWithKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -678,7 +678,7 @@ func TestAuthFastSHA256PasswordSecure(t *testing.T) {
 	// unset TLS config to prevent the actual establishment of a TLS wrapper
 	mc.cfg.TLS = nil
 
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1343,7 +1343,7 @@ func TestEd25519Auth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mc.writeHandshakeResponsePacket(authResp, plugin)
+	err = mc.writeHandshakeResponsePacket(authResp, 0, 0, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -484,8 +484,8 @@ func BenchmarkReceiveMetadata(b *testing.B) {
 		db.SetMaxIdleConns(1)
 
 		// Create a slice to scan all columns
-		values := make([]interface{}, 1000)
-		valuePtrs := make([]interface{}, 1000)
+		values := make([]any, 1000)
+		valuePtrs := make([]any, 1000)
 		for j := range values {
 			valuePtrs[j] = &values[j]
 		}
@@ -498,7 +498,7 @@ func BenchmarkReceiveMetadata(b *testing.B) {
 		defer stmt.Close()
 
 		// Benchmark metadata retrieval
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			rows := tb.checkRows(stmt.Query())
 
 			rows.Next()

--- a/connection.go
+++ b/connection.go
@@ -391,7 +391,7 @@ func (mc *mysqlConn) exec(query string) error {
 		}
 
 		// rows
-		if err := mc.skipResultSetRows(); err != nil {
+		if err := mc.skipRows(); err != nil {
 			return err
 		}
 	}
@@ -477,7 +477,7 @@ func (mc *mysqlConn) getSystemVar(name string) ([]byte, error) {
 
 		dest := make([]driver.Value, resLen)
 		if err = rows.readRow(dest); err == nil {
-			return dest[0].([]byte), mc.skipResultSetRows()
+			return dest[0].([]byte), mc.skipRows()
 		}
 	}
 	return nil, err

--- a/connection.go
+++ b/connection.go
@@ -24,22 +24,22 @@ import (
 )
 
 type mysqlConn struct {
-	buf                   buffer
-	netConn               net.Conn
-	rawConn               net.Conn    // underlying connection when netConn is TLS connection.
-	result                mysqlResult // managed by clearResult() and handleOkPacket().
-	compIO                *compIO
-	cfg                   *Config
-	connector             *connector
-	maxAllowedPacket      int
-	maxWriteSize          int
-	clientCapabilities    capabilityFlag
-	clientExtCapabilities extendedCapabilityFlag
-	status                statusFlag
-	sequence              uint8
-	compressSequence      uint8
-	parseTime             bool
-	compress              bool
+	buf              buffer
+	netConn          net.Conn
+	rawConn          net.Conn    // underlying connection when netConn is TLS connection.
+	result           mysqlResult // managed by clearResult() and handleOkPacket().
+	compIO           *compIO
+	cfg              *Config
+	connector        *connector
+	maxAllowedPacket int
+	maxWriteSize     int
+	capabilities     capabilityFlag
+	extCapabilities  extendedCapabilityFlag
+	status           statusFlag
+	sequence         uint8
+	compressSequence uint8
+	parseTime        bool
+	compress         bool
 
 	// for context support (Go 1.8+)
 	watching bool
@@ -230,7 +230,7 @@ func (mc *mysqlConn) Prepare(query string) (driver.Stmt, error) {
 		}
 
 		if columnCount > 0 {
-			if mc.clientExtCapabilities&clientCacheMetadata != 0 {
+			if mc.extCapabilities&clientCacheMetadata != 0 {
 				if stmt.columns, err = mc.readColumns(int(columnCount)); err != nil {
 					return nil, err
 				}

--- a/connection.go
+++ b/connection.go
@@ -24,21 +24,22 @@ import (
 )
 
 type mysqlConn struct {
-	buf              buffer
-	netConn          net.Conn
-	rawConn          net.Conn    // underlying connection when netConn is TLS connection.
-	result           mysqlResult // managed by clearResult() and handleOkPacket().
-	compIO           *compIO
-	cfg              *Config
-	connector        *connector
-	maxAllowedPacket int
-	maxWriteSize     int
-	flags            clientFlag
-	status           statusFlag
-	sequence         uint8
-	compressSequence uint8
-	parseTime        bool
-	compress         bool
+	buf                   buffer
+	netConn               net.Conn
+	rawConn               net.Conn    // underlying connection when netConn is TLS connection.
+	result                mysqlResult // managed by clearResult() and handleOkPacket().
+	compIO                *compIO
+	cfg                   *Config
+	connector             *connector
+	maxAllowedPacket      int
+	maxWriteSize          int
+	clientCapabilities    capabilityFlag
+	clientExtCapabilities extendedCapabilityFlag
+	status                statusFlag
+	sequence              uint8
+	compressSequence      uint8
+	parseTime             bool
+	compress              bool
 
 	// for context support (Go 1.8+)
 	watching bool
@@ -223,13 +224,21 @@ func (mc *mysqlConn) Prepare(query string) (driver.Stmt, error) {
 	columnCount, err := stmt.readPrepareResultPacket()
 	if err == nil {
 		if stmt.paramCount > 0 {
-			if err = mc.readUntilEOF(); err != nil {
+			if err = mc.skipColumns(stmt.paramCount); err != nil {
 				return nil, err
 			}
 		}
 
 		if columnCount > 0 {
-			err = mc.readUntilEOF()
+			if mc.clientExtCapabilities&clientCacheMetadata != 0 {
+				if stmt.columns, err = mc.readColumns(int(columnCount)); err != nil {
+					return nil, err
+				}
+			} else {
+				if err = mc.skipColumns(int(columnCount)); err != nil {
+					return nil, err
+				}
+			}
 		}
 	}
 
@@ -370,19 +379,19 @@ func (mc *mysqlConn) exec(query string) error {
 	}
 
 	// Read Result
-	resLen, err := handleOk.readResultSetHeaderPacket()
+	resLen, _, err := handleOk.readResultSetHeaderPacket()
 	if err != nil {
 		return err
 	}
 
 	if resLen > 0 {
 		// columns
-		if err := mc.readUntilEOF(); err != nil {
+		if err := mc.skipColumns(resLen); err != nil {
 			return err
 		}
 
 		// rows
-		if err := mc.readUntilEOF(); err != nil {
+		if err := mc.skipResultSetRows(); err != nil {
 			return err
 		}
 	}
@@ -419,7 +428,7 @@ func (mc *mysqlConn) query(query string, args []driver.Value) (*textRows, error)
 
 	// Read Result
 	var resLen int
-	resLen, err = handleOk.readResultSetHeaderPacket()
+	resLen, _, err = handleOk.readResultSetHeaderPacket()
 	if err != nil {
 		return nil, err
 	}
@@ -453,7 +462,7 @@ func (mc *mysqlConn) getSystemVar(name string) ([]byte, error) {
 	}
 
 	// Read Result
-	resLen, err := handleOk.readResultSetHeaderPacket()
+	resLen, _, err := handleOk.readResultSetHeaderPacket()
 	if err == nil {
 		rows := new(textRows)
 		rows.mc = mc
@@ -461,14 +470,14 @@ func (mc *mysqlConn) getSystemVar(name string) ([]byte, error) {
 
 		if resLen > 0 {
 			// Columns
-			if err := mc.readUntilEOF(); err != nil {
+			if err := mc.skipColumns(resLen); err != nil {
 				return nil, err
 			}
 		}
 
 		dest := make([]driver.Value, resLen)
 		if err = rows.readRow(dest); err == nil {
-			return dest[0].([]byte), mc.readUntilEOF()
+			return dest[0].([]byte), mc.skipResultSetRows()
 		}
 	}
 	return nil, err

--- a/connector.go
+++ b/connector.go
@@ -137,10 +137,6 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 		return nil, err
 	}
 
-	if mc.cfg.TLS != nil && serverCapabilities&clientSSL == 0 {
-		return nil, fmt.Errorf("TLS is required, but server doesn't support it")
-	}
-
 	if plugin == "" {
 		plugin = defaultAuthPlugin
 	}

--- a/const.go
+++ b/const.go
@@ -43,10 +43,10 @@ const (
 )
 
 // https://dev.mysql.com/doc/internals/en/capability-flags.html#packet-Protocol::CapabilityFlags
-type clientFlag uint32
+type capabilityFlag uint32
 
 const (
-	clientLongPassword clientFlag = 1 << iota
+	clientMySQL capabilityFlag = 1 << iota
 	clientFoundRows
 	clientLongFlag
 	clientConnectWithDB
@@ -71,6 +71,18 @@ const (
 	clientCanHandleExpiredPasswords
 	clientSessionTrack
 	clientDeprecateEOF
+)
+
+// https://mariadb.com/kb/en/connection/#capabilities
+type extendedCapabilityFlag uint32
+
+const (
+	progressIndicator extendedCapabilityFlag = 1 << iota
+	clientComMulti
+	clientStmtBulkOperations
+	clientExtendedMetadata
+	clientCacheMetadata
+	clientUnitBulkResult
 )
 
 const (

--- a/const.go
+++ b/const.go
@@ -42,7 +42,8 @@ const (
 	iERR          byte = 0xff
 )
 
-// https://dev.mysql.com/doc/internals/en/capability-flags.html#packet-Protocol::CapabilityFlags
+// https://dev.mysql.com/doc/dev/mysql-server/latest/group__group__cs__capabilities__flags.html
+// https://mariadb.com/kb/en/connection/#capabilities
 type capabilityFlag uint32
 
 const (

--- a/packets.go
+++ b/packets.go
@@ -363,13 +363,11 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, plugin string
 		}
 		// MariaDB Extended Capabilities
 		binary.LittleEndian.PutUint32(data[13+19:], uint32(mc.extCapabilities))
-		pos += 4
 	} else {
 		for ; pos < 13+23; pos++ {
 			data[pos] = 0
 		}
 	}
-	// assert len(data) == pos
 
 	// SSL Connection Request Packet
 	// https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_ssl_request.html
@@ -707,7 +705,7 @@ func (mc *okHandler) handleOkPacket(data []byte) error {
 func (mc *mysqlConn) readColumns(count int) ([]mysqlField, error) {
 	columns := make([]mysqlField, count)
 
-	for i := 0; i < count; i++ {
+	for i := range count {
 		data, err := mc.readPacket()
 		if err != nil {
 			return nil, err
@@ -905,6 +903,7 @@ func (mc *mysqlConn) skipPackets(n int) error {
 	return nil
 }
 
+// skips EOF packet after n * ColumnDefinition packets when clientDeprecateEOF is not set
 func (mc *mysqlConn) skipEof() error {
 	if mc.capabilities&clientDeprecateEOF == 0 {
 		if _, err := mc.readPacket(); err != nil {

--- a/packets_test.go
+++ b/packets_test.go
@@ -332,9 +332,17 @@ func TestRegression801(t *testing.T) {
 		112, 97, 115, 115, 119, 111, 114, 100}
 	conn.maxReads = 1
 
-	authData, pluginName, err := mc.readHandshakePacket()
+	authData, serverCapabilities, serverExtendedCapabilities, pluginName, err := mc.readHandshakePacket()
 	if err != nil {
 		t.Fatalf("got error: %v", err)
+	}
+
+	if serverCapabilities != 2148530143 {
+		t.Fatalf("expected serverCapabilities to be 2148530143, got %v", serverCapabilities)
+	}
+
+	if serverExtendedCapabilities != 0 {
+		t.Fatalf("expected serverExtendedCapabilities to be 0, got %v", serverExtendedCapabilities)
 	}
 
 	if pluginName != "mysql_native_password" {

--- a/rows.go
+++ b/rows.go
@@ -113,7 +113,7 @@ func (rows *mysqlRows) Close() (err error) {
 
 	// Remove unread packets from stream
 	if !rows.rs.done {
-		err = mc.skipResultSetRows()
+		err = mc.skipRows()
 	}
 	if err == nil {
 		handleOk := mc.clearResult()
@@ -143,7 +143,7 @@ func (rows *mysqlRows) nextResultSet() (int, error) {
 
 	// Remove unread packets from stream
 	if !rows.rs.done {
-		if err := rows.mc.skipResultSetRows(); err != nil {
+		if err := rows.mc.skipRows(); err != nil {
 			return 0, err
 		}
 		rows.rs.done = true

--- a/rows.go
+++ b/rows.go
@@ -113,7 +113,7 @@ func (rows *mysqlRows) Close() (err error) {
 
 	// Remove unread packets from stream
 	if !rows.rs.done {
-		err = mc.readUntilEOF()
+		err = mc.skipResultSetRows()
 	}
 	if err == nil {
 		handleOk := mc.clearResult()
@@ -143,7 +143,7 @@ func (rows *mysqlRows) nextResultSet() (int, error) {
 
 	// Remove unread packets from stream
 	if !rows.rs.done {
-		if err := rows.mc.readUntilEOF(); err != nil {
+		if err := rows.mc.skipResultSetRows(); err != nil {
 			return 0, err
 		}
 		rows.rs.done = true
@@ -156,7 +156,7 @@ func (rows *mysqlRows) nextResultSet() (int, error) {
 	rows.rs = resultSet{}
 	// rows.mc.affectedRows and rows.mc.insertIds accumulate on each call to
 	// nextResultSet.
-	resLen, err := rows.mc.resultUnchanged().readResultSetHeaderPacket()
+	resLen, _, err := rows.mc.resultUnchanged().readResultSetHeaderPacket()
 	if err != nil {
 		// Clean up about multi-results flag
 		rows.rs.done = true

--- a/statement.go
+++ b/statement.go
@@ -20,6 +20,7 @@ type mysqlStmt struct {
 	mc         *mysqlConn
 	id         uint32
 	paramCount int
+	columns    []mysqlField
 }
 
 func (stmt *mysqlStmt) Close() error {
@@ -64,19 +65,19 @@ func (stmt *mysqlStmt) Exec(args []driver.Value) (driver.Result, error) {
 	handleOk := stmt.mc.clearResult()
 
 	// Read Result
-	resLen, err := handleOk.readResultSetHeaderPacket()
+	resLen, _, err := handleOk.readResultSetHeaderPacket()
 	if err != nil {
 		return nil, err
 	}
 
 	if resLen > 0 {
 		// Columns
-		if err = mc.readUntilEOF(); err != nil {
+		if err = mc.skipColumns(resLen); err != nil {
 			return nil, err
 		}
 
 		// Rows
-		if err := mc.readUntilEOF(); err != nil {
+		if err = mc.skipResultSetRows(); err != nil {
 			return nil, err
 		}
 	}
@@ -107,7 +108,7 @@ func (stmt *mysqlStmt) query(args []driver.Value) (*binaryRows, error) {
 
 	// Read Result
 	handleOk := stmt.mc.clearResult()
-	resLen, err := handleOk.readResultSetHeaderPacket()
+	resLen, metadataFollows, err := handleOk.readResultSetHeaderPacket()
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +117,17 @@ func (stmt *mysqlStmt) query(args []driver.Value) (*binaryRows, error) {
 
 	if resLen > 0 {
 		rows.mc = mc
-		rows.rs.columns, err = mc.readColumns(resLen)
+		if metadataFollows {
+			if rows.rs.columns, err = mc.readColumns(resLen); err != nil {
+				return nil, err
+			}
+			stmt.columns = rows.rs.columns
+		} else {
+			if err = mc.skipEof(); err != nil {
+				return nil, err
+			}
+			rows.rs.columns = stmt.columns
+		}
 	} else {
 		rows.rs.done = true
 

--- a/statement.go
+++ b/statement.go
@@ -77,7 +77,7 @@ func (stmt *mysqlStmt) Exec(args []driver.Value) (driver.Result, error) {
 		}
 
 		// Rows
-		if err = mc.skipResultSetRows(); err != nil {
+		if err = mc.skipRows(); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
### Implement MariaDB metadata skipping

This is in replacement for #1692, for a simplier (still requiring lots of changes). 
See [MariaDB metadata skipping](https://mariadb.com/kb/en/mariadb-protocol-differences-with-mysql/#prepare-statement-skipping-metadata). With this change, MariaDB server won't send metadata when they have not changed, saving client parsing metadata and network. 

Even if metadata skipping change is not so big, this rely on big changes : 
* capabilities support 
* EOF packet deprecation makes current implementation to be revised

A benchmark BenchmarkReceiveMetadata has been added to show the difference. 
On a local server, difference gain is only a few percent. 
on a distant server, difference is huge. Example here with a server next to client : 
goos: linux
goarch: amd64
pkg: github.com/go-sql-driver/mysql
cpu: 11th Gen Intel(R) Core(TM) i9-11900K @ 3.50GHz
BenchmarkReceiveMetadata
BenchmarkReceiveMetadata/query

before : 
BenchmarkReceiveMetadata/query-16         	     138	   7849971 ns/op	   90379 B/op	    1015 allocs/op

after change:
BenchmarkReceiveMetadata/query-16         	     362	   2974155 ns/op	   33337 B/op	      16 allocs/op

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a benchmark to measure performance when retrieving many metadata columns.
  - Improved support for MariaDB extended connection capabilities and metadata caching in queries.

- **Bug Fixes**
  - Enhanced protocol compliance and robustness in handling server capabilities and EOF packet processing.

- **Refactor**
  - Streamlined internal handling of capability flags and packet reading for improved performance and maintainability.

- **Tests**
  - Updated tests to cover new capability negotiation logic and benchmark scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->