### PR TITLE
result: don't panic when affectedRows/insertIds are empty

### DIFF
--- a/result.go
+++ b/result.go
@@ -36,10 +36,16 @@ type mysqlResult struct {
 }
 
 func (res *mysqlResult) LastInsertId() (int64, error) {
+	if len(res.insertIds) == 0 {
+		return 0, nil
+	}
 	return res.insertIds[len(res.insertIds)-1], nil
 }
 
 func (res *mysqlResult) RowsAffected() (int64, error) {
+	if len(res.affectedRows) == 0 {
+		return 0, nil
+	}
 	return res.affectedRows[len(res.affectedRows)-1], nil
 }
 

--- a/result_test.go
+++ b/result_test.go
@@ -1,0 +1,22 @@
+// Go MySQL Driver - A MySQL-Driver for Go's database/sql package
+//
+// Copyright 2026 The Go-MySQL-Driver Authors. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package mysql
+
+import "testing"
+
+// Regression for #1733: indexing into an empty result slice used to panic.
+func TestEmptyResult(t *testing.T) {
+	r := &mysqlResult{}
+	if id, err := r.LastInsertId(); err != nil || id != 0 {
+		t.Errorf("LastInsertId() = (%d, %v), want (0, nil)", id, err)
+	}
+	if rows, err := r.RowsAffected(); err != nil || rows != 0 {
+		t.Errorf("RowsAffected() = (%d, %v), want (0, nil)", rows, err)
+	}
+}


### PR DESCRIPTION
Closes #1733.

`mysqlResult.LastInsertId` / `RowsAffected` indexed into their slices without checking length, so any code path that left the slices empty (e.g. an error before the affected-rows packet) panicked the caller. Return `0, nil` instead, which matches the `database/sql.Result` contract for "no rows affected".