### PR TITLE
Implement query attributes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,6 +38,7 @@ Daniel Montoya <dsmontoyam at gmail.com>
 Daniel Nichter <nil at codenode.com>
 Daniël van Eeden <git at myname.nl>
 Dave Protasowski <dprotaso at gmail.com>
+David Li <li.davidm96 at gmail.com>
 Demouth <yuya at demouth.net>
 Diego Dupin <diego.dupin at gmail.com>
 Dirkjan Bussink <d.bussink at gmail.com>

--- a/connection.go
+++ b/connection.go
@@ -40,6 +40,7 @@ type mysqlConn struct {
 	compressSequence uint8
 	parseTime        bool
 	compress         bool
+	serverVersion    [3]int
 
 	// for context support (Go 1.8+)
 	watching bool
@@ -433,6 +434,10 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 }
 
 func (mc *mysqlConn) Exec(query string, args []driver.Value) (driver.Result, error) {
+	return mc.execArgs(query, args, nil)
+}
+
+func (mc *mysqlConn) execArgs(query string, args []driver.Value, attrs []QueryAttribute) (driver.Result, error) {
 	if mc.closed.Load() {
 		return nil, driver.ErrBadConn
 	}
@@ -448,48 +453,53 @@ func (mc *mysqlConn) Exec(query string, args []driver.Value) (driver.Result, err
 		query = prepared
 	}
 
-	err := mc.exec(query)
-	if err == nil {
-		copied := mc.result
-		return &copied, err
-	}
-	return nil, mc.markBadConn(err)
-}
-
-// Internal function to execute commands
-func (mc *mysqlConn) exec(query string) error {
 	handleOk := mc.clearResult()
 	// Send command
-	if err := mc.writeCommandPacketStr(comQuery, query); err != nil {
-		return mc.markBadConn(err)
+	if err := mc.writeQueryPacket(query, attrs); err != nil {
+		return nil, mc.markBadConn(err)
 	}
 
 	// Read Result
 	resLen, _, err := handleOk.readResultSetHeaderPacket()
 	if err != nil {
-		return err
+		return nil, mc.markBadConn(err)
 	}
 
 	if resLen > 0 {
 		// columns
 		if err := mc.skipColumns(resLen); err != nil {
-			return err
+			return nil, mc.markBadConn(err)
 		}
 
 		// rows
 		if err := mc.skipRows(); err != nil {
-			return err
+			return nil, mc.markBadConn(err)
 		}
 	}
 
-	return handleOk.discardResults()
+	if err := handleOk.discardResults(); err != nil {
+		return nil, mc.markBadConn(err)
+	}
+
+	copied := mc.result
+	return &copied, nil
+}
+
+// Internal function to execute commands
+func (mc *mysqlConn) exec(query string) error {
+	_, err := mc.execArgs(query, nil, nil)
+	return err
 }
 
 func (mc *mysqlConn) Query(query string, args []driver.Value) (driver.Rows, error) {
-	return mc.query(query, args)
+	return mc.queryWithAttributes(query, args, nil)
 }
 
 func (mc *mysqlConn) query(query string, args []driver.Value) (*textRows, error) {
+	return mc.queryWithAttributes(query, args, nil)
+}
+
+func (mc *mysqlConn) queryWithAttributes(query string, args []driver.Value, attrs []QueryAttribute) (*textRows, error) {
 	handleOk := mc.clearResult()
 
 	if mc.closed.Load() {
@@ -507,7 +517,7 @@ func (mc *mysqlConn) query(query string, args []driver.Value) (*textRows, error)
 		query = prepared
 	}
 	// Send command
-	err := mc.writeCommandPacketStr(comQuery, query)
+	err := mc.writeQueryPacket(query, attrs)
 	if err != nil {
 		return nil, mc.markBadConn(err)
 	}
@@ -542,7 +552,7 @@ func (mc *mysqlConn) query(query string, args []driver.Value) (*textRows, error)
 func (mc *mysqlConn) getSystemVar(name string) (string, error) {
 	// Send command
 	handleOk := mc.clearResult()
-	if err := mc.writeCommandPacketStr(comQuery, "SELECT @@"+name); err != nil {
+	if err := mc.writeQueryPacket("SELECT @@"+name, nil); err != nil {
 		return "", err
 	}
 
@@ -634,7 +644,7 @@ func (mc *mysqlConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver
 }
 
 func (mc *mysqlConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-	dargs, err := namedValueToValue(args)
+	dargs, attrs, err := namedValueToValue(args)
 	if err != nil {
 		return nil, err
 	}
@@ -643,7 +653,7 @@ func (mc *mysqlConn) QueryContext(ctx context.Context, query string, args []driv
 		return nil, err
 	}
 
-	rows, err := mc.query(query, dargs)
+	rows, err := mc.queryWithAttributes(query, dargs, attrs)
 	if err != nil {
 		mc.finish()
 		return nil, err
@@ -653,7 +663,7 @@ func (mc *mysqlConn) QueryContext(ctx context.Context, query string, args []driv
 }
 
 func (mc *mysqlConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-	dargs, err := namedValueToValue(args)
+	dargs, attrs, err := namedValueToValue(args)
 	if err != nil {
 		return nil, err
 	}
@@ -663,7 +673,7 @@ func (mc *mysqlConn) ExecContext(ctx context.Context, query string, args []drive
 	}
 	defer mc.finish()
 
-	return mc.Exec(query, dargs)
+	return mc.execArgs(query, dargs, attrs)
 }
 
 func (mc *mysqlConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
@@ -687,7 +697,7 @@ func (mc *mysqlConn) PrepareContext(ctx context.Context, query string) (driver.S
 }
 
 func (stmt *mysqlStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
-	dargs, err := namedValueToValue(args)
+	dargs, attrs, err := namedValueToValue(args)
 	if err != nil {
 		return nil, err
 	}
@@ -696,7 +706,7 @@ func (stmt *mysqlStmt) QueryContext(ctx context.Context, args []driver.NamedValu
 		return nil, err
 	}
 
-	rows, err := stmt.query(dargs)
+	rows, err := stmt.queryWithAttributes(dargs, attrs)
 	if err != nil {
 		stmt.mc.finish()
 		return nil, err
@@ -706,7 +716,7 @@ func (stmt *mysqlStmt) QueryContext(ctx context.Context, args []driver.NamedValu
 }
 
 func (stmt *mysqlStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
-	dargs, err := namedValueToValue(args)
+	dargs, attrs, err := namedValueToValue(args)
 	if err != nil {
 		return nil, err
 	}
@@ -716,7 +726,7 @@ func (stmt *mysqlStmt) ExecContext(ctx context.Context, args []driver.NamedValue
 	}
 	defer stmt.mc.finish()
 
-	return stmt.Exec(dargs)
+	return stmt.execWithAttributes(dargs, attrs)
 }
 
 func (mc *mysqlConn) watchCancel(ctx context.Context) error {
@@ -770,6 +780,9 @@ func (mc *mysqlConn) startWatcher() {
 }
 
 func (mc *mysqlConn) CheckNamedValue(nv *driver.NamedValue) (err error) {
+	if attr, ok := nv.Value.(QueryAttribute); ok {
+		return validateQueryAttribute(attr)
+	}
 	nv.Value, err = converter{}.ConvertValue(nv.Value)
 	return
 }
@@ -806,6 +819,24 @@ func (mc *mysqlConn) ResetSession(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// supportsPreparedQueryAttributes checks whether query attributes are fully supported.
+func (mc *mysqlConn) supportsPreparedQueryAttributes() bool {
+	if mc.capabilities&clientQueryAttributes == 0 {
+		return false
+	}
+
+	// MySQL < 8.0.26 had some bugs in processing query attributes
+	// The official client doesn't send query attributes for these versions, so we do the same
+	// check: https://github.com/mysql/mysql-server/blob/d229bb760c49b65e19ec28342236961ad961d7fe/libmysql/libmysql.cc#L1846-L1858
+	// send_param_count: https://github.com/mysql/mysql-server/blob/d229bb760c49b65e19ec28342236961ad961d7fe/libmysql/libmysql.cc#L1986-L1987
+	// which is checked against MySQL 8.0.26:
+	// https://github.com/mysql/mysql-server/blob/d229bb760c49b65e19ec28342236961ad961d7fe/libmysql/libmysql.cc#L1944-L1945
+
+	version := mc.serverVersion
+	return version[0] > 8 ||
+		(version[0] == 8 && (version[1] > 0 || version[1] == 0 && version[2] >= 26))
 }
 
 // IsValid implements driver.Validator interface

--- a/connection.go
+++ b/connection.go
@@ -492,7 +492,7 @@ func (mc *mysqlConn) exec(query string) error {
 }
 
 func (mc *mysqlConn) Query(query string, args []driver.Value) (driver.Rows, error) {
-	return mc.queryWithAttributes(query, args, nil)
+	return mc.query(query, args)
 }
 
 func (mc *mysqlConn) query(query string, args []driver.Value) (*textRows, error) {
@@ -781,7 +781,7 @@ func (mc *mysqlConn) startWatcher() {
 
 func (mc *mysqlConn) CheckNamedValue(nv *driver.NamedValue) (err error) {
 	if attr, ok := nv.Value.(QueryAttribute); ok {
-		return validateQueryAttribute(attr)
+		return attr.validate()
 	}
 	nv.Value, err = converter{}.ConvertValue(nv.Value)
 	return

--- a/const.go
+++ b/const.go
@@ -72,7 +72,12 @@ const (
 	clientCanHandleExpiredPasswords
 	clientSessionTrack
 	clientDeprecateEOF
+	clientOptionalResultsetMetadata
+	clientZstdCompressionAlgorithm
+	clientQueryAttributes
 )
+
+const parameterCountAvailable byte = 0x08
 
 // https://mariadb.com/kb/en/connection/#capabilities
 type extendedCapabilityFlag uint32

--- a/packets.go
+++ b/packets.go
@@ -202,8 +202,13 @@ func (mc *mysqlConn) readHandshakePacket() (data []byte, capabilities capability
 	}
 
 	// server version [null terminated string]
+	versionEnd := bytes.IndexByte(data[1:], 0x00)
+	if versionEnd < 0 {
+		return nil, 0, 0, "", ErrMalformPkt
+	}
+	mc.serverVersion = parseServerVersion(string(data[1 : 1+versionEnd]))
 	// connection id [4 bytes]
-	pos := 1 + bytes.IndexByte(data[1:], 0x00) + 1 + 4
+	pos := 1 + versionEnd + 1 + 4
 
 	// first part of the password cipher [8 bytes]
 	authData := data[pos : pos+8]
@@ -289,7 +294,8 @@ func (mc *mysqlConn) initCapabilities(serverCapabilities capabilityFlag, serverE
 			clientPluginAuth |
 			clientMultiResults |
 			clientConnectAttrs |
-			clientDeprecateEOF
+			clientDeprecateEOF |
+			clientQueryAttributes
 
 	if cfg.ClientFoundRows {
 		clientCapabilities |= clientFoundRows
@@ -467,6 +473,39 @@ func (mc *mysqlConn) writeCommandPacketStr(command byte, arg string) error {
 	copy(data[5:], arg)
 
 	// Send CMD packet
+	err = mc.writePacket(data)
+	mc.syncSequence()
+	return err
+}
+
+func (mc *mysqlConn) writeQueryPacket(query string, attrs []QueryAttribute) error {
+	if mc.capabilities&clientQueryAttributes == 0 {
+		// N.B. even if we have no attrs, if we've negotiated
+		// clientQueryAttributes, we must send the full extended packet below
+		return mc.writeCommandPacketStr(comQuery, query)
+	}
+
+	mc.resetSequence()
+	data, err := mc.buf.takeCompleteBuffer()
+	if err != nil {
+		return err
+	}
+	data = data[:5]
+	data[4] = comQuery
+	data = appendLengthEncodedInteger(data, uint64(len(attrs)))
+	data = appendLengthEncodedInteger(data, 1)
+	if len(attrs) > 0 {
+		data = append(data, make([]byte, (len(attrs)+7)/8)...)
+		data = append(data, 1)
+		for _, attr := range attrs {
+			data = append(data, byte(fieldTypeString), 0)
+			data = appendLengthEncodedString(data, attr.Name)
+		}
+		for _, attr := range attrs {
+			data = appendLengthEncodedString(data, attr.Value.(string))
+		}
+	}
+	data = append(data, query...)
 	err = mc.writePacket(data)
 	mc.syncSequence()
 	return err
@@ -1042,7 +1081,7 @@ func (stmt *mysqlStmt) writeCommandLongData(paramID int, arg []byte) error {
 
 // Execute Prepared Statement
 // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_execute.html
-func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
+func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value, attrs []QueryAttribute) error {
 	if len(args) != stmt.paramCount {
 		return fmt.Errorf(
 			"argument count mismatch (got: %d; has: %d)",
@@ -1053,6 +1092,10 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 
 	const minPktLen = 4 + 1 + 4 + 1 + 4
 	mc := stmt.mc
+	if !mc.supportsPreparedQueryAttributes() {
+		attrs = nil
+	}
+	parameterCount := len(args) + len(attrs)
 
 	// Determine threshold dynamically to avoid packet size shortage.
 	longDataSize := max(mc.maxAllowedPacket/(stmt.paramCount+1), 64)
@@ -1063,7 +1106,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 	var data []byte
 	var err error
 
-	if len(args) == 0 {
+	if parameterCount == 0 {
 		data, err = mc.buf.takeBuffer(minPktLen)
 	} else {
 		data, err = mc.buf.takeCompleteBuffer()
@@ -1081,26 +1124,35 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 
 	// flags (0: CURSOR_TYPE_NO_CURSOR) [1 byte]
 	data[9] = 0x00
+	if len(attrs) > 0 {
+		data[9] |= parameterCountAvailable
+	}
 
 	// iteration_count (uint32(1)) [4 bytes]
 	binary.LittleEndian.PutUint32(data[10:], 1)
 
-	if len(args) > 0 {
+	if parameterCount > 0 {
 		pos := minPktLen
+		if mc.capabilities&clientQueryAttributes != 0 {
+			data = appendLengthEncodedInteger(data[:pos], uint64(parameterCount))
+			pos = len(data)
+		}
 
+		maskLen := (parameterCount + 7) / 8
 		var nullMask []byte
-		if maskLen, typesLen := (len(args)+7)/8, 1+2*len(args); pos+maskLen+typesLen >= cap(data) {
+		if pos+maskLen+1 > cap(data) {
 			// buffer has to be extended but we don't know by how much so
 			// we depend on append after all data with known sizes fit.
 			// We stop at that because we deal with a lot of columns here
 			// which makes the required allocation size hard to guess.
-			tmp := make([]byte, pos+maskLen+typesLen)
+			tmp := make([]byte, pos+maskLen+1)
 			copy(tmp[:pos], data[:pos])
 			data = tmp
 			nullMask = data[pos : pos+maskLen]
 			// No need to clean nullMask as make ensures that.
 			pos += maskLen
 		} else {
+			data = data[:pos+maskLen+1]
 			nullMask = data[pos : pos+maskLen]
 			for i := range nullMask {
 				nullMask[i] = 0
@@ -1112,20 +1164,19 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 		data[pos] = 0x01
 		pos++
 
-		// type of each parameter [len(args)*2 bytes]
-		paramTypes := data[pos:]
-		pos += len(args) * 2
-
-		// value of each parameter [n bytes]
-		paramValues := data[pos:pos]
-		valuesCap := cap(paramValues)
+		paramTypes := make([]byte, 0, parameterCount*3)
+		paramValues := make([]byte, 0)
 
 		for i, arg := range args {
+			typePos := len(paramTypes)
+			paramTypes = append(paramTypes, 0, 0)
+			if mc.capabilities&clientQueryAttributes != 0 {
+				paramTypes = append(paramTypes, 0) // empty parameter name
+			}
 			// build NULL-bitmap
 			if arg == nil {
 				nullMask[i/8] |= 1 << (uint(i) & 7)
-				paramTypes[i+i] = byte(fieldTypeNULL)
-				paramTypes[i+i+1] = 0x00
+				paramTypes[typePos] = byte(fieldTypeNULL)
 				continue
 			}
 
@@ -1135,23 +1186,20 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 			// cache types and values
 			switch v := arg.(type) {
 			case int64:
-				paramTypes[i+i] = byte(fieldTypeLongLong)
-				paramTypes[i+i+1] = 0x00
+				paramTypes[typePos] = byte(fieldTypeLongLong)
 				paramValues = binary.LittleEndian.AppendUint64(paramValues, uint64(v))
 
 			case uint64:
-				paramTypes[i+i] = byte(fieldTypeLongLong)
-				paramTypes[i+i+1] = 0x80 // type is unsigned
+				paramTypes[typePos] = byte(fieldTypeLongLong)
+				paramTypes[typePos+1] = 0x80 // type is unsigned
 				paramValues = binary.LittleEndian.AppendUint64(paramValues, uint64(v))
 
 			case float64:
-				paramTypes[i+i] = byte(fieldTypeDouble)
-				paramTypes[i+i+1] = 0x00
+				paramTypes[typePos] = byte(fieldTypeDouble)
 				paramValues = binary.LittleEndian.AppendUint64(paramValues, math.Float64bits(v))
 
 			case bool:
-				paramTypes[i+i] = byte(fieldTypeTiny)
-				paramTypes[i+i+1] = 0x00
+				paramTypes[typePos] = byte(fieldTypeTiny)
 
 				if v {
 					paramValues = append(paramValues, 0x01)
@@ -1162,8 +1210,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 			case []byte:
 				// Common case (non-nil value) first
 				if v != nil {
-					paramTypes[i+i] = byte(fieldTypeString)
-					paramTypes[i+i+1] = 0x00
+					paramTypes[typePos] = byte(fieldTypeString)
 
 					if len(v) < longDataSize {
 						paramValues = appendLengthEncodedInteger(paramValues,
@@ -1180,12 +1227,10 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 
 				// Handle []byte(nil) as a NULL value
 				nullMask[i/8] |= 1 << (uint(i) & 7)
-				paramTypes[i+i] = byte(fieldTypeNULL)
-				paramTypes[i+i+1] = 0x00
+				paramTypes[typePos] = byte(fieldTypeNULL)
 
 			case string:
-				paramTypes[i+i] = byte(fieldTypeString)
-				paramTypes[i+i+1] = 0x00
+				paramTypes[typePos] = byte(fieldTypeString)
 
 				if len(v) < longDataSize {
 					paramValues = appendLengthEncodedInteger(paramValues,
@@ -1199,8 +1244,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 				}
 
 			case time.Time:
-				paramTypes[i+i] = byte(fieldTypeString)
-				paramTypes[i+i+1] = 0x00
+				paramTypes[typePos] = byte(fieldTypeString)
 
 				var a [64]byte
 				var b = a[:0]
@@ -1224,15 +1268,15 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 			}
 		}
 
-		// Check if param values exceeded the available buffer
-		// In that case we must build the data packet with the new values buffer
-		if valuesCap != cap(paramValues) {
-			data = append(data[:pos], paramValues...)
-			mc.buf.store(data) // allow this buffer to be reused
+		for _, attr := range attrs {
+			paramTypes = append(paramTypes, byte(fieldTypeString), 0)
+			paramTypes = appendLengthEncodedString(paramTypes, attr.Name)
+			paramValues = appendLengthEncodedString(paramValues, attr.Value.(string))
 		}
 
-		pos += len(paramValues)
-		data = data[:pos]
+		data = append(data[:pos], paramTypes...)
+		data = append(data, paramValues...)
+		mc.buf.store(data)
 	}
 
 	err = mc.writePacket(data)

--- a/packets.go
+++ b/packets.go
@@ -203,7 +203,10 @@ func (mc *mysqlConn) readHandshakePacket() (data []byte, capabilities capability
 
 	// server version [null terminated string]
 	versionEnd := bytes.IndexByte(data[1:], 0x00)
-	if versionEnd < 0 {
+	// check that the packet is long enough to contain the remaining
+	// fields: null terminator, then the other fields listed below
+	const fixedHandshakeSuffix = 1 + 4 + 8 + 1 + 2
+	if versionEnd < 0 || 1+versionEnd+fixedHandshakeSuffix > len(data) {
 		return nil, 0, 0, "", ErrMalformPkt
 	}
 	mc.serverVersion = parseServerVersion(string(data[1 : 1+versionEnd]))

--- a/query_attribute.go
+++ b/query_attribute.go
@@ -1,0 +1,31 @@
+// Go MySQL Driver - A MySQL-Driver for Go's database/sql package
+//
+// Copyright 2026 The Go-MySQL-Driver Authors. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package mysql
+
+import "fmt"
+
+// QueryAttribute is a per-query key-value pair sent using MySQL query
+// attributes. Query attributes are not SQL bind parameters and apply only to
+// the Exec or Query call in which they are supplied.
+//
+// Currently, Value must be a string.
+type QueryAttribute struct {
+	Name  string
+	Value any
+}
+
+func validateQueryAttribute(attr QueryAttribute) error {
+	if attr.Name == "" {
+		return fmt.Errorf("mysql: query attribute name must not be empty")
+	}
+	if _, ok := attr.Value.(string); !ok {
+		return fmt.Errorf("mysql: unsupported query attribute value type %T", attr.Value)
+	}
+	return nil
+}

--- a/query_attribute.go
+++ b/query_attribute.go
@@ -20,7 +20,7 @@ type QueryAttribute struct {
 	Value any
 }
 
-func validateQueryAttribute(attr QueryAttribute) error {
+func (attr *QueryAttribute) validate() error {
 	if attr.Name == "" {
 		return fmt.Errorf("mysql: query attribute name must not be empty")
 	}

--- a/query_attribute_test.go
+++ b/query_attribute_test.go
@@ -12,23 +12,9 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
-	"reflect"
+	"slices"
 	"testing"
 )
-
-func checkNoError(t *testing.T, err error) {
-	t.Helper()
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func checkEqual[T any](t *testing.T, want, got T) {
-	t.Helper()
-	if !reflect.DeepEqual(want, got) {
-		t.Fatalf("want %#v, got %#v", want, got)
-	}
-}
 
 func TestNamedValueToValueQueryAttributes(t *testing.T) {
 	args, attrs, err := namedValueToValue([]driver.NamedValue{
@@ -37,12 +23,20 @@ func TestNamedValueToValueQueryAttributes(t *testing.T) {
 		{Ordinal: 3, Value: "bound"},
 		{Ordinal: 4, Value: QueryAttribute{Name: "region", Value: "west"}},
 	})
-	checkNoError(t, err)
-	checkEqual(t, []driver.Value{int64(42), "bound"}, args)
-	checkEqual(t, []QueryAttribute{
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantArgs := []driver.Value{int64(42), "bound"}
+	if !slices.Equal(args, wantArgs) {
+		t.Fatalf("args = %#v; want %#v", args, wantArgs)
+	}
+	wantAttrs := []QueryAttribute{
 		{Name: "trace", Value: "abc"},
 		{Name: "region", Value: "west"},
-	}, attrs)
+	}
+	if !slices.Equal(attrs, wantAttrs) {
+		t.Fatalf("attrs = %#v; want %#v", attrs, wantAttrs)
+	}
 }
 
 func TestQueryAttributeValidation(t *testing.T) {
@@ -70,12 +64,14 @@ func TestWriteQueryPacketWithAttributes(t *testing.T) {
 	mc.capabilities = clientQueryAttributes
 
 	err := mc.writeQueryPacket("SELECT 1", []QueryAttribute{{Name: "trace", Value: "abc"}})
-	checkNoError(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(conn.written) != int(conn.written[0])+4 {
 		t.Fatalf("packet length header is %d, packet length is %d", conn.written[0], len(conn.written)-4)
 	}
-	checkEqual(t, []byte{
+	want := []byte{
 		comQuery,
 		1, 1, // parameter count and parameter set count
 		0, // null bitmap
@@ -83,7 +79,10 @@ func TestWriteQueryPacketWithAttributes(t *testing.T) {
 		byte(fieldTypeString), 0, 5, 't', 'r', 'a', 'c', 'e',
 		3, 'a', 'b', 'c',
 		'S', 'E', 'L', 'E', 'C', 'T', ' ', '1',
-	}, conn.written[4:])
+	}
+	if got := conn.written[4:]; !slices.Equal(got, want) {
+		t.Fatalf("packet = %#v; want %#v", got, want)
+	}
 }
 
 func TestWriteQueryPacketWithoutAttributes(t *testing.T) {
@@ -91,27 +90,44 @@ func TestWriteQueryPacketWithoutAttributes(t *testing.T) {
 	mc.capabilities = clientQueryAttributes
 
 	err := mc.writeQueryPacket("DO 1", nil)
-	checkNoError(t, err)
-	checkEqual(t, []byte{comQuery, 0, 1, 'D', 'O', ' ', '1'}, conn.written[4:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []byte{comQuery, 0, 1, 'D', 'O', ' ', '1'}
+	if got := conn.written[4:]; !slices.Equal(got, want) {
+		t.Fatalf("packet = %#v; want %#v", got, want)
+	}
 }
 
 func TestWriteQueryPacketAttributesDoNotPersist(t *testing.T) {
 	conn, mc := newRWMockConn(0)
 	mc.capabilities = clientQueryAttributes
 
-	checkNoError(t, mc.writeQueryPacket("DO 1", []QueryAttribute{{Name: "trace", Value: "abc"}}))
+	if err := mc.writeQueryPacket("DO 1", []QueryAttribute{{Name: "trace", Value: "abc"}}); err != nil {
+		t.Fatal(err)
+	}
 	conn.written = nil
-	checkNoError(t, mc.writeQueryPacket("DO 2", nil))
+	if err := mc.writeQueryPacket("DO 2", nil); err != nil {
+		t.Fatal(err)
+	}
 
-	checkEqual(t, []byte{comQuery, 0, 1, 'D', 'O', ' ', '2'}, conn.written[4:])
+	want := []byte{comQuery, 0, 1, 'D', 'O', ' ', '2'}
+	if got := conn.written[4:]; !slices.Equal(got, want) {
+		t.Fatalf("packet = %#v; want %#v", got, want)
+	}
 }
 
 func TestWriteQueryPacketIgnoresAttributesWithoutCapability(t *testing.T) {
 	conn, mc := newRWMockConn(0)
 
 	err := mc.writeQueryPacket("DO 1", []QueryAttribute{{Name: "trace", Value: "abc"}})
-	checkNoError(t, err)
-	checkEqual(t, []byte{comQuery, 'D', 'O', ' ', '1'}, conn.written[4:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []byte{comQuery, 'D', 'O', ' ', '1'}
+	if got := conn.written[4:]; !slices.Equal(got, want) {
+		t.Fatalf("packet = %#v; want %#v", got, want)
+	}
 }
 
 func TestWriteExecutePacketWithQueryAttribute(t *testing.T) {
@@ -124,9 +140,11 @@ func TestWriteExecutePacketWithQueryAttribute(t *testing.T) {
 		[]driver.Value{"bound"},
 		[]QueryAttribute{{Name: "trace", Value: "abc"}},
 	)
-	checkNoError(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	checkEqual(t, []byte{
+	want := []byte{
 		comStmtExecute,
 		7, 0, 0, 0,
 		parameterCountAvailable,
@@ -138,7 +156,10 @@ func TestWriteExecutePacketWithQueryAttribute(t *testing.T) {
 		byte(fieldTypeString), 0, 5, 't', 'r', 'a', 'c', 'e',
 		5, 'b', 'o', 'u', 'n', 'd',
 		3, 'a', 'b', 'c',
-	}, conn.written[4:])
+	}
+	if got := conn.written[4:]; !slices.Equal(got, want) {
+		t.Fatalf("packet = %#v; want %#v", got, want)
+	}
 }
 
 func TestWriteExecutePacketIgnoresUnsafeQueryAttribute(t *testing.T) {
@@ -148,18 +169,33 @@ func TestWriteExecutePacketIgnoresUnsafeQueryAttribute(t *testing.T) {
 	stmt := mysqlStmt{mc: mc, id: 7}
 
 	err := stmt.writeExecutePacket(nil, []QueryAttribute{{Name: "trace", Value: "abc"}})
-	checkNoError(t, err)
-	checkEqual(t, []byte{
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []byte{
 		comStmtExecute,
 		7, 0, 0, 0,
 		0,
 		1, 0, 0, 0,
-	}, conn.written[4:])
+	}
+	if got := conn.written[4:]; !slices.Equal(got, want) {
+		t.Fatalf("packet = %#v; want %#v", got, want)
+	}
 }
 
 func TestParseServerVersion(t *testing.T) {
-	checkEqual(t, [3]int{8, 0, 26}, parseServerVersion("8.0.26-commercial"))
-	checkEqual(t, [3]int{-1, -1, -1}, parseServerVersion("invalid"))
+	tests := []struct {
+		version string
+		want    [3]int
+	}{
+		{version: "8.0.26-commercial", want: [3]int{8, 0, 26}},
+		{version: "invalid", want: [3]int{-1, -1, -1}},
+	}
+	for _, test := range tests {
+		if got := parseServerVersion(test.version); got != test.want {
+			t.Errorf("parseServerVersion(%q) = %v; want %v", test.version, got, test.want)
+		}
+	}
 }
 
 func TestQueryAttributesLive(t *testing.T) {
@@ -168,52 +204,89 @@ func TestQueryAttributesLive(t *testing.T) {
 	}
 
 	db, err := sql.Open(driverNameTest, dsn)
-	checkNoError(t, err)
-	t.Cleanup(func() { checkNoError(t, db.Close()) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Error(err)
+		}
+	})
 
 	ctx := context.Background()
 	conn, err := db.Conn(ctx)
-	checkNoError(t, err)
-	t.Cleanup(func() { checkNoError(t, conn.Close()) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Close(); err != nil {
+			t.Error(err)
+		}
+	})
 
 	var versionString string
-	checkNoError(t, conn.QueryRowContext(ctx, "SELECT VERSION()").Scan(&versionString))
+	if err := conn.QueryRowContext(ctx, "SELECT VERSION()").Scan(&versionString); err != nil {
+		t.Fatal(err)
+	}
 	version := parseServerVersion(versionString)
 	if version[0] < 8 || version[0] == 8 && version[1] == 0 && version[2] < 26 {
 		t.Skipf("query attributes in prepared statements require MySQL 8.0.26 or newer; got %s", versionString)
 	}
 
 	_, err = conn.ExecContext(ctx, "CREATE TEMPORARY TABLE query_attributes_live (attribute_value VARCHAR(255), bound_value VARCHAR(255))")
-	checkNoError(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	_, err = conn.ExecContext(
 		ctx,
 		"INSERT INTO query_attributes_live VALUES (mysql_query_attribute_string('trace_id'), 'direct')",
 		QueryAttribute{Name: "trace_id", Value: "exec-direct"},
 	)
-	checkNoError(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	stmt, err := conn.PrepareContext(ctx, "INSERT INTO query_attributes_live VALUES (mysql_query_attribute_string('trace_id'), ?)")
-	checkNoError(t, err)
-	t.Cleanup(func() { checkNoError(t, stmt.Close()) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := stmt.Close(); err != nil {
+			t.Error(err)
+		}
+	})
 	_, err = stmt.ExecContext(ctx, QueryAttribute{Name: "trace_id", Value: "exec-prepared"}, "bound")
-	checkNoError(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	rows, err := conn.QueryContext(ctx, "SELECT attribute_value, bound_value FROM query_attributes_live ORDER BY bound_value")
-	checkNoError(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer rows.Close()
 
 	var values [][2]string
 	for rows.Next() {
 		var value [2]string
-		checkNoError(t, rows.Scan(&value[0], &value[1]))
+		if err := rows.Scan(&value[0], &value[1]); err != nil {
+			t.Fatal(err)
+		}
 		values = append(values, value)
 	}
-	checkNoError(t, rows.Err())
-	checkEqual(t, [][2]string{{"exec-prepared", "bound"}, {"exec-direct", "direct"}}, values)
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	want := [][2]string{{"exec-prepared", "bound"}, {"exec-direct", "direct"}}
+	if !slices.Equal(values, want) {
+		t.Fatalf("values = %#v; want %#v", values, want)
+	}
 
 	var attribute sql.NullString
-	checkNoError(t, conn.QueryRowContext(ctx, "SELECT mysql_query_attribute_string('trace_id')").Scan(&attribute))
+	if err := conn.QueryRowContext(ctx, "SELECT mysql_query_attribute_string('trace_id')").Scan(&attribute); err != nil {
+		t.Fatal(err)
+	}
 	if attribute.Valid {
 		t.Fatal("query attribute persisted to the next query")
 	}

--- a/query_attribute_test.go
+++ b/query_attribute_test.go
@@ -1,0 +1,220 @@
+// Go MySQL Driver - A MySQL-Driver for Go's database/sql package
+//
+// Copyright 2026 The Go-MySQL-Driver Authors. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"reflect"
+	"testing"
+)
+
+func checkNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func checkEqual[T any](t *testing.T, want, got T) {
+	t.Helper()
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("want %#v, got %#v", want, got)
+	}
+}
+
+func TestNamedValueToValueQueryAttributes(t *testing.T) {
+	args, attrs, err := namedValueToValue([]driver.NamedValue{
+		{Ordinal: 1, Value: int64(42)},
+		{Ordinal: 2, Value: QueryAttribute{Name: "trace", Value: "abc"}},
+		{Ordinal: 3, Value: "bound"},
+		{Ordinal: 4, Value: QueryAttribute{Name: "region", Value: "west"}},
+	})
+	checkNoError(t, err)
+	checkEqual(t, []driver.Value{int64(42), "bound"}, args)
+	checkEqual(t, []QueryAttribute{
+		{Name: "trace", Value: "abc"},
+		{Name: "region", Value: "west"},
+	}, attrs)
+}
+
+func TestQueryAttributeValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		attr QueryAttribute
+		err  string
+	}{
+		{name: "empty name", attr: QueryAttribute{Value: "value"}, err: "mysql: query attribute name must not be empty"},
+		{name: "unsupported value", attr: QueryAttribute{Name: "name", Value: 42}, err: "mysql: unsupported query attribute value type int"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := namedValueToValue([]driver.NamedValue{{Ordinal: 1, Value: test.attr}})
+			if err == nil || err.Error() != test.err {
+				t.Fatalf("want error %q, got %v", test.err, err)
+			}
+		})
+	}
+}
+
+func TestWriteQueryPacketWithAttributes(t *testing.T) {
+	conn, mc := newRWMockConn(0)
+	mc.capabilities = clientQueryAttributes
+
+	err := mc.writeQueryPacket("SELECT 1", []QueryAttribute{{Name: "trace", Value: "abc"}})
+	checkNoError(t, err)
+
+	if len(conn.written) != int(conn.written[0])+4 {
+		t.Fatalf("packet length header is %d, packet length is %d", conn.written[0], len(conn.written)-4)
+	}
+	checkEqual(t, []byte{
+		comQuery,
+		1, 1, // parameter count and parameter set count
+		0, // null bitmap
+		1, // new parameters bound
+		byte(fieldTypeString), 0, 5, 't', 'r', 'a', 'c', 'e',
+		3, 'a', 'b', 'c',
+		'S', 'E', 'L', 'E', 'C', 'T', ' ', '1',
+	}, conn.written[4:])
+}
+
+func TestWriteQueryPacketWithoutAttributes(t *testing.T) {
+	conn, mc := newRWMockConn(0)
+	mc.capabilities = clientQueryAttributes
+
+	err := mc.writeQueryPacket("DO 1", nil)
+	checkNoError(t, err)
+	checkEqual(t, []byte{comQuery, 0, 1, 'D', 'O', ' ', '1'}, conn.written[4:])
+}
+
+func TestWriteQueryPacketAttributesDoNotPersist(t *testing.T) {
+	conn, mc := newRWMockConn(0)
+	mc.capabilities = clientQueryAttributes
+
+	checkNoError(t, mc.writeQueryPacket("DO 1", []QueryAttribute{{Name: "trace", Value: "abc"}}))
+	conn.written = nil
+	checkNoError(t, mc.writeQueryPacket("DO 2", nil))
+
+	checkEqual(t, []byte{comQuery, 0, 1, 'D', 'O', ' ', '2'}, conn.written[4:])
+}
+
+func TestWriteQueryPacketIgnoresAttributesWithoutCapability(t *testing.T) {
+	conn, mc := newRWMockConn(0)
+
+	err := mc.writeQueryPacket("DO 1", []QueryAttribute{{Name: "trace", Value: "abc"}})
+	checkNoError(t, err)
+	checkEqual(t, []byte{comQuery, 'D', 'O', ' ', '1'}, conn.written[4:])
+}
+
+func TestWriteExecutePacketWithQueryAttribute(t *testing.T) {
+	conn, mc := newRWMockConn(0)
+	mc.capabilities = clientQueryAttributes
+	mc.serverVersion = [3]int{8, 0, 26}
+	stmt := mysqlStmt{mc: mc, id: 7, paramCount: 1}
+
+	err := stmt.writeExecutePacket(
+		[]driver.Value{"bound"},
+		[]QueryAttribute{{Name: "trace", Value: "abc"}},
+	)
+	checkNoError(t, err)
+
+	checkEqual(t, []byte{
+		comStmtExecute,
+		7, 0, 0, 0,
+		parameterCountAvailable,
+		1, 0, 0, 0,
+		2,                           // parameter count
+		0,                           // null bitmap
+		1,                           // new parameters bound
+		byte(fieldTypeString), 0, 0, // ordinary bind has an empty name
+		byte(fieldTypeString), 0, 5, 't', 'r', 'a', 'c', 'e',
+		5, 'b', 'o', 'u', 'n', 'd',
+		3, 'a', 'b', 'c',
+	}, conn.written[4:])
+}
+
+func TestWriteExecutePacketIgnoresUnsafeQueryAttribute(t *testing.T) {
+	conn, mc := newRWMockConn(0)
+	mc.capabilities = clientQueryAttributes
+	mc.serverVersion = [3]int{8, 0, 25}
+	stmt := mysqlStmt{mc: mc, id: 7}
+
+	err := stmt.writeExecutePacket(nil, []QueryAttribute{{Name: "trace", Value: "abc"}})
+	checkNoError(t, err)
+	checkEqual(t, []byte{
+		comStmtExecute,
+		7, 0, 0, 0,
+		0,
+		1, 0, 0, 0,
+	}, conn.written[4:])
+}
+
+func TestParseServerVersion(t *testing.T) {
+	checkEqual(t, [3]int{8, 0, 26}, parseServerVersion("8.0.26-commercial"))
+	checkEqual(t, [3]int{-1, -1, -1}, parseServerVersion("invalid"))
+}
+
+func TestQueryAttributesLive(t *testing.T) {
+	if !available {
+		t.Skipf("MySQL server not running on %s", netAddr)
+	}
+
+	db, err := sql.Open(driverNameTest, dsn)
+	checkNoError(t, err)
+	t.Cleanup(func() { checkNoError(t, db.Close()) })
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	checkNoError(t, err)
+	t.Cleanup(func() { checkNoError(t, conn.Close()) })
+
+	var versionString string
+	checkNoError(t, conn.QueryRowContext(ctx, "SELECT VERSION()").Scan(&versionString))
+	version := parseServerVersion(versionString)
+	if version[0] < 8 || version[0] == 8 && version[1] == 0 && version[2] < 26 {
+		t.Skipf("query attributes in prepared statements require MySQL 8.0.26 or newer; got %s", versionString)
+	}
+
+	_, err = conn.ExecContext(ctx, "CREATE TEMPORARY TABLE query_attributes_live (attribute_value VARCHAR(255), bound_value VARCHAR(255))")
+	checkNoError(t, err)
+
+	_, err = conn.ExecContext(
+		ctx,
+		"INSERT INTO query_attributes_live VALUES (mysql_query_attribute_string('trace_id'), 'direct')",
+		QueryAttribute{Name: "trace_id", Value: "exec-direct"},
+	)
+	checkNoError(t, err)
+
+	stmt, err := conn.PrepareContext(ctx, "INSERT INTO query_attributes_live VALUES (mysql_query_attribute_string('trace_id'), ?)")
+	checkNoError(t, err)
+	t.Cleanup(func() { checkNoError(t, stmt.Close()) })
+	_, err = stmt.ExecContext(ctx, QueryAttribute{Name: "trace_id", Value: "exec-prepared"}, "bound")
+	checkNoError(t, err)
+
+	rows, err := conn.QueryContext(ctx, "SELECT attribute_value, bound_value FROM query_attributes_live ORDER BY bound_value")
+	checkNoError(t, err)
+	defer rows.Close()
+
+	var values [][2]string
+	for rows.Next() {
+		var value [2]string
+		checkNoError(t, rows.Scan(&value[0], &value[1]))
+		values = append(values, value)
+	}
+	checkNoError(t, rows.Err())
+	checkEqual(t, [][2]string{{"exec-prepared", "bound"}, {"exec-direct", "direct"}}, values)
+
+	var attribute sql.NullString
+	checkNoError(t, conn.QueryRowContext(ctx, "SELECT mysql_query_attribute_string('trace_id')").Scan(&attribute))
+	if attribute.Valid {
+		t.Fatal("query attribute persisted to the next query")
+	}
+}

--- a/query_attribute_test.go
+++ b/query_attribute_test.go
@@ -232,6 +232,10 @@ func TestQueryAttributesLive(t *testing.T) {
 	if version[0] < 8 || version[0] == 8 && version[1] == 0 && version[2] < 26 {
 		t.Skipf("query attributes in prepared statements require MySQL 8.0.26 or newer; got %s", versionString)
 	}
+	var componentProbe sql.NullString
+	if err := conn.QueryRowContext(ctx, "SELECT mysql_query_attribute_string('trace_id')").Scan(&componentProbe); err != nil {
+		t.Skipf("query_attributes component is unavailable: %v", err)
+	}
 
 	_, err = conn.ExecContext(ctx, "CREATE TEMPORARY TABLE query_attributes_live (attribute_value VARCHAR(255), bound_value VARCHAR(255))")
 	if err != nil {

--- a/statement.go
+++ b/statement.go
@@ -39,7 +39,9 @@ func (stmt *mysqlStmt) Close() error {
 }
 
 func (stmt *mysqlStmt) NumInput() int {
-	return stmt.paramCount
+	// QueryAttribute arguments are removed from the bind parameters by the
+	// driver, so database/sql cannot validate the argument count itself.
+	return -1
 }
 
 func (stmt *mysqlStmt) ColumnConverter(idx int) driver.ValueConverter {
@@ -47,16 +49,23 @@ func (stmt *mysqlStmt) ColumnConverter(idx int) driver.ValueConverter {
 }
 
 func (stmt *mysqlStmt) CheckNamedValue(nv *driver.NamedValue) (err error) {
+	if attr, ok := nv.Value.(QueryAttribute); ok {
+		return validateQueryAttribute(attr)
+	}
 	nv.Value, err = converter{}.ConvertValue(nv.Value)
 	return
 }
 
 func (stmt *mysqlStmt) Exec(args []driver.Value) (driver.Result, error) {
+	return stmt.execWithAttributes(args, nil)
+}
+
+func (stmt *mysqlStmt) execWithAttributes(args []driver.Value, attrs []QueryAttribute) (driver.Result, error) {
 	if stmt.mc.closed.Load() {
 		return nil, driver.ErrBadConn
 	}
 	// Send command
-	err := stmt.writeExecutePacket(args)
+	err := stmt.writeExecutePacket(args, attrs)
 	if err != nil {
 		return nil, stmt.mc.markBadConn(err)
 	}
@@ -98,15 +107,19 @@ func (stmt *mysqlStmt) Exec(args []driver.Value) (driver.Result, error) {
 }
 
 func (stmt *mysqlStmt) Query(args []driver.Value) (driver.Rows, error) {
-	return stmt.query(args)
+	return stmt.queryWithAttributes(args, nil)
 }
 
 func (stmt *mysqlStmt) query(args []driver.Value) (*binaryRows, error) {
+	return stmt.queryWithAttributes(args, nil)
+}
+
+func (stmt *mysqlStmt) queryWithAttributes(args []driver.Value, attrs []QueryAttribute) (*binaryRows, error) {
 	if stmt.mc.closed.Load() {
 		return nil, driver.ErrBadConn
 	}
 	// Send command
-	err := stmt.writeExecutePacket(args)
+	err := stmt.writeExecutePacket(args, attrs)
 	if err != nil {
 		return nil, stmt.mc.markBadConn(err)
 	}

--- a/statement.go
+++ b/statement.go
@@ -50,7 +50,7 @@ func (stmt *mysqlStmt) ColumnConverter(idx int) driver.ValueConverter {
 
 func (stmt *mysqlStmt) CheckNamedValue(nv *driver.NamedValue) (err error) {
 	if attr, ok := nv.Value.(QueryAttribute); ok {
-		return validateQueryAttribute(attr)
+		return attr.validate()
 	}
 	nv.Value, err = converter{}.ConvertValue(nv.Value)
 	return

--- a/utils.go
+++ b/utils.go
@@ -777,16 +777,47 @@ func (ae *atomicError) Value() error {
 	return nil
 }
 
-func namedValueToValue(named []driver.NamedValue) ([]driver.Value, error) {
-	dargs := make([]driver.Value, len(named))
-	for n, param := range named {
+func namedValueToValue(named []driver.NamedValue) ([]driver.Value, []QueryAttribute, error) {
+	dargs := make([]driver.Value, 0, len(named))
+	var attrs []QueryAttribute
+	for _, param := range named {
+		if attr, ok := param.Value.(QueryAttribute); ok {
+			if err := validateQueryAttribute(attr); err != nil {
+				return nil, nil, err
+			}
+			attrs = append(attrs, attr)
+			continue
+		}
 		if len(param.Name) > 0 {
 			// TODO: support the use of Named Parameters #561
-			return nil, errors.New("mysql: driver does not support the use of Named Parameters")
+			return nil, nil, errors.New("mysql: driver does not support the use of Named Parameters")
 		}
-		dargs[n] = param.Value
+		dargs = append(dargs, param.Value)
 	}
-	return dargs, nil
+	return dargs, attrs, nil
+}
+
+func parseServerVersion(version string) [3]int {
+	parsed := [3]int{-1, -1, -1}
+	for i := range parsed {
+		end := 0
+		for end < len(version) && version[end] >= '0' && version[end] <= '9' {
+			end++
+		}
+		if end == 0 {
+			return [3]int{-1, -1, -1}
+		}
+		n, err := strconv.Atoi(version[:end])
+		if err != nil {
+			return [3]int{-1, -1, -1}
+		}
+		parsed[i] = n
+		if end == len(version) || version[end] != '.' {
+			break
+		}
+		version = version[end+1:]
+	}
+	return parsed
 }
 
 func mapIsolationLevel(level driver.IsolationLevel) (string, error) {

--- a/utils.go
+++ b/utils.go
@@ -782,7 +782,7 @@ func namedValueToValue(named []driver.NamedValue) ([]driver.Value, []QueryAttrib
 	var attrs []QueryAttribute
 	for _, param := range named {
 		if attr, ok := param.Value.(QueryAttribute); ok {
-			if err := validateQueryAttribute(attr); err != nil {
+			if err := attr.validate(); err != nil {
 				return nil, nil, err
 			}
 			attrs = append(attrs, attr)


### PR DESCRIPTION
### Description
Add support for passing query attributes via a special bind parameter. The intent is to enable passing through OpenTelemetry traceparents which is now possible with MySQL 9.7 Community.

AI usage disclosure: created with GPT 5.6 Sol then reviewed and edited by hand.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
