### PR TITLE
doc: clarify timeTruncate units and when to use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,11 @@ Type:           duration
 Default:        0
 ```
 
-[Truncate time values](https://pkg.go.dev/time#Duration.Truncate) to the specified duration. The value must be a decimal number with a unit suffix (*"ms"*, *"s"*, *"m"*, *"h"*), such as *"30s"*, *"0.5m"* or *"1m30s"*.
+[Truncate time values](https://pkg.go.dev/time#Duration.Truncate) in query arguments to the specified duration. The value must be a decimal number with a unit suffix (*"ns"*, *"us"*, *"ms"*, *"s"*, *"m"*, *"h"*), such as *"1us"*, *"30s"* or *"1m30s"*.
+
+`time.Time` arguments are sent with up to nanosecond precision, so a value from `time.Now()` usually has more fractional-second digits than a `DATETIME(N)` or `TIMESTAMP(N)` column stores. On MariaDB, comparing such a value against an indexed column can prevent an index range scan, turning it into a full index scan. Truncating to the column's precision (`1us` for `DATETIME(6)`) avoids this. Only arguments sent to the server are truncated; values read from the server are not affected.
+
+`Config.timeTruncate` is unexported, so it must be set in the DSN string or with `cfg.Apply(mysql.TimeTruncate(time.Microsecond))`. Putting `timeTruncate` in `Config.Params` does not work: unrecognized parameters are sent to the server as [system variables](#system-variables), which fails at connect time.
 
 ##### `maxAllowedPacket`
 ```

--- a/README.md
+++ b/README.md
@@ -314,11 +314,10 @@ Type:           duration
 Default:        0
 ```
 
-[Truncate time values](https://pkg.go.dev/time#Duration.Truncate) in query arguments to the specified duration. The value must be a decimal number with a unit suffix (*"ns"*, *"us"*, *"ms"*, *"s"*, *"m"*, *"h"*), such as *"1us"*, *"30s"* or *"1m30s"*.
+[Truncate time values](https://pkg.go.dev/time#Duration.Truncate) in query arguments to the specified duration. The value must be a decimal number with a unit suffix (*"ns"*, *"us"*, *"ms"*, etc...), such as "1us", "1ms", or "10ns".
 
-`time.Time` arguments are sent with up to nanosecond precision, so a value from `time.Now()` usually has more fractional-second digits than a `DATETIME(N)` or `TIMESTAMP(N)` column stores. On MariaDB, comparing such a value against an indexed column can prevent an index range scan, turning it into a full index scan. Truncating to the column's precision (`1us` for `DATETIME(6)`) avoids this. Only arguments sent to the server are truncated; values read from the server are not affected.
-
-`Config.timeTruncate` is unexported, so it must be set in the DSN string or with `cfg.Apply(mysql.TimeTruncate(time.Microsecond))`. Putting `timeTruncate` in `Config.Params` does not work: unrecognized parameters are sent to the server as [system variables](#system-variables), which fails at connect time.
+> [!NOTE]
+> `time.Time` arguments are sent with up to nanosecond precision, so a value from `time.Now()` usually has more fractional-second digits than a `DATETIME(N)` or `TIMESTAMP(N)` column stores. On MariaDB, comparing such a value against an indexed column can prevent an index range scan, turning it into a full index scan. Truncating to the column's precision (`1us` for `DATETIME(6)`) avoids this. Only arguments sent to the server are truncated; values read from the server are not affected.
 
 ##### `maxAllowedPacket`
 ```


### PR DESCRIPTION
### Description

`timeTruncate` is documented as *what* it does, but not *why* you would enable it — and the listed unit suffixes omit the one that matters most for it.

**1. The unit list is incomplete.** The current sentence lists *"ms"*, *"s"*, *"m"*, *"h"*; it is a copy of the one under `readTimeout`, where sub-millisecond units are pointless. `time.ParseDuration` also accepts `ns` and `us`, and `1us` is the interesting value here because it matches `DATETIME(6)`. As written, the README implies microsecond truncation isn't available.

**2. There is no motivation.** `time.Time` arguments are formatted with up to 9 fractional digits (`appendDateTime` trims only trailing zeros), so a `time.Now()`-derived value almost always carries more precision than the column stores. On MariaDB this silently prevents an index range scan — nothing errors and nothing is logged.

Measured on a 1M-row table with an indexed `DATETIME(6)` column, `WHERE last_activity_at >= ?` with a 9-fractional-digit argument, driver defaults:

| engine | without `timeTruncate` | with `timeTruncate=1us` |
|---|---|---|
| MariaDB 10.5.29 | 59.0 ms — 1,000,000 index reads | 275 µs — 876 |
| MariaDB 10.11.15 | 53.8 ms — 1,000,000 index reads | 363 µs — 876 |
| MariaDB 11.8.8 | 58.6 ms — 1,000,000 index reads | 257 µs — 876 |
| MySQL 5.7.44 | 377 µs — 876 index reads | 248 µs — 876 |
| MySQL 8.4.11 | 607 µs — 876 index reads | 280 µs — 876 |

Row counts are identical in every run (876), so truncation does not change the result set. MySQL is unaffected across the supported range; only MariaDB degrades, which is why the README text names it rather than generalising.

On MariaDB, `EXPLAIN` shows `type` going from `range` (1000 rows) to `index` (998490 rows). `key` and `key_len` are unchanged, so the plan still *looks* like it is using the index — which is what makes this easy to miss.

The `interpolateParams=true` path behaves identically (both paths go through `appendDateTime`).

I have deliberately kept these numbers out of the README; the README change only states the qualitative behaviour.

**3. `Config.Params` is a footgun here.** `Config.timeTruncate` is unexported, so the natural-looking `cfg.Params["timeTruncate"] = "1us"` does not set it. Instead the key falls through to `handleParams`, which emits `SET timeTruncate = 1us` at connect time and fails every connection. The supported paths are the DSN string or `cfg.Apply(mysql.TimeTruncate(time.Microsecond))`. This is also true of `compress` and `charset`; I documented it only under `timeTruncate` to keep the change small, but I'm happy to drop that paragraph or move it to a general note under `#### Parameters` if you'd prefer.

<details>
<summary>Reproduction</summary>

Fixture (portable across both engines, no CTEs):

```sql
CREATE TABLE tt_seq (n TINYINT NOT NULL);
INSERT INTO tt_seq VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);

CREATE TABLE tt_demo (
  id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
  last_activity_at DATETIME(6) NOT NULL,
  KEY idx_last_activity_at (last_activity_at)
) ENGINE=InnoDB;

INSERT INTO tt_demo (last_activity_at)
SELECT TIMESTAMPADD(MICROSECOND,
  (a.n + b.n*10 + c.n*100 + d.n*1000 + e.n*10000 + f.n*100000) * 1000,
  '2024-01-01 00:00:00.000000')
FROM tt_seq a, tt_seq b, tt_seq c, tt_seq d, tt_seq e, tt_seq f;

ANALYZE TABLE tt_demo;
```

Server-side control, no driver involved:

```sql
EXPLAIN SELECT COUNT(*) FROM tt_demo WHERE last_activity_at >= '2024-01-01 00:16:39.000000';
EXPLAIN SELECT COUNT(*) FROM tt_demo WHERE last_activity_at >= '2024-01-01 00:16:39.000000123';
```

Driver side — run with and without `timeTruncate=1us`, using `time.Date(2024, 1, 1, 0, 16, 39, 123456789, time.UTC)` as the argument, on a single pinned `*sql.Conn`, reading `Handler_read_next` + `Handler_read_rnd_next` before and after:

```go
conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM tt_demo WHERE last_activity_at >= ?", arg).Scan(&n)
```

`SELECT CAST(? AS CHAR)` with the same argument confirms what goes on the wire:
`2024-01-01 00:16:39.123456789` without the option, `2024-01-01 00:16:39.123456` with it.

</details>

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible) — docs-only, no behaviour change
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file — docs-only change with no copyrightable code, so I left this alone to match previous README-only commits; happy to add myself if you'd prefer
