### PR TITLE
[test] update MariaDB test versions to support one

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,12 +39,10 @@ jobs:
               '8.4', # LTS
               '8.0',
               '5.7',
+              'mariadb-11.8',   # LTS
               'mariadb-11.4',   # LTS
-              'mariadb-11.2',
-              'mariadb-11.1',
               'mariadb-10.11',  # LTS
               'mariadb-10.6',   # LTS
-              'mariadb-10.5',   # LTS
           ]
 
           includes = []


### PR DESCRIPTION
This update test suite to currently support servers. 

* adds MariaDB 11.8 LTS server
* remove EOL servers 10.5, 11.1 and 11.2

see https://endoflife.date/mariadb