### PR TITLE
dsn: document that usernames containing colons require NewConfig()

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -392,7 +392,13 @@ func (cfg *Config) FormatDSN() string {
 	return buf.String()
 }
 
-// ParseDSN parses the DSN string to a Config
+// ParseDSN parses the DSN string to a Config.
+//
+// The DSN format is [user[:password]@][net[(addr)]]/dbname[?params].
+// Because the colon is used as the user/password separator, usernames that
+// contain a colon cannot be represented unambiguously in the DSN string format.
+// If your username contains a colon, use [NewConfig] and set the fields directly
+// instead of constructing a DSN string.
 func ParseDSN(dsn string) (cfg *Config, err error) {
 	// New config with some default values
 	cfg = NewConfig()


### PR DESCRIPTION
## Updated Approach

After the maintainer review (thank you @shogo82148 and @methane), I've updated this PR to be **documentation-only** — no behavioral change.

### What changed

Added a godoc note to `ParseDSN` explaining the fundamental ambiguity:

```go
// ParseDSN parses the DSN string to a Config.
//
// The DSN format is [user[:password]@][net[(addr)]]/dbname[?params].
// Because the colon is used as the user/password separator, usernames that
// contain a colon cannot be represented unambiguously in the DSN string format.
// If your username contains a colon, use NewConfig and set the fields directly
// instead of constructing a DSN string.
```

### Why this approach

The original fix (last colon) broke passwords containing colons — a symmetric bug to the one it was fixing. There is no unambiguous parse rule for the `user:password@` portion when either field can contain a colon.

The correct solution is to steer users to `NewConfig()`, which has no such ambiguity.

Fixes #1747