### PR TITLE
Export ErrBadConnNoWrite so Close() errors are identifiable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -53,6 +53,7 @@ Hajime Nakagami <nakagami at gmail.com>
 Hanno Braun <mail at hannobraun.com>
 Henri Yandell <flamefew at gmail.com>
 Hirotaka Yamamoto <ymmt2005 at gmail.com>
+Hiroto Toyoda <hiroto.toyoda at dena.com>
 Huyiguang <hyg at webterren.com>
 ICHINOSE Shogo <shogo82148 at gmail.com>
 Ilia Cimpoes <ichimpoesh at gmail.com>

--- a/connection.go
+++ b/connection.go
@@ -126,10 +126,10 @@ func (mc *mysqlConn) handleParams() (err error) {
 	return
 }
 
-// markBadConn replaces errBadConnNoWrite with driver.ErrBadConn.
+// markBadConn replaces ErrBadConnNoWrite with driver.ErrBadConn.
 // This function is used to return driver.ErrBadConn only when safe to retry.
 func (mc *mysqlConn) markBadConn(err error) error {
-	if err == errBadConnNoWrite {
+	if err == ErrBadConnNoWrite {
 		return driver.ErrBadConn
 	}
 	return err

--- a/connection_test.go
+++ b/connection_test.go
@@ -196,6 +196,23 @@ func TestPingErrInvalidConn(t *testing.T) {
 	}
 }
 
+func TestCloseErrBadConnNoWrite(t *testing.T) {
+	nc := badConnection{err: errors.New("failed to write"), n: 0}
+	mc := &mysqlConn{
+		netConn:          nc,
+		buf:              newBuffer(),
+		maxAllowedPacket: defaultMaxAllowedPacket,
+		closech:          make(chan struct{}),
+		cfg:              NewConfig(),
+	}
+
+	err := mc.Close()
+
+	if !errors.Is(err, ErrBadConnNoWrite) {
+		t.Errorf("expected errors.Is(err, ErrBadConnNoWrite) to be true, got err=%#v", err)
+	}
+}
+
 type badConnection struct {
 	n   int
 	err error

--- a/errors.go
+++ b/errors.go
@@ -30,11 +30,14 @@ var (
 	ErrPktTooLarge       = errors.New("packet for query is too large. Try adjusting the `Config.MaxAllowedPacket`")
 	ErrBusyBuffer        = errors.New("busy buffer")
 
-	// errBadConnNoWrite is used for connection errors where nothing was sent to the database yet.
+	// ErrBadConnNoWrite is used for connection errors where nothing was sent to the database yet.
 	// If this happens first in a function starting a database interaction, it should be replaced by driver.ErrBadConn
 	// to trigger a resend. Use mc.markBadConn(err) to do this.
 	// See https://github.com/go-sql-driver/mysql/pull/302
-	errBadConnNoWrite = errors.New("bad connection")
+	//
+	// It is also returned as-is from Conn.Close when the peer closed the connection before
+	// COM_QUIT could be sent; check for it with errors.Is if you need to distinguish that case.
+	ErrBadConnNoWrite = errors.New("bad connection")
 )
 
 var defaultLogger = Logger(log.New(os.Stderr, "[mysql] ", log.Ldate|log.Ltime))

--- a/packets.go
+++ b/packets.go
@@ -153,7 +153,7 @@ func (mc *mysqlConn) writePacket(data []byte) error {
 			if n == 0 && pktLen == len(data)-4 {
 				// only for the first loop iteration when nothing was written yet
 				mc.log(err)
-				return errBadConnNoWrite
+				return ErrBadConnNoWrite
 			} else {
 				return err
 			}


### PR DESCRIPTION
### Description

`Conn.Close()` can return `errBadConnNoWrite` as-is: when the peer has already
closed the connection before `COM_QUIT` could be sent, `writePacket()` returns
this sentinel, and `Close()` does not run it through `markBadConn()` (Close is
not a retryable operation, so converting it to `driver.ErrBadConn` would be
meaningless there).

Being unexported, this value cannot be identified by callers except by
matching the error string `"bad connection"`, which is fragile since it
depends on an internal implementation detail. This is a real-world problem
when apps want to distinguish this specific, benign, unpreventable condition
(closing an already-dead idle pooled connection, e.g. during graceful
shutdown) from other, more meaningful close errors.

This PR simply exports `errBadConnNoWrite` as `ErrBadConnNoWrite`. It is a
pure rename: the error value, its message, and every existing code path
(including `markBadConn`'s conversion to `driver.ErrBadConn` for the
retry-safe call sites: `Begin`/`BeginTx`/`Exec`/`ExecContext`/`Prepare`/
`PrepareContext`/`Query`/`QueryContext`) are unchanged. Callers can now write
`errors.Is(err, mysql.ErrBadConnNoWrite)` instead of matching on the error
string.

#### Related history

- Introduced unexported in #302.
- #1303 shows the assumption at the time: this error is "internal" and
  should never reach a caller un-converted, because `markBadConn` always
  turns it into `driver.ErrBadConn` first. `Close()` is the one path where
  that assumption doesn't hold, since it intentionally skips `markBadConn`.
- #1582/#1583 proposed removing this sentinel (and `markBadConn`) entirely.
  That PR was split into #1641/#1642, which trimmed the other use sites
  (busy-buffer cases) while intentionally keeping the single remaining one
  in `writePacket()`, precisely because removing it entirely would break
  retry-safety signaling for `Query`/`Exec` when the first write fails with
  zero bytes sent. This PR does not touch that retained logic at all — it
  only makes the existing sentinel usable via `errors.Is` by external
  callers.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
