### PR TITLE
Return useful error for busy connections

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -134,6 +134,7 @@ Zhang Xiang <angwerzx at 126.com>
 Zhenye Xie <xiezhenye at gmail.com>
 Zhixin Wen <john.wenzhixin at gmail.com>
 Ziheng Lyu <zihenglv at gmail.com>
+ZYZ666-RGB <1991039819 at qq.com>
 
 # Organizations
 

--- a/connection.go
+++ b/connection.go
@@ -212,7 +212,7 @@ func (mc *mysqlConn) Prepare(query string) (driver.Stmt, error) {
 	err := mc.writeCommandPacketStr(comStmtPrepare, query)
 	if err != nil {
 		if err == ErrBusyBuffer {
-			return nil, err
+			return nil, fmt.Errorf("%w: unread data remains on the connection", err)
 		}
 		// STMT_PREPARE is safe to retry.  So we can return ErrBadConn here.
 		mc.log(err)

--- a/connection.go
+++ b/connection.go
@@ -211,6 +211,9 @@ func (mc *mysqlConn) Prepare(query string) (driver.Stmt, error) {
 	// Send command
 	err := mc.writeCommandPacketStr(comStmtPrepare, query)
 	if err != nil {
+		if err == ErrBusyBuffer {
+			return nil, err
+		}
 		// STMT_PREPARE is safe to retry.  So we can return ErrBadConn here.
 		mc.log(err)
 		return nil, driver.ErrBadConn

--- a/connection_test.go
+++ b/connection_test.go
@@ -205,7 +205,7 @@ func TestPrepareBusyBuffer(t *testing.T) {
 		t.Fatalf("expected ErrBusyBuffer, got %#v", err)
 	}
 
-	const want = "connection is busy with a previous result set; close it before reusing the connection"
+	const want = "busy buffer: unread data remains on the connection"
 	if err.Error() != want {
 		t.Fatalf("expected %q, got %q", want, err)
 	}

--- a/connection_test.go
+++ b/connection_test.go
@@ -196,6 +196,21 @@ func TestPingErrInvalidConn(t *testing.T) {
 	}
 }
 
+func TestPrepareBusyBuffer(t *testing.T) {
+	mc := &mysqlConn{buf: newBuffer()}
+	mc.buf.buf = []byte{1}
+
+	_, err := mc.Prepare("SELECT 1")
+	if !errors.Is(err, ErrBusyBuffer) {
+		t.Fatalf("expected ErrBusyBuffer, got %#v", err)
+	}
+
+	const want = "connection is busy with a previous result set; close it before reusing the connection"
+	if err.Error() != want {
+		t.Fatalf("expected %q, got %q", want, err)
+	}
+}
+
 type badConnection struct {
 	n   int
 	err error

--- a/driver_test.go
+++ b/driver_test.go
@@ -16,6 +16,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -1556,6 +1557,40 @@ func TestReuseClosedConnection(t *testing.T) {
 		t.Errorf("unexpected error '%s', expected '%s'",
 			err.Error(), driver.ErrBadConn.Error())
 	}
+}
+
+func TestPrepareWithOpenRows(t *testing.T) {
+	runTests(t, dsn, func(dbt *DBTest) {
+		tx, err := dbt.db.Begin()
+		if err != nil {
+			dbt.Fatal(err)
+		}
+		defer tx.Rollback()
+
+		rows, err := tx.Query("SELECT 1 UNION ALL SELECT 2")
+		if err != nil {
+			dbt.Fatal(err)
+		}
+		if !rows.Next() {
+			dbt.Fatalf("expected the first row, got %v", rows.Err())
+		}
+
+		_, err = tx.Prepare("SELECT 3")
+		if !errors.Is(err, ErrBusyBuffer) {
+			dbt.Fatalf("expected ErrBusyBuffer, got %#v", err)
+		}
+
+		if err := rows.Close(); err != nil {
+			dbt.Fatal(err)
+		}
+		stmt, err := tx.Prepare("SELECT 3")
+		if err != nil {
+			dbt.Fatalf("connection was not reusable after closing rows: %v", err)
+		}
+		if err := stmt.Close(); err != nil {
+			dbt.Fatal(err)
+		}
+	})
 }
 
 func TestCharset(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -28,7 +28,7 @@ var (
 	ErrPktSync           = errors.New("commands out of sync. You can't run this command now")
 	ErrPktSyncMul        = errors.New("commands out of sync. Did you run multiple statements at once?")
 	ErrPktTooLarge       = errors.New("packet for query is too large. Try adjusting the `Config.MaxAllowedPacket`")
-	ErrBusyBuffer        = errors.New("busy buffer")
+	ErrBusyBuffer        = errors.New("connection is busy with a previous result set; close it before reusing the connection")
 
 	// errBadConnNoWrite is used for connection errors where nothing was sent to the database yet.
 	// If this happens first in a function starting a database interaction, it should be replaced by driver.ErrBadConn

--- a/errors.go
+++ b/errors.go
@@ -28,7 +28,7 @@ var (
 	ErrPktSync           = errors.New("commands out of sync. You can't run this command now")
 	ErrPktSyncMul        = errors.New("commands out of sync. Did you run multiple statements at once?")
 	ErrPktTooLarge       = errors.New("packet for query is too large. Try adjusting the `Config.MaxAllowedPacket`")
-	ErrBusyBuffer        = errors.New("connection is busy with a previous result set; close it before reusing the connection")
+	ErrBusyBuffer        = errors.New("busy buffer")
 
 	// errBadConnNoWrite is used for connection errors where nothing was sent to the database yet.
 	// If this happens first in a function starting a database interaction, it should be replaced by driver.ErrBadConn


### PR DESCRIPTION
### Description

When a previous result set still owns the connection buffer, `Prepare` logs `busy buffer` and converts the error to `driver.ErrBadConn`. This hides the actual caller mistake.

This change:

- returns a wrapped `ErrBusyBuffer` from `Prepare` instead of `driver.ErrBadConn`
- adds cause-neutral context indicating that unread data remains on the connection
- adds regression tests covering the error and connection reuse
- adds the contributor to `AUTHORS`

Fixes #526.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change
- [x] All relevant tests pass
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file

### Validation

- `go test ./... -run 'TestPrepareBusyBuffer|TestPrepareWithOpenRows' -count=1`
- `go vet ./...`
