### PR TITLE
Interpolate typed-nil json.RawMessage as NULL

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -129,6 +129,7 @@ Xiangyu Hu <xiangyu.hu at outlook.com>
 Xiaobing Jiang <s7v7nislands at gmail.com>
 Xiuming Chen <cc at cxm.cc>
 Xuehong Chan <chanxuehong at gmail.com>
+Yoshito Ohata <yoshito.dev at gmail.com>
 Zhang Xiang <angwerzx at 126.com>
 Zhenye Xie <xiezhenye at gmail.com>
 Zhixin Wen <john.wenzhixin at gmail.com>

--- a/connection.go
+++ b/connection.go
@@ -384,7 +384,9 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 						buf = append(buf, '\'')
 					}
 				case json.RawMessage:
-					if noBackslashEscapes {
+					if v == nil {
+						buf = append(buf, "NULL"...)
+					} else if noBackslashEscapes {
 						buf = escapeBytesQuotes(buf, v, false)
 					} else {
 						buf = escapeBytesBackslash(buf, v, false)

--- a/connection_test.go
+++ b/connection_test.go
@@ -65,6 +65,28 @@ func TestInterpolateParamsJSONRawMessage(t *testing.T) {
 	}
 }
 
+func TestInterpolateParamsJSONRawMessageNil(t *testing.T) {
+	mc := &mysqlConn{
+		buf:              newBuffer(),
+		maxAllowedPacket: maxPacketSize,
+		cfg: &Config{
+			InterpolateParams: true,
+		},
+	}
+
+	// A typed nil json.RawMessage must be interpolated as NULL, not as an
+	// empty quoted string. See https://github.com/go-sql-driver/mysql/issues/1781
+	q, err := mc.interpolateParams("SELECT ?", []driver.Value{json.RawMessage(nil)})
+	if err != nil {
+		t.Errorf("Expected err=nil, got %#v", err)
+		return
+	}
+	expected := `SELECT NULL`
+	if q != expected {
+		t.Errorf("Expected: %q\nGot: %q", expected, q)
+	}
+}
+
 func TestInterpolateParamsTooManyPlaceholders(t *testing.T) {
 	mc := &mysqlConn{
 		buf:              newBuffer(),


### PR DESCRIPTION
### Description

Fixes #1781.

When `interpolateParams=true`, a typed-nil `json.RawMessage` (for example a nil `json.RawMessage` carried inside a `driver.Value`/`interface{}`) was interpolated as an empty quoted string (`''`) instead of `NULL`. Inserting that into a JSON column made the server reject it with `Error 3140` (invalid JSON text value).

The typed nil passes the initial untyped-`nil` check and reaches the `case json.RawMessage:` branch in `interpolateParams` (`connection.go`), which escaped/quoted the value unconditionally. The adjacent `case []byte:` branch already guards for `nil` and emits `NULL`; this change adds the same guard so `json.RawMessage(nil)` is interpolated as `NULL`, matching the server-side prepared-statement path (`interpolateParams=false`).

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (`TestInterpolateParamsJSONRawMessageNil`)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary (not needed)
- [x] Added myself / the copyright holder to the AUTHORS file