### PR TITLE
fix: Config.Clone(nil) returns nil instead of panicking

### DIFF
--- a/clone_nil_test.go
+++ b/clone_nil_test.go
@@ -1,0 +1,15 @@
+package mysql
+
+import "testing"
+
+func TestConfigCloneNil(t *testing.T) {
+	var c *Config
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Clone panicked: %v", r)
+		}
+	}()
+	if c.Clone() != nil {
+		t.Fatal("want nil")
+	}
+}

--- a/dsn.go
+++ b/dsn.go
@@ -152,6 +152,9 @@ func Charset(charset, collation string) Option {
 }
 
 func (cfg *Config) Clone() *Config {
+	if cfg == nil {
+		return nil
+	}
 	cp := *cfg
 	if cp.TLS != nil {
 		cp.TLS = cfg.TLS.Clone()


### PR DESCRIPTION
```go
var c *mysql.Config
c.Clone() // panic: nil pointer
```

Return nil when the receiver is nil.