### PR TITLE
Add LTS MariaDB 11.8 and 12.3 into the testing matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,6 @@ jobs:
               '8.4', # LTS
               '8.0',
               '5.7',
-              'mariadb-13.0',
               'mariadb-12.3',   # LTS
               'mariadb-11.8',   # LTS
               'mariadb-11.4',   # LTS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
               '8.4', # LTS
               '8.0',
               '5.7',
-              'mariadb-13.0'
+              'mariadb-13.0',
               'mariadb-12.3',   # LTS
               'mariadb-11.8',   # LTS
               'mariadb-11.4',   # LTS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,6 @@ jobs:
               'mariadb-12.3',   # LTS
               'mariadb-11.8',   # LTS
               'mariadb-11.4',   # LTS
-              'mariadb-11.2',
-              'mariadb-11.1',
               'mariadb-10.11',  # LTS
               'mariadb-10.6',   # LTS
               'mariadb-10.5',   # LTS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ jobs:
               '8.4', # LTS
               '8.0',
               '5.7',
+              'mariadb-13.0'
+              'mariadb-12.3',   # LTS
+              'mariadb-11.8',   # LTS
               'mariadb-11.4',   # LTS
               'mariadb-11.2',
               'mariadb-11.1',


### PR DESCRIPTION
### Description
Adds MariaDB LTS versions 11.8 and 12.3 into the testing matrix. See [MariaDB's maintenance policy](https://mariadb.org/about/#maintenance-policy) for support timelines.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
