### PR TITLE
Introduce a new method mysqlConn.Reset()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,6 +42,7 @@ Demouth <yuya at demouth.net>
 Diego Dupin <diego.dupin at gmail.com>
 Dirkjan Bussink <d.bussink at gmail.com>
 DisposaBoy <disposaboy at dby.me>
+Dmitry Zenovich <dzenovich at gmail.com>
 Egor Smolyakov <egorsmkv at gmail.com>
 Erwan Martin <hello at erwan.io>
 Evan Elias <evan at skeema.net>

--- a/connection.go
+++ b/connection.go
@@ -687,7 +687,7 @@ func (mc *mysqlConn) startWatcher() {
 
 // Reset resets the MySQL connection.
 func (mc *mysqlConn) Reset(ctx context.Context) (err error) {
-	return mc.sendNoArgsCommandWithResultOK(ctx, comConnReset)
+	return mc.sendNoArgsCommandWithResultOK(ctx, comResetConnection)
 }
 
 func (mc *mysqlConn) CheckNamedValue(nv *driver.NamedValue) (err error) {

--- a/connection.go
+++ b/connection.go
@@ -685,7 +685,16 @@ func (mc *mysqlConn) startWatcher() {
 	}()
 }
 
-// Reset resets the MySQL connection.
+// Reset resets the server-side session state using COM_RESET_CONNECTION.
+// It clears most per-session state (e.g., user variables, prepared statements)
+// without re-authenticating.
+// Usage hint: call via database/sql.Conn.Raw using a method assertion:
+//   conn.Raw(func(c any) error {
+//     if r, ok := c.(interface{ Reset(context.Context) error }); ok {
+//       return r.Reset(ctx)
+//     }
+//     return nil
+//   })
 func (mc *mysqlConn) Reset(ctx context.Context) (err error) {
 	return mc.sendSimpleCommandOK(ctx, comResetConnection)
 }

--- a/connection.go
+++ b/connection.go
@@ -503,10 +503,10 @@ func (mc *mysqlConn) finish() {
 
 // Ping implements driver.Pinger interface
 func (mc *mysqlConn) Ping(ctx context.Context) (err error) {
-	return mc.sendNoArgsCommandWithResultOK(ctx, comPing)
+	return mc.sendSimpleCommandOK(ctx, comPing)
 }
 
-func (mc *mysqlConn) sendNoArgsCommandWithResultOK(ctx context.Context, cmd byte) (err error) {
+func (mc *mysqlConn) sendSimpleCommandOK(ctx context.Context, cmd byte) (err error) {
 	if mc.closed.Load() {
 		return driver.ErrBadConn
 	}
@@ -687,7 +687,7 @@ func (mc *mysqlConn) startWatcher() {
 
 // Reset resets the MySQL connection.
 func (mc *mysqlConn) Reset(ctx context.Context) (err error) {
-	return mc.sendNoArgsCommandWithResultOK(ctx, comResetConnection)
+	return mc.sendSimpleCommandOK(ctx, comResetConnection)
 }
 
 func (mc *mysqlConn) CheckNamedValue(nv *driver.NamedValue) (err error) {

--- a/connection.go
+++ b/connection.go
@@ -685,6 +685,11 @@ func (mc *mysqlConn) startWatcher() {
 	}()
 }
 
+// Reset resets the MySQL connection.
+func (mc *mysqlConn) Reset(ctx context.Context) (err error) {
+	return mc.sendNoArgsCommandWithResultOK(ctx, comConnReset)
+}
+
 func (mc *mysqlConn) CheckNamedValue(nv *driver.NamedValue) (err error) {
 	nv.Value, err = converter{}.ConvertValue(nv.Value)
 	return

--- a/connection.go
+++ b/connection.go
@@ -503,6 +503,10 @@ func (mc *mysqlConn) finish() {
 
 // Ping implements driver.Pinger interface
 func (mc *mysqlConn) Ping(ctx context.Context) (err error) {
+	return mc.sendNoArgsCommandWithResultOK(ctx, comPing)
+}
+
+func (mc *mysqlConn) sendNoArgsCommandWithResultOK(ctx context.Context, cmd byte) (err error) {
 	if mc.closed.Load() {
 		return driver.ErrBadConn
 	}
@@ -513,7 +517,7 @@ func (mc *mysqlConn) Ping(ctx context.Context) (err error) {
 	defer mc.finish()
 
 	handleOk := mc.clearResult()
-	if err = mc.writeCommandPacket(comPing); err != nil {
+	if err = mc.writeCommandPacket(cmd); err != nil {
 		return mc.markBadConn(err)
 	}
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -129,65 +129,98 @@ func TestCheckNamedValue(t *testing.T) {
 	}
 }
 
-// TestCleanCancel tests passed context is cancelled at start.
+// TestNoArgsCommandCleanCancel tests passed context is cancelled at start.
 // No packet should be sent.  Connection should keep current status.
-func TestCleanCancel(t *testing.T) {
-	mc := &mysqlConn{
-		closech: make(chan struct{}),
-	}
-	mc.startWatcher()
-	defer mc.cleanup()
+func TestNoArgsCommandCleanCancel(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		funcToCall func(ctx context.Context, mc *mysqlConn) error
+	} {
+		{name: "Ping", funcToCall: func(ctx context.Context, mc *mysqlConn) error { return mc.Ping(ctx) }},
+		{name: "Reset", funcToCall: func(ctx context.Context, mc *mysqlConn) error { return mc.Reset(ctx) }},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			mc := &mysqlConn{
+				closech: make(chan struct{}),
+			}
+			mc.startWatcher()
+			defer mc.cleanup()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
 
-	for range 3 { // Repeat same behavior
-		err := mc.Ping(ctx)
-		if err != context.Canceled {
-			t.Errorf("expected context.Canceled, got %#v", err)
-		}
+			for range 3 { // Repeat same behavior
+				err := test.funcToCall(ctx, mc)
+				if err != context.Canceled {
+					t.Errorf("expected context.Canceled, got %#v", err)
+				}
 
-		if mc.closed.Load() {
-			t.Error("expected mc is not closed, closed actually")
-		}
+				if mc.closed.Load() {
+					t.Error("expected mc is not closed, closed actually")
+				}
 
-		if mc.watching {
-			t.Error("expected watching is false, but true")
-		}
-	}
-}
-
-func TestPingMarkBadConnection(t *testing.T) {
-	nc := badConnection{err: errors.New("boom")}
-	mc := &mysqlConn{
-		netConn:          nc,
-		buf:              newBuffer(),
-		maxAllowedPacket: defaultMaxAllowedPacket,
-		closech:          make(chan struct{}),
-		cfg:              NewConfig(),
-	}
-
-	err := mc.Ping(context.Background())
-
-	if err != driver.ErrBadConn {
-		t.Errorf("expected driver.ErrBadConn, got  %#v", err)
+				if mc.watching {
+					t.Error("expected watching is false, but true")
+				}
+			}
+		})
 	}
 }
 
-func TestPingErrInvalidConn(t *testing.T) {
-	nc := badConnection{err: errors.New("failed to write"), n: 10}
-	mc := &mysqlConn{
-		netConn:          nc,
-		buf:              newBuffer(),
-		maxAllowedPacket: defaultMaxAllowedPacket,
-		closech:          make(chan struct{}),
-		cfg:              NewConfig(),
+func TestNoArgsCommandMarkBadConnection(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		funcToCall func(mc *mysqlConn) error
+	} {
+		{name: "Ping", funcToCall: func(mc *mysqlConn) error { return mc.Ping(context.Background()) }},
+		{name: "Reset", funcToCall: func(mc *mysqlConn) error { return mc.Reset(context.Background()) }},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			nc := badConnection{err: errors.New("boom")}
+			mc := &mysqlConn{
+				netConn:          nc,
+				buf:              newBuffer(),
+				maxAllowedPacket: defaultMaxAllowedPacket,
+				closech:          make(chan struct{}),
+				cfg:              NewConfig(),
+			}
+
+			err := test.funcToCall(mc)
+
+			if err != driver.ErrBadConn {
+				t.Errorf("expected driver.ErrBadConn, got  %#v", err)
+			}
+		})
 	}
+}
 
-	err := mc.Ping(context.Background())
+func TestNoArgsCommandErrInvalidConn(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		funcToCall func(mc *mysqlConn) error
+	} {
+		{name: "Ping", funcToCall: func(mc *mysqlConn) error { return mc.Ping(context.Background()) }},
+		{name: "Reset", funcToCall: func(mc *mysqlConn) error { return mc.Reset(context.Background()) }},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			nc := badConnection{err: errors.New("failed to write"), n: 10}
+			mc := &mysqlConn{
+				netConn:          nc,
+				buf:              newBuffer(),
+				maxAllowedPacket: defaultMaxAllowedPacket,
+				closech:          make(chan struct{}),
+				cfg:              NewConfig(),
+			}
 
-	if err != nc.err {
-		t.Errorf("expected %#v, got  %#v", nc.err, err)
+			err := test.funcToCall(mc)
+
+			if err != nc.err {
+				t.Errorf("expected %#v, got  %#v", nc.err, err)
+			}
+		})
 	}
 }
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -129,9 +129,9 @@ func TestCheckNamedValue(t *testing.T) {
 	}
 }
 
-// TestNoArgsCommandCleanCancel tests passed context is cancelled at start.
+// TestSimpleCommandOKCleanCancel tests passed context is cancelled at start.
 // No packet should be sent.  Connection should keep current status.
-func TestNoArgsCommandCleanCancel(t *testing.T) {
+func TestSimpleCommandOKCleanCancel(t *testing.T) {
 	for _, test := range []struct {
 		name string
 		funcToCall func(ctx context.Context, mc *mysqlConn) error
@@ -168,7 +168,7 @@ func TestNoArgsCommandCleanCancel(t *testing.T) {
 	}
 }
 
-func TestNoArgsCommandMarkBadConnection(t *testing.T) {
+func TestSimpleCommandOKMarkBadConnection(t *testing.T) {
 	for _, test := range []struct {
 		name string
 		funcToCall func(mc *mysqlConn) error
@@ -196,7 +196,7 @@ func TestNoArgsCommandMarkBadConnection(t *testing.T) {
 	}
 }
 
-func TestNoArgsCommandErrInvalidConn(t *testing.T) {
+func TestSimpleCommandOKErrInvalidConn(t *testing.T) {
 	for _, test := range []struct {
 		name string
 		funcToCall func(mc *mysqlConn) error

--- a/const.go
+++ b/const.go
@@ -115,7 +115,9 @@ const (
 	comStmtReset
 	comSetOption
 	comStmtFetch
-	comConnReset = 31
+	comDaemon
+	comBinlogDumpGTID
+	comResetConnection
 )
 
 // https://dev.mysql.com/doc/internals/en/com-query-response.html#packet-Protocol::ColumnType

--- a/const.go
+++ b/const.go
@@ -115,6 +115,7 @@ const (
 	comStmtReset
 	comSetOption
 	comStmtFetch
+	comConnReset = 31
 )
 
 // https://dev.mysql.com/doc/internals/en/com-query-response.html#packet-Protocol::ColumnType

--- a/driver_test.go
+++ b/driver_test.go
@@ -2353,9 +2353,9 @@ func TestSimpleCommandOK(t *testing.T) {
 					c := conn.(*mysqlConn)
 
 					// Issue a query that sets affectedRows and insertIds.
-					q, err := c.Query(`SELECT 1`, nil)
+					q, err := c.QueryContext(ctx, `SELECT 1`, nil)
 					if err != nil {
-						dbt.fail("Conn", "Query", err)
+						dbt.fail("Conn", "QueryContext", err)
 					}
 					if got, want := c.result.affectedRows, []int64{0}; !reflect.DeepEqual(got, want) {
 						dbt.Fatalf("bad affectedRows: got %v, want=%v", got, want)
@@ -2363,7 +2363,9 @@ func TestSimpleCommandOK(t *testing.T) {
 					if got, want := c.result.insertIds, []int64{0}; !reflect.DeepEqual(got, want) {
 						dbt.Fatalf("bad insertIds: got %v, want=%v", got, want)
 					}
-					q.Close()
+					if err := q.Close(); err != nil {
+						dbt.fail("Rows", "Close", err)
+					}
 
 					// Verify that Ping()/Reset() clears both fields.
 					for range 2 {
@@ -2437,6 +2439,8 @@ func TestReset(t *testing.T) {
 			if err != nil {
 				dbt.fail("Conn", "QueryContext", err)
 			}
+			// We intentionally do not clear the destination before calling Next()
+			// to make sure the SELECT really returns nil
 			err = rows.Next(result)
 			if err != nil {
 				dbt.fail("Rows", "Next", err)

--- a/driver_test.go
+++ b/driver_test.go
@@ -2439,8 +2439,8 @@ func TestReset(t *testing.T) {
 			if err != nil {
 				dbt.fail("Conn", "QueryContext", err)
 			}
-			// We intentionally do not clear the destination before calling Next()
-			// to make sure the SELECT really returns nil
+			// Seed with a sentinel to ensure Rows.Next overwrites it with nil.
+			result = []driver.Value{"sentinel-non-nil"}
 			err = rows.Next(result)
 			if err != nil {
 				dbt.fail("Rows", "Next", err)

--- a/driver_test.go
+++ b/driver_test.go
@@ -2322,13 +2322,69 @@ func TestRejectReadOnly(t *testing.T) {
 }
 
 func TestPing(t *testing.T) {
-	ctx := context.Background()
 	runTests(t, dsn, func(dbt *DBTest) {
 		if err := dbt.db.Ping(); err != nil {
 			dbt.fail("Ping", "Ping", err)
 		}
 	})
+}
 
+func TestNoArgsCommand(t *testing.T) {
+	ctx := context.Background()
+	for _, test := range []struct{
+		method string
+		query string
+		funcToCall func(ctx context.Context, mc *mysqlConn) error
+	} {
+		{method: "Ping", query: "Ping", funcToCall: func(ctx context.Context, mc *mysqlConn) error {return mc.Ping(ctx)}},
+		{method: "Conn", query: "Reset", funcToCall: func(ctx context.Context, mc *mysqlConn) error {return mc.Reset(ctx)}},
+	} {
+		test := test
+		t.Run(test.method+"_"+test.query, func(t *testing.T) {
+			runTests(t, dsn, func(dbt *DBTest) {
+				conn, err := dbt.db.Conn(ctx)
+				if err != nil {
+					dbt.fail("db", "Conn", err)
+				}
+
+				// Check that affectedRows and insertIds are cleared after each call.
+				conn.Raw(func(conn any) error {
+					c := conn.(*mysqlConn)
+
+					// Issue a query that sets affectedRows and insertIds.
+					q, err := c.Query(`SELECT 1`, nil)
+					if err != nil {
+						dbt.fail("Conn", "Query", err)
+					}
+					if got, want := c.result.affectedRows, []int64{0}; !reflect.DeepEqual(got, want) {
+						dbt.Fatalf("bad affectedRows: got %v, want=%v", got, want)
+					}
+					if got, want := c.result.insertIds, []int64{0}; !reflect.DeepEqual(got, want) {
+						dbt.Fatalf("bad insertIds: got %v, want=%v", got, want)
+					}
+					q.Close()
+
+					// Verify that Ping()/Reset() clears both fields.
+					for range 2 {
+						if err := test.funcToCall(ctx, c); err != nil {
+							dbt.fail(test.method, test.query, err)
+						}
+						if got, want := c.result.affectedRows, []int64(nil); !reflect.DeepEqual(got, want) {
+							t.Errorf("bad affectedRows: got %v, want=%v", got, want)
+						}
+						if got, want := c.result.insertIds, []int64(nil); !reflect.DeepEqual(got, want) {
+							t.Errorf("bad affectedRows: got %v, want=%v", got, want)
+						}
+					}
+					return nil
+				})
+			})
+		})
+	}
+}
+
+func TestReset(t *testing.T) {
+	ctx := context.Background()
 	runTests(t, dsn, func(dbt *DBTest) {
 		conn, err := dbt.db.Conn(ctx)
 		if err != nil {
@@ -2339,31 +2395,49 @@ func TestPing(t *testing.T) {
 		conn.Raw(func(conn any) error {
 			c := conn.(*mysqlConn)
 
-			// Issue a query that sets affectedRows and insertIds.
-			q, err := c.Query(`SELECT 1`, nil)
+			_, err = c.ExecContext(ctx, "SET @a := 1", nil)
 			if err != nil {
-				dbt.fail("Conn", "Query", err)
+				dbt.fail("Conn", "ExecContext", err)
 			}
-			if got, want := c.result.affectedRows, []int64{0}; !reflect.DeepEqual(got, want) {
-				dbt.Fatalf("bad affectedRows: got %v, want=%v", got, want)
+			var rows driver.Rows
+			rows, err = c.QueryContext(ctx, "SELECT @a", nil)
+			if err != nil {
+				dbt.fail("Conn", "QueryContext", err)
 			}
-			if got, want := c.result.insertIds, []int64{0}; !reflect.DeepEqual(got, want) {
-				dbt.Fatalf("bad insertIds: got %v, want=%v", got, want)
+			result := []driver.Value{0}
+			err = rows.Next(result)
+			if err != nil {
+				dbt.fail("Rows", "Next", err)
 			}
-			q.Close()
+			err = rows.Close()
+			if err != nil {
+				dbt.fail("Rows", "Close", err)
+			}
+			if !reflect.DeepEqual([]driver.Value{int64(1)}, result) {
+				dbt.Fatalf("failed to set @a to 1 with SET: got %v, want=%v", result, []driver.Value{int64(1)})
+			}
 
-			// Verify that Ping() clears both fields.
-			for range 2 {
-				if err := c.Ping(ctx); err != nil {
-					dbt.fail("Pinger", "Ping", err)
-				}
-				if got, want := c.result.affectedRows, []int64(nil); !reflect.DeepEqual(got, want) {
-					t.Errorf("bad affectedRows: got %v, want=%v", got, want)
-				}
-				if got, want := c.result.insertIds, []int64(nil); !reflect.DeepEqual(got, want) {
-					t.Errorf("bad affectedRows: got %v, want=%v", got, want)
-				}
+			err = c.Reset(ctx)
+			if err != nil {
+				dbt.fail("Conn", "Reset", err)
 			}
+
+			rows, err = c.QueryContext(ctx, "SELECT @a", nil)
+			if err != nil {
+				dbt.fail("Conn", "QueryContext", err)
+			}
+			err = rows.Next(result)
+			if err != nil {
+				dbt.fail("Rows", "Next", err)
+			}
+			err = rows.Close()
+			if err != nil {
+				dbt.fail("Rows", "Close", err)
+			}
+			if !reflect.DeepEqual([]driver.Value{nil}, result) {
+				dbt.Fatalf("Reset did not reset the session (@a is still set): got %v, want=%v", result, []driver.Value{nil})
+			}
+
 			return nil
 		})
 	})

--- a/driver_test.go
+++ b/driver_test.go
@@ -2368,6 +2368,11 @@ func TestSimpleCommandOK(t *testing.T) {
 					// Verify that Ping()/Reset() clears both fields.
 					for range 2 {
 						if err := test.funcToCall(ctx, c); err != nil {
+							// Skip Reset on servers lacking COM_RESET_CONNECTION support.
+							if test.query == "Reset" {
+								maybeSkip(t, err, 1047) // ER_UNKNOWN_COM_ERROR
+								maybeSkip(t, err, 1235) // ER_NOT_SUPPORTED_YET
+							}
 							dbt.fail(test.method, test.query, err)
 						}
 						if got, want := c.result.affectedRows, []int64(nil); !reflect.DeepEqual(got, want) {
@@ -2406,7 +2411,7 @@ func TestReset(t *testing.T) {
 			if err != nil {
 				dbt.fail("Conn", "QueryContext", err)
 			}
-			result := []driver.Value{0}
+			result := []driver.Value{nil}
 			err = rows.Next(result)
 			if err != nil {
 				dbt.fail("Rows", "Next", err)
@@ -2415,12 +2420,16 @@ func TestReset(t *testing.T) {
 			if err != nil {
 				dbt.fail("Rows", "Close", err)
 			}
-			if !reflect.DeepEqual([]driver.Value{int64(1)}, result) {
-				dbt.Fatalf("failed to set @a to 1 with SET: got %v, want=%v", result, []driver.Value{int64(1)})
+			if !(reflect.DeepEqual([]driver.Value{int64(1)}, result) ||
+				reflect.DeepEqual([]driver.Value{[]byte("1")}, result)) {
+				dbt.Fatalf("failed to set @a to 1 with SET: got %v, want int64(1) or []byte(\"1\")", result)
 			}
 
 			err = c.Reset(ctx)
 			if err != nil {
+				// Allow skipping on unsupported COM_RESET_CONNECTION
+				maybeSkip(t, err, 1047) // ER_UNKNOWN_COM_ERROR
+				maybeSkip(t, err, 1235) // ER_NOT_SUPPORTED_YET
 				dbt.fail("Conn", "Reset", err)
 			}
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -2329,14 +2329,14 @@ func TestPing(t *testing.T) {
 	})
 }
 
-func TestNoArgsCommand(t *testing.T) {
+func TestSimpleCommandOK(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range []struct{
 		method string
 		query string
 		funcToCall func(ctx context.Context, mc *mysqlConn) error
 	} {
-		{method: "Ping", query: "Ping", funcToCall: func(ctx context.Context, mc *mysqlConn) error {return mc.Ping(ctx)}},
+		{method: "Pinger", query: "Ping", funcToCall: func(ctx context.Context, mc *mysqlConn) error {return mc.Ping(ctx)}},
 		{method: "Conn", query: "Reset", funcToCall: func(ctx context.Context, mc *mysqlConn) error {return mc.Reset(ctx)}},
 	} {
 		test := test
@@ -2346,6 +2346,7 @@ func TestNoArgsCommand(t *testing.T) {
 				if err != nil {
 					dbt.fail("db", "Conn", err)
 				}
+				defer conn.Close()
 
 				// Check that affectedRows and insertIds are cleared after each call.
 				conn.Raw(func(conn any) error {
@@ -2373,7 +2374,7 @@ func TestNoArgsCommand(t *testing.T) {
 							t.Errorf("bad affectedRows: got %v, want=%v", got, want)
 						}
 						if got, want := c.result.insertIds, []int64(nil); !reflect.DeepEqual(got, want) {
-							t.Errorf("bad affectedRows: got %v, want=%v", got, want)
+							t.Errorf("bad insertIds: got %v, want=%v", got, want)
 						}
 					}
 					return nil
@@ -2390,8 +2391,9 @@ func TestReset(t *testing.T) {
 		if err != nil {
 			dbt.fail("db", "Conn", err)
 		}
+		defer conn.Close()
 
-		// Check that affectedRows and insertIds are cleared after each call.
+		// Verify that COM_RESET_CONNECTION clears session state (e.g., user variables).
 		conn.Raw(func(conn any) error {
 			c := conn.(*mysqlConn)
 


### PR DESCRIPTION
### Description
This PR introduces a new method mysqlConn.Reset() sending COM_RESET_CONNECTION to the connection and checking the result.

As discussed in #1273, although there are strong reasons (https://github.com/go-sql-driver/mysql/issues/1273#issuecomment-2227210191,  https://github.com/go-sql-driver/mysql/issues/1273#issuecomment-3202690653) to call this new method in mysqlConn.ResetSession() (probably at the end of the method), we are not going to call it for now because it has not been decided yet.

Here, we only add the implementation to allow people not to go through creating dirty hacks like those here: https://github.com/France-ioi/AlgoreaBackend/blob/master/app/database/mysql_conn_reset.go#L95

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
