### PR TITLE
Optimization: statements reuse previous column name

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -490,14 +490,13 @@ func BenchmarkReceiveMetadata(b *testing.B) {
 			valuePtrs[j] = &values[j]
 		}
 
-		b.ReportAllocs()
-		b.ResetTimer()
-
 		// Prepare a SELECT query to retrieve metadata
 		stmt := tb.checkStmt(db.Prepare("SELECT * FROM large_integer_table LIMIT 1"))
 		defer stmt.Close()
 
 		// Benchmark metadata retrieval
+		b.ReportAllocs()
+		b.ResetTimer()
 		for range b.N {
 			rows := tb.checkRows(stmt.Query())
 

--- a/connection.go
+++ b/connection.go
@@ -231,7 +231,7 @@ func (mc *mysqlConn) Prepare(query string) (driver.Stmt, error) {
 
 		if columnCount > 0 {
 			if mc.extCapabilities&clientCacheMetadata != 0 {
-				if stmt.columns, err = mc.readColumns(int(columnCount)); err != nil {
+				if stmt.columns, err = mc.readColumns(int(columnCount), nil); err != nil {
 					return nil, err
 				}
 			} else {
@@ -448,7 +448,7 @@ func (mc *mysqlConn) query(query string, args []driver.Value) (*textRows, error)
 	}
 
 	// Columns
-	rows.rs.columns, err = mc.readColumns(resLen)
+	rows.rs.columns, err = mc.readColumns(resLen, nil)
 	return rows, err
 }
 

--- a/rows.go
+++ b/rows.go
@@ -186,7 +186,7 @@ func (rows *binaryRows) NextResultSet() error {
 		return err
 	}
 
-	rows.rs.columns, err = rows.mc.readColumns(resLen)
+	rows.rs.columns, err = rows.mc.readColumns(resLen, nil)
 	return err
 }
 
@@ -208,7 +208,7 @@ func (rows *textRows) NextResultSet() (err error) {
 		return err
 	}
 
-	rows.rs.columns, err = rows.mc.readColumns(resLen)
+	rows.rs.columns, err = rows.mc.readColumns(resLen, nil)
 	return err
 }
 

--- a/statement.go
+++ b/statement.go
@@ -74,7 +74,7 @@ func (stmt *mysqlStmt) Exec(args []driver.Value) (driver.Result, error) {
 		// Columns
 		if metadataFollows && stmt.mc.extCapabilities&clientCacheMetadata != 0 {
 			// we can not skip column metadata because next stmt.Query() may use it.
-			if stmt.columns, err = mc.readColumns(resLen); err != nil {
+			if stmt.columns, err = mc.readColumns(resLen, stmt.columns); err != nil {
 				return nil, err
 			}
 		} else {
@@ -125,7 +125,7 @@ func (stmt *mysqlStmt) query(args []driver.Value) (*binaryRows, error) {
 	if resLen > 0 {
 		rows.mc = mc
 		if metadataFollows {
-			if rows.rs.columns, err = mc.readColumns(resLen); err != nil {
+			if rows.rs.columns, err = mc.readColumns(resLen, stmt.columns); err != nil {
 				return nil, err
 			}
 			stmt.columns = rows.rs.columns


### PR DESCRIPTION
### Description

#1708 added `[]mysqlField` cache to stmt. It was used only for MariaDB cached metadata.

This commit allows MySQL to also benefit from the metadata cache. If the column names are the same as the cached metadata, it reuses them instead of allocating new strings.

```
$ ~/go/bin/benchstat master.txt reuse.txt
goos: darwin
goarch: arm64
pkg: github.com/go-sql-driver/mysql
cpu: Apple M1 Pro
                  │ master.txt  │           reuse.txt           │
                  │   sec/op    │   sec/op     vs base          │
ReceiveMetadata-8   1.273m ± 2%   1.269m ± 2%  ~ (p=1.000 n=10)

                  │  master.txt  │              reuse.txt              │
                  │     B/op     │     B/op      vs base               │
ReceiveMetadata-8   88.17Ki ± 0%   80.39Ki ± 0%  -8.82% (p=0.000 n=10)

                  │  master.txt  │             reuse.txt              │
                  │  allocs/op   │ allocs/op   vs base                │
ReceiveMetadata-8   1015.00 ± 0%   16.00 ± 0%  -98.42% (p=0.000 n=10)
```

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
	- Reduced unnecessary memory allocations when reading column metadata, resulting in improved efficiency during query execution.
- **Tests**
	- Updated benchmark timing to more accurately measure only the metadata retrieval and scanning phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->