### PR TITLE
dsn: default Net to tcp in NewConfig so Addr-only configs round-trip

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -91,7 +91,6 @@ type Option func(*Config) error
 // NewConfig creates a new Config and sets default values.
 func NewConfig() *Config {
 	cfg := &Config{
-		Net:                  "tcp",
 		Loc:                  time.UTC,
 		MaxAllowedPacket:     defaultMaxAllowedPacket,
 		Logger:               defaultLogger,
@@ -264,14 +263,20 @@ func (cfg *Config) FormatDSN() string {
 		buf.WriteByte('@')
 	}
 
-	// [protocol[(address)]]. Skip the bare protocol when no address is
-	// set, otherwise FormatDSN(NewConfig()) would always print 'tcp/'
-	// even though there's nothing to connect to.
-	if len(cfg.Net) > 0 && len(cfg.Addr) > 0 {
-		buf.WriteString(cfg.Net)
+	// [protocol[(address)]]
+	if len(cfg.Addr) > 0 {
+		net := cfg.Net
+		if net == "" {
+			net = "tcp"
+		}
+		buf.WriteString(net)
 		buf.WriteByte('(')
 		buf.WriteString(cfg.Addr)
 		buf.WriteByte(')')
+	} else if cfg.Net != "" && cfg.Net != "tcp" {
+		// Preserve an explicit non-default protocol when there's no
+		// address, so e.g. Net="unix" still round-trips.
+		buf.WriteString(cfg.Net)
 	}
 
 	// /dbname

--- a/dsn.go
+++ b/dsn.go
@@ -91,6 +91,7 @@ type Option func(*Config) error
 // NewConfig creates a new Config and sets default values.
 func NewConfig() *Config {
 	cfg := &Config{
+		Net:                  "tcp",
 		Loc:                  time.UTC,
 		MaxAllowedPacket:     defaultMaxAllowedPacket,
 		Logger:               defaultLogger,
@@ -263,14 +264,14 @@ func (cfg *Config) FormatDSN() string {
 		buf.WriteByte('@')
 	}
 
-	// [protocol[(address)]]
-	if len(cfg.Net) > 0 {
+	// [protocol[(address)]]. Skip the bare protocol when no address is
+	// set, otherwise FormatDSN(NewConfig()) would always print 'tcp/'
+	// even though there's nothing to connect to.
+	if len(cfg.Net) > 0 && len(cfg.Addr) > 0 {
 		buf.WriteString(cfg.Net)
-		if len(cfg.Addr) > 0 {
-			buf.WriteByte('(')
-			buf.WriteString(cfg.Addr)
-			buf.WriteByte(')')
-		}
+		buf.WriteByte('(')
+		buf.WriteString(cfg.Addr)
+		buf.WriteByte(')')
 	}
 
 	// /dbname

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -355,6 +355,18 @@ func TestFormatDSN_NetWithoutAddr(t *testing.T) {
 	}
 }
 
+func TestFormatDSN_AddrWithoutNet(t *testing.T) {
+	// Direct check of the bug from #1616: an Addr-only Config should
+	// format with the default tcp protocol so it round-trips.
+	cfg := NewConfig()
+	cfg.Addr = "myhost:3306"
+	got := cfg.FormatDSN()
+	want := "tcp(myhost:3306)/"
+	if got != want {
+		t.Errorf("FormatDSN() = %q, want %q", got, want)
+	}
+}
+
 func TestParamsAreSorted(t *testing.T) {
 	expected := "/dbname?interpolateParams=true&foobar=baz&quux=loo"
 	cfg := NewConfig()

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -330,6 +330,31 @@ func TestDSNUnsafeCollation(t *testing.T) {
 	}
 }
 
+func TestFormatDSN_NetWithoutAddr(t *testing.T) {
+	// An explicit non-default Net should still appear in the formatted
+	// DSN when Addr is empty, so the Config round-trips.
+	cases := []struct {
+		name string
+		net  string
+		want string
+	}{
+		{"unix without addr", "unix", "unix/"},
+		// tcp is the default; dropping it is a no-op on parse.
+		{"tcp without addr", "tcp", "/"},
+		{"empty net empty addr", "", "/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := NewConfig()
+			cfg.Net = tc.net
+			cfg.Addr = ""
+			if got := cfg.FormatDSN(); got != tc.want {
+				t.Errorf("FormatDSN() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestParamsAreSorted(t *testing.T) {
 	expected := "/dbname?interpolateParams=true&foobar=baz&quux=loo"
 	cfg := NewConfig()


### PR DESCRIPTION
Closes #1616.

`NewConfig()` left `Net` empty, so building a Config in code with just an `Addr` and calling `FormatDSN` produced `/` instead of `tcp(my-address)/`. Default `Net` to `tcp` (matching the docs) and skip the bare protocol in `FormatDSN` when there's no `Addr`, so a fresh `NewConfig().FormatDSN()` doesn't grow a useless `tcp` prefix.