### PR TITLE
Improve Config handling

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -24,22 +24,22 @@ import (
 )
 
 type mysqlConn struct {
-	buf              buffer
-	netConn          net.Conn
-	rawConn          net.Conn    // underlying connection when netConn is TLS connection.
-	result           mysqlResult // managed by clearResult() and handleOkPacket().
-	compIO           *compIO
-	cfg              *Config
-	connector        *connector
-	maxAllowedPacket int
-	maxWriteSize     int
-	capabilities     capabilityFlag
-	extCapabilities  extendedCapabilityFlag
-	status           statusFlag
-	sequence         uint8
-	compressSequence uint8
-	parseTime        bool
-	compress         bool
+	buf               buffer
+	netConn           net.Conn
+	rawConn           net.Conn    // underlying connection when netConn is TLS connection.
+	result            mysqlResult // managed by clearResult() and handleOkPacket().
+	compIO            *compIO
+	cfg               *Config
+	encodedAttributes string
+	maxAllowedPacket  int
+	maxWriteSize      int
+	capabilities      capabilityFlag
+	extCapabilities   extendedCapabilityFlag
+	status            statusFlag
+	sequence          uint8
+	compressSequence  uint8
+	parseTime         bool
+	compress          bool
 
 	// for context support (Go 1.8+)
 	watching bool

--- a/connection.go
+++ b/connection.go
@@ -24,22 +24,21 @@ import (
 )
 
 type mysqlConn struct {
-	buf               buffer
-	netConn           net.Conn
-	rawConn           net.Conn    // underlying connection when netConn is TLS connection.
-	result            mysqlResult // managed by clearResult() and handleOkPacket().
-	compIO            *compIO
-	cfg               *Config
-	encodedAttributes string
-	maxAllowedPacket  int
-	maxWriteSize      int
-	capabilities      capabilityFlag
-	extCapabilities   extendedCapabilityFlag
-	status            statusFlag
-	sequence          uint8
-	compressSequence  uint8
-	parseTime         bool
-	compress          bool
+	buf              buffer
+	netConn          net.Conn
+	rawConn          net.Conn    // underlying connection when netConn is TLS connection.
+	result           mysqlResult // managed by clearResult() and handleOkPacket().
+	compIO           *compIO
+	cfg              *Config
+	maxAllowedPacket int
+	maxWriteSize     int
+	capabilities     capabilityFlag
+	extCapabilities  extendedCapabilityFlag
+	status           statusFlag
+	sequence         uint8
+	compressSequence uint8
+	parseTime        bool
+	compress         bool
 
 	// for context support (Go 1.8+)
 	watching bool

--- a/connector.go
+++ b/connector.go
@@ -19,8 +19,7 @@ import (
 )
 
 type connector struct {
-	cfg               *Config // immutable private copy.
-	encodedAttributes string  // Encoded connection attributes.
+	cfg *Config // immutable private copy.
 }
 
 func encodeConnectionAttributes(cfg *Config) string {
@@ -55,10 +54,8 @@ func encodeConnectionAttributes(cfg *Config) string {
 }
 
 func newConnector(cfg *Config) *connector {
-	encodedAttributes := encodeConnectionAttributes(cfg)
 	return &connector{
-		cfg:               cfg,
-		encodedAttributes: encodedAttributes,
+		cfg: cfg,
 	}
 }
 
@@ -79,11 +76,11 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 
 	// New mysqlConn
 	mc := &mysqlConn{
-		maxAllowedPacket: maxPacketSize,
-		maxWriteSize:     maxPacketSize - 1,
-		closech:          make(chan struct{}),
-		cfg:              cfg,
-		connector:        c,
+		maxAllowedPacket:  maxPacketSize,
+		maxWriteSize:      maxPacketSize - 1,
+		closech:           make(chan struct{}),
+		cfg:               cfg,
+		encodedAttributes: encodeConnectionAttributes(cfg),
 	}
 	mc.parseTime = mc.cfg.ParseTime
 
@@ -91,12 +88,12 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 	dctx := ctx
 	if mc.cfg.Timeout > 0 {
 		var cancel context.CancelFunc
-		dctx, cancel = context.WithTimeout(ctx, c.cfg.Timeout)
+		dctx, cancel = context.WithTimeout(ctx, mc.cfg.Timeout)
 		defer cancel()
 	}
 
-	if c.cfg.DialFunc != nil {
-		mc.netConn, err = c.cfg.DialFunc(dctx, mc.cfg.Net, mc.cfg.Addr)
+	if mc.cfg.DialFunc != nil {
+		mc.netConn, err = mc.cfg.DialFunc(dctx, mc.cfg.Net, mc.cfg.Addr)
 	} else {
 		dialsLock.RLock()
 		dial, ok := dials[mc.cfg.Net]
@@ -116,7 +113,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 	// Enable TCP Keepalives on TCP connections
 	if tc, ok := mc.netConn.(*net.TCPConn); ok {
 		if err := tc.SetKeepAlive(true); err != nil {
-			c.cfg.Logger.Print(err)
+			mc.cfg.Logger.Print(err)
 		}
 	}
 
@@ -145,7 +142,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 	authResp, err := mc.auth(authData, plugin)
 	if err != nil {
 		// try the default auth plugin, if using the requested plugin failed
-		c.cfg.Logger.Print("could not use requested auth plugin '"+plugin+"': ", err.Error())
+		mc.cfg.Logger.Print("could not use requested auth plugin '"+plugin+"': ", err.Error())
 		plugin = defaultAuthPlugin
 		authResp, err = mc.auth(authData, plugin)
 		if err != nil {
@@ -153,7 +150,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 			return nil, err
 		}
 	}
-	mc.initCapabilities(serverCapabilities, serverExtCapabilities, mc.cfg)
+	mc.initCapabilities(serverCapabilities, serverExtCapabilities)
 	if err = mc.writeHandshakeResponsePacket(authResp, plugin); err != nil {
 		mc.cleanup()
 		return nil, err

--- a/connector.go
+++ b/connector.go
@@ -72,7 +72,6 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 		if err != nil {
 			return nil, err
 		}
-		cfg.normalizeTLSConfigServerName()
 	}
 
 	// New mysqlConn

--- a/connector.go
+++ b/connector.go
@@ -72,6 +72,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 		if err != nil {
 			return nil, err
 		}
+		cfg.normalizeTLSConfigServerName()
 	}
 
 	// New mysqlConn

--- a/connector.go
+++ b/connector.go
@@ -72,15 +72,17 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 		if err != nil {
 			return nil, err
 		}
+		if err = cfg.normalize(); err != nil {
+			return nil, err
+		}
 	}
 
 	// New mysqlConn
 	mc := &mysqlConn{
-		maxAllowedPacket:  maxPacketSize,
-		maxWriteSize:      maxPacketSize - 1,
-		closech:           make(chan struct{}),
-		cfg:               cfg,
-		encodedAttributes: encodeConnectionAttributes(cfg),
+		maxAllowedPacket: maxPacketSize,
+		maxWriteSize:     maxPacketSize - 1,
+		closech:          make(chan struct{}),
+		cfg:              cfg,
 	}
 	mc.parseTime = mc.cfg.ParseTime
 

--- a/connector.go
+++ b/connector.go
@@ -72,9 +72,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err = cfg.normalize(); err != nil {
-			return nil, err
-		}
+		cfg.encodedAttributes = encodeConnectionAttributes(cfg)
 	}
 
 	// New mysqlConn

--- a/connector_test.go
+++ b/connector_test.go
@@ -3,7 +3,6 @@ package mysql
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"errors"
 	"net"
 	"testing"
@@ -62,52 +61,6 @@ func TestBeforeConnectUsesEffectiveTimeout(t *testing.T) {
 	}
 	if remaining < 59*time.Minute || remaining > 61*time.Minute {
 		t.Fatalf("dial timeout = %v, want about 1h", remaining)
-	}
-}
-
-func TestBeforeConnectUpdatesDerivedTLSServerName(t *testing.T) {
-	dialErr := errors.New("stop after observing effective config")
-	tests := []struct {
-		name        string
-		serverName  string
-		want        string
-		wantDerived bool
-	}{
-		{"derived", "", "callback.example", true},
-		{"explicit", "database.example", "database.example", false},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			var effectiveCfg *Config
-			cfg := NewConfig()
-			cfg.Addr = "initial.example:3306"
-			cfg.TLS = &tls.Config{ServerName: tc.serverName}
-			cfg.DialFunc = func(context.Context, string, string) (net.Conn, error) {
-				return nil, dialErr
-			}
-			if err := cfg.Apply(BeforeConnect(func(_ context.Context, cfg *Config) error {
-				cfg.Addr = "callback.example:3306"
-				effectiveCfg = cfg
-				return nil
-			})); err != nil {
-				t.Fatal(err)
-			}
-
-			connector, err := NewConnector(cfg)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if _, err := connector.Connect(context.Background()); !errors.Is(err, dialErr) {
-				t.Fatalf("Connect() error = %v, want %v", err, dialErr)
-			}
-			if got := effectiveCfg.TLS.ServerName; got != tc.want {
-				t.Errorf("TLS ServerName = %q, want %q", got, tc.want)
-			}
-			if got := effectiveCfg.tlsServerNameDerived; got != tc.wantDerived {
-				t.Errorf("tlsServerNameDerived = %v, want %v", got, tc.wantDerived)
-			}
-		})
 	}
 }
 

--- a/connector_test.go
+++ b/connector_test.go
@@ -1,7 +1,9 @@
 package mysql
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"net"
 	"testing"
 	"time"
@@ -26,5 +28,102 @@ func TestConnectorReturnsTimeout(t *testing.T) {
 		}
 	} else {
 		t.Fatalf("expected %T, got %T", nerr, err)
+	}
+}
+
+func TestBeforeConnectUsesEffectiveTimeout(t *testing.T) {
+	dialErr := errors.New("stop after observing dial context")
+	var remaining time.Duration
+
+	cfg := NewConfig()
+	cfg.Timeout = 2 * time.Hour
+	cfg.DialFunc = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("dial context has no deadline")
+		}
+		remaining = time.Until(deadline)
+		return nil, dialErr
+	}
+	if err := cfg.Apply(BeforeConnect(func(_ context.Context, cfg *Config) error {
+		cfg.Timeout = time.Hour
+		return nil
+	})); err != nil {
+		t.Fatal(err)
+	}
+
+	connector, err := NewConnector(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := connector.Connect(context.Background()); !errors.Is(err, dialErr) {
+		t.Fatalf("Connect() error = %v, want %v", err, dialErr)
+	}
+	if remaining < 59*time.Minute || remaining > 61*time.Minute {
+		t.Fatalf("dial timeout = %v, want about 1h", remaining)
+	}
+}
+
+func TestBeforeConnectUsesEffectiveDialerAndAttributes(t *testing.T) {
+	mock := &mockConn{
+		data: []byte{72, 0, 0, 0, 10, 53, 46, 53, 46, 56, 0, 165, 0, 0, 0,
+			60, 70, 63, 58, 68, 104, 34, 97, 0, 223, 247, 33, 2, 0, 31, 128, 21, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 98, 120, 114, 47, 85, 75, 109, 99, 51, 77,
+			50, 64, 0, 109, 121, 115, 113, 108, 95, 110, 97, 116, 105, 118, 101, 95,
+			112, 97, 115, 115, 119, 111, 114, 100},
+		queuedReplies: [][]byte{
+			{7, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0},
+		},
+	}
+
+	var (
+		initialDialCalled bool
+		dialNetwork       string
+		dialAddress       string
+	)
+	cfg := NewConfig()
+	cfg.Addr = "initial.example:3306"
+	cfg.ConnectionAttributes = "phase:initial"
+	cfg.DialFunc = func(context.Context, string, string) (net.Conn, error) {
+		initialDialCalled = true
+		return nil, errors.New("initial dialer must not be called")
+	}
+	if err := cfg.Apply(BeforeConnect(func(_ context.Context, cfg *Config) error {
+		cfg.Addr = "callback.example:3306"
+		cfg.ConnectionAttributes = "phase:callback"
+		cfg.DialFunc = func(_ context.Context, network, address string) (net.Conn, error) {
+			dialNetwork = network
+			dialAddress = address
+			return mock, nil
+		}
+		return nil
+	})); err != nil {
+		t.Fatal(err)
+	}
+
+	connector, err := NewConnector(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := connector.Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if initialDialCalled {
+		t.Fatal("Connect() used the pre-callback DialFunc")
+	}
+	if dialNetwork != "tcp" || dialAddress != "callback.example:3306" {
+		t.Fatalf("dialed %s(%s), want tcp(callback.example:3306)", dialNetwork, dialAddress)
+	}
+	if !bytes.Contains(mock.written, []byte("phase\bcallback")) {
+		t.Fatalf("handshake response does not contain callback attributes: %q", mock.written)
+	}
+	if bytes.Contains(mock.written, []byte("phase\x07initial")) {
+		t.Fatalf("handshake response contains stale attributes: %q", mock.written)
+	}
+	if !bytes.Contains(mock.written, []byte("callback.example")) {
+		t.Fatalf("handshake response does not contain callback server host: %q", mock.written)
 	}
 }

--- a/connector_test.go
+++ b/connector_test.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"net"
 	"testing"
@@ -61,6 +62,49 @@ func TestBeforeConnectUsesEffectiveTimeout(t *testing.T) {
 	}
 	if remaining < 59*time.Minute || remaining > 61*time.Minute {
 		t.Fatalf("dial timeout = %v, want about 1h", remaining)
+	}
+}
+
+func TestBeforeConnectUpdatesDerivedTLSServerName(t *testing.T) {
+	dialErr := errors.New("stop after observing effective config")
+	tests := []struct {
+		name       string
+		serverName string
+		want       string
+	}{
+		{"derived", "", "callback.example"},
+		{"explicit", "database.example", "database.example"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var effectiveCfg *Config
+
+			cfg := NewConfig()
+			cfg.Addr = "initial.example:3306"
+			cfg.TLS = &tls.Config{ServerName: tc.serverName}
+			cfg.DialFunc = func(context.Context, string, string) (net.Conn, error) {
+				return nil, dialErr
+			}
+			if err := cfg.Apply(BeforeConnect(func(_ context.Context, cfg *Config) error {
+				cfg.Addr = "callback.example:3306"
+				effectiveCfg = cfg
+				return nil
+			})); err != nil {
+				t.Fatal(err)
+			}
+
+			connector, err := NewConnector(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := connector.Connect(context.Background()); !errors.Is(err, dialErr) {
+				t.Fatalf("Connect() error = %v, want %v", err, dialErr)
+			}
+			if got := effectiveCfg.TLS.ServerName; got != tc.want {
+				t.Errorf("TLS ServerName = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/connector_test.go
+++ b/connector_test.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"net"
 	"testing"
@@ -61,6 +62,52 @@ func TestBeforeConnectUsesEffectiveTimeout(t *testing.T) {
 	}
 	if remaining < 59*time.Minute || remaining > 61*time.Minute {
 		t.Fatalf("dial timeout = %v, want about 1h", remaining)
+	}
+}
+
+func TestBeforeConnectUpdatesDerivedTLSServerName(t *testing.T) {
+	dialErr := errors.New("stop after observing effective config")
+	tests := []struct {
+		name        string
+		serverName  string
+		want        string
+		wantDerived bool
+	}{
+		{"derived", "", "callback.example", true},
+		{"explicit", "database.example", "database.example", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var effectiveCfg *Config
+			cfg := NewConfig()
+			cfg.Addr = "initial.example:3306"
+			cfg.TLS = &tls.Config{ServerName: tc.serverName}
+			cfg.DialFunc = func(context.Context, string, string) (net.Conn, error) {
+				return nil, dialErr
+			}
+			if err := cfg.Apply(BeforeConnect(func(_ context.Context, cfg *Config) error {
+				cfg.Addr = "callback.example:3306"
+				effectiveCfg = cfg
+				return nil
+			})); err != nil {
+				t.Fatal(err)
+			}
+
+			connector, err := NewConnector(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := connector.Connect(context.Background()); !errors.Is(err, dialErr) {
+				t.Fatalf("Connect() error = %v, want %v", err, dialErr)
+			}
+			if got := effectiveCfg.TLS.ServerName; got != tc.want {
+				t.Errorf("TLS ServerName = %q, want %q", got, tc.want)
+			}
+			if got := effectiveCfg.tlsServerNameDerived; got != tc.wantDerived {
+				t.Errorf("tlsServerNameDerived = %v, want %v", got, tc.wantDerived)
+			}
+		})
 	}
 }
 

--- a/connector_test.go
+++ b/connector_test.go
@@ -3,7 +3,6 @@ package mysql
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"errors"
 	"net"
 	"testing"
@@ -62,49 +61,6 @@ func TestBeforeConnectUsesEffectiveTimeout(t *testing.T) {
 	}
 	if remaining < 59*time.Minute || remaining > 61*time.Minute {
 		t.Fatalf("dial timeout = %v, want about 1h", remaining)
-	}
-}
-
-func TestBeforeConnectUpdatesDerivedTLSServerName(t *testing.T) {
-	dialErr := errors.New("stop after observing effective config")
-	tests := []struct {
-		name       string
-		serverName string
-		want       string
-	}{
-		{"derived", "", "callback.example"},
-		{"explicit", "database.example", "database.example"},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			var effectiveCfg *Config
-
-			cfg := NewConfig()
-			cfg.Addr = "initial.example:3306"
-			cfg.TLS = &tls.Config{ServerName: tc.serverName}
-			cfg.DialFunc = func(context.Context, string, string) (net.Conn, error) {
-				return nil, dialErr
-			}
-			if err := cfg.Apply(BeforeConnect(func(_ context.Context, cfg *Config) error {
-				cfg.Addr = "callback.example:3306"
-				effectiveCfg = cfg
-				return nil
-			})); err != nil {
-				t.Fatal(err)
-			}
-
-			connector, err := NewConnector(cfg)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if _, err := connector.Connect(context.Background()); !errors.Is(err, dialErr) {
-				t.Fatalf("Connect() error = %v, want %v", err, dialErr)
-			}
-			if got := effectiveCfg.TLS.ServerName; got != tc.want {
-				t.Errorf("TLS ServerName = %q, want %q", got, tc.want)
-			}
-		})
 	}
 }
 

--- a/connector_test.go
+++ b/connector_test.go
@@ -65,15 +65,32 @@ func TestBeforeConnectUsesEffectiveTimeout(t *testing.T) {
 }
 
 func TestBeforeConnectUsesEffectiveDialerAndAttributes(t *testing.T) {
+	serverHandshake := []byte(
+		"\x48\x00\x00\x00" + // Packet header: 72-byte payload, sequence 0.
+			"\x0a" + // Protocol version 10.
+			"5.5.8\x00" + // NUL-terminated server version.
+			"\xa5\x00\x00\x00" + // Connection ID 165.
+			"<F?:Dh\"a" + // First 8 bytes of the authentication scramble.
+			"\x00" + // Filler.
+			"\xdf\xf7" + // Lower 2 bytes of the server capability flags.
+			"\x21" + // utf8_general_ci character set.
+			"\x02\x00" + // SERVER_STATUS_AUTOCOMMIT.
+			"\x1f\x80" + // Upper 2 bytes of the server capability flags.
+			"\x15" + // Authentication plugin data length: 21 bytes.
+			"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" + // Reserved.
+			"bxr/UKmc3M2@\x00" + // Remaining authentication scramble.
+			"mysql_native_password", // Authentication plugin name.
+	)
+	okPacket := []byte(
+		"\x07\x00\x00\x02" + // Packet header: 7-byte payload, sequence 2.
+			"\x00" + // OK packet header.
+			"\x00\x00" + // Zero affected rows and last insert ID.
+			"\x02\x00" + // SERVER_STATUS_AUTOCOMMIT.
+			"\x00\x00", // Zero warnings.
+	)
 	mock := &mockConn{
-		data: []byte{72, 0, 0, 0, 10, 53, 46, 53, 46, 56, 0, 165, 0, 0, 0,
-			60, 70, 63, 58, 68, 104, 34, 97, 0, 223, 247, 33, 2, 0, 31, 128, 21, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 98, 120, 114, 47, 85, 75, 109, 99, 51, 77,
-			50, 64, 0, 109, 121, 115, 113, 108, 95, 110, 97, 116, 105, 118, 101, 95,
-			112, 97, 115, 115, 119, 111, 114, 100},
-		queuedReplies: [][]byte{
-			{7, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0},
-		},
+		data:          serverHandshake,
+		queuedReplies: [][]byte{okPacket},
 	}
 
 	var (

--- a/dsn.go
+++ b/dsn.go
@@ -147,6 +147,9 @@ func TimeTruncate(d time.Duration) Option {
 }
 
 // BeforeConnect sets the function to be invoked before a connection is established.
+// If the function changes [Config.Addr] while [Config.TLS] is non-nil and its
+// InsecureSkipVerify field is false, it must also update ServerName to match
+// the hostname in the new address.
 func BeforeConnect(fn func(context.Context, *Config) error) Option {
 	return func(cfg *Config) error {
 		cfg.beforeConnect = fn

--- a/dsn.go
+++ b/dsn.go
@@ -77,8 +77,9 @@ type Config struct {
 	// unexported fields. new options should be come here.
 	// boolean first. alphabetical order.
 
-	compress       bool // Enable zlib compression
-	tinyInt1IsBool bool // Treat signed TINYINT(1) as boolean
+	compress             bool // Enable zlib compression
+	tinyInt1IsBool       bool // Treat signed TINYINT(1) as boolean
+	tlsServerNameDerived bool // Whether TLS.ServerName was derived from Addr
 
 	beforeConnect     func(context.Context, *Config) error // Invoked before a connection is established
 	encodedAttributes string                               // Encoded connection attributes
@@ -247,10 +248,11 @@ func (cfg *Config) normalize() error {
 		}
 	}
 
-	if cfg.TLS != nil && cfg.TLS.ServerName == "" && !cfg.TLS.InsecureSkipVerify {
+	if cfg.TLS != nil && (cfg.TLS.ServerName == "" || cfg.tlsServerNameDerived) && !cfg.TLS.InsecureSkipVerify {
 		host, _, err := net.SplitHostPort(cfg.Addr)
 		if err == nil {
 			cfg.TLS.ServerName = host
+			cfg.tlsServerNameDerived = true
 		}
 	}
 

--- a/dsn.go
+++ b/dsn.go
@@ -84,6 +84,7 @@ type Config struct {
 	paramOrder    []string                             // Order of connection parameters parsed from the DSN
 	pubKey        *rsa.PublicKey                       // Server public key
 	timeTruncate  time.Duration                        // Truncate time.Time values to the specified duration
+	tlsServerName string                               // TLS server name automatically derived from Addr
 	charsets      []string                             // Connection charset. When set, this will be set in SET NAMES <charset> query
 }
 
@@ -246,12 +247,7 @@ func (cfg *Config) normalize() error {
 		}
 	}
 
-	if cfg.TLS != nil && cfg.TLS.ServerName == "" && !cfg.TLS.InsecureSkipVerify {
-		host, _, err := net.SplitHostPort(cfg.Addr)
-		if err == nil {
-			cfg.TLS.ServerName = host
-		}
-	}
+	cfg.normalizeTLSConfigServerName()
 
 	if cfg.ServerPubKey != "" {
 		cfg.pubKey = getServerPubKey(cfg.ServerPubKey)
@@ -265,6 +261,16 @@ func (cfg *Config) normalize() error {
 	}
 
 	return nil
+}
+
+func (cfg *Config) normalizeTLSConfigServerName() {
+	if cfg.TLS != nil && cfg.TLS.ServerName == cfg.tlsServerName && !cfg.TLS.InsecureSkipVerify {
+		host, _, err := net.SplitHostPort(cfg.Addr)
+		if err == nil {
+			cfg.TLS.ServerName = host
+			cfg.tlsServerName = host
+		}
+	}
 }
 
 func writeDSNParam(buf *bytes.Buffer, hasParam *bool, name, value string) {

--- a/dsn.go
+++ b/dsn.go
@@ -80,11 +80,12 @@ type Config struct {
 	compress       bool // Enable zlib compression
 	tinyInt1IsBool bool // Treat signed TINYINT(1) as boolean
 
-	beforeConnect func(context.Context, *Config) error // Invoked before a connection is established
-	paramOrder    []string                             // Order of connection parameters parsed from the DSN
-	pubKey        *rsa.PublicKey                       // Server public key
-	timeTruncate  time.Duration                        // Truncate time.Time values to the specified duration
-	charsets      []string                             // Connection charset. When set, this will be set in SET NAMES <charset> query
+	beforeConnect     func(context.Context, *Config) error // Invoked before a connection is established
+	encodedAttributes string                               // Encoded connection attributes
+	paramOrder        []string                             // Order of connection parameters parsed from the DSN
+	pubKey            *rsa.PublicKey                       // Server public key
+	timeTruncate      time.Duration                        // Truncate time.Time values to the specified duration
+	charsets          []string                             // Connection charset. When set, this will be set in SET NAMES <charset> query
 }
 
 // Functional Options Pattern
@@ -263,6 +264,7 @@ func (cfg *Config) normalize() error {
 	if cfg.Logger == nil {
 		cfg.Logger = defaultLogger
 	}
+	cfg.encodedAttributes = encodeConnectionAttributes(cfg)
 
 	return nil
 }

--- a/dsn.go
+++ b/dsn.go
@@ -77,9 +77,8 @@ type Config struct {
 	// unexported fields. new options should be come here.
 	// boolean first. alphabetical order.
 
-	compress             bool // Enable zlib compression
-	tinyInt1IsBool       bool // Treat signed TINYINT(1) as boolean
-	tlsServerNameDerived bool // Whether TLS.ServerName was derived from Addr
+	compress       bool // Enable zlib compression
+	tinyInt1IsBool bool // Treat signed TINYINT(1) as boolean
 
 	beforeConnect     func(context.Context, *Config) error // Invoked before a connection is established
 	encodedAttributes string                               // Encoded connection attributes
@@ -248,11 +247,10 @@ func (cfg *Config) normalize() error {
 		}
 	}
 
-	if cfg.TLS != nil && (cfg.TLS.ServerName == "" || cfg.tlsServerNameDerived) && !cfg.TLS.InsecureSkipVerify {
+	if cfg.TLS != nil && cfg.TLS.ServerName == "" && !cfg.TLS.InsecureSkipVerify {
 		host, _, err := net.SplitHostPort(cfg.Addr)
 		if err == nil {
 			cfg.TLS.ServerName = host
-			cfg.tlsServerNameDerived = true
 		}
 	}
 

--- a/dsn.go
+++ b/dsn.go
@@ -84,7 +84,6 @@ type Config struct {
 	paramOrder    []string                             // Order of connection parameters parsed from the DSN
 	pubKey        *rsa.PublicKey                       // Server public key
 	timeTruncate  time.Duration                        // Truncate time.Time values to the specified duration
-	tlsServerName string                               // TLS server name automatically derived from Addr
 	charsets      []string                             // Connection charset. When set, this will be set in SET NAMES <charset> query
 }
 
@@ -247,7 +246,12 @@ func (cfg *Config) normalize() error {
 		}
 	}
 
-	cfg.normalizeTLSConfigServerName()
+	if cfg.TLS != nil && cfg.TLS.ServerName == "" && !cfg.TLS.InsecureSkipVerify {
+		host, _, err := net.SplitHostPort(cfg.Addr)
+		if err == nil {
+			cfg.TLS.ServerName = host
+		}
+	}
 
 	if cfg.ServerPubKey != "" {
 		cfg.pubKey = getServerPubKey(cfg.ServerPubKey)
@@ -261,16 +265,6 @@ func (cfg *Config) normalize() error {
 	}
 
 	return nil
-}
-
-func (cfg *Config) normalizeTLSConfigServerName() {
-	if cfg.TLS != nil && cfg.TLS.ServerName == cfg.tlsServerName && !cfg.TLS.InsecureSkipVerify {
-		host, _, err := net.SplitHostPort(cfg.Addr)
-		if err == nil {
-			cfg.TLS.ServerName = host
-			cfg.tlsServerName = host
-		}
-	}
 }
 
 func writeDSNParam(buf *bytes.Buffer, hasParam *bool, name, value string) {

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -241,6 +241,7 @@ func TestDSNParser(t *testing.T) {
 
 			// pointer not static
 			cfg.TLS = nil
+			cfg.tlsServerName = ""
 
 			if !reflect.DeepEqual(cfg, tst.out) {
 				t.Errorf("%d. ParseDSN(%q) mismatch:\ngot  %+v\nwant %+v", i, tst.in, cfg, tst.out)

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -33,6 +33,7 @@ func newTestConfig(update func(*Config)) *Config {
 	if update != nil {
 		update(cfg)
 	}
+	cfg.encodedAttributes = encodeConnectionAttributes(cfg)
 	return cfg
 }
 

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -242,7 +242,6 @@ func TestDSNParser(t *testing.T) {
 
 			// pointer not static
 			cfg.TLS = nil
-			cfg.tlsServerNameDerived = false
 
 			if !reflect.DeepEqual(cfg, tst.out) {
 				t.Errorf("%d. ParseDSN(%q) mismatch:\ngot  %+v\nwant %+v", i, tst.in, cfg, tst.out)

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -241,7 +241,6 @@ func TestDSNParser(t *testing.T) {
 
 			// pointer not static
 			cfg.TLS = nil
-			cfg.tlsServerName = ""
 
 			if !reflect.DeepEqual(cfg, tst.out) {
 				t.Errorf("%d. ParseDSN(%q) mismatch:\ngot  %+v\nwant %+v", i, tst.in, cfg, tst.out)

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -242,6 +242,7 @@ func TestDSNParser(t *testing.T) {
 
 			// pointer not static
 			cfg.TLS = nil
+			cfg.tlsServerNameDerived = false
 
 			if !reflect.DeepEqual(cfg, tst.out) {
 				t.Errorf("%d. ParseDSN(%q) mismatch:\ngot  %+v\nwant %+v", i, tst.in, cfg, tst.out)

--- a/packets.go
+++ b/packets.go
@@ -405,9 +405,9 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, plugin string
 
 	// Connection Attributes
 	if mc.capabilities&clientConnectAttrs != 0 {
-		connAttrsLen := len(mc.encodedAttributes)
+		connAttrsLen := len(mc.cfg.encodedAttributes)
 		data = appendLengthEncodedInteger(data, uint64(connAttrsLen))
-		data = append(data, mc.encodedAttributes...)
+		data = append(data, mc.cfg.encodedAttributes...)
 	}
 
 	// Send Auth packet

--- a/packets.go
+++ b/packets.go
@@ -277,7 +277,7 @@ func (mc *mysqlConn) readHandshakePacket() (data []byte, capabilities capability
 }
 
 // initCapabilities initializes the capabilities based on server support and configuration
-func (mc *mysqlConn) initCapabilities(serverCapabilities capabilityFlag, serverExtCapabilities extendedCapabilityFlag, cfg *Config) {
+func (mc *mysqlConn) initCapabilities(serverCapabilities capabilityFlag, serverExtCapabilities extendedCapabilityFlag) {
 	clientCapabilities :=
 		clientMySQL |
 			clientLongFlag |
@@ -291,10 +291,10 @@ func (mc *mysqlConn) initCapabilities(serverCapabilities capabilityFlag, serverE
 			clientConnectAttrs |
 			clientDeprecateEOF
 
-	if cfg.ClientFoundRows {
+	if mc.cfg.ClientFoundRows {
 		clientCapabilities |= clientFoundRows
 	}
-	if cfg.compress {
+	if mc.cfg.compress {
 		clientCapabilities |= clientCompress
 	}
 	// To enable TLS / SSL
@@ -305,7 +305,7 @@ func (mc *mysqlConn) initCapabilities(serverCapabilities capabilityFlag, serverE
 	if mc.cfg.MultiStatements {
 		clientCapabilities |= clientMultiStatements
 	}
-	if n := len(cfg.DBName); n > 0 {
+	if n := len(mc.cfg.DBName); n > 0 {
 		clientCapabilities |= clientConnectWithDB
 	}
 
@@ -405,9 +405,9 @@ func (mc *mysqlConn) writeHandshakeResponsePacket(authResp []byte, plugin string
 
 	// Connection Attributes
 	if mc.capabilities&clientConnectAttrs != 0 {
-		connAttrsLen := len(mc.connector.encodedAttributes)
+		connAttrsLen := len(mc.encodedAttributes)
 		data = appendLengthEncodedInteger(data, uint64(connAttrsLen))
-		data = append(data, mc.connector.encodedAttributes...)
+		data = append(data, mc.encodedAttributes...)
 	}
 
 	// Send Auth packet

--- a/packets_test.go
+++ b/packets_test.go
@@ -97,14 +97,16 @@ var _ net.Conn = new(mockConn)
 func newRWMockConn(sequence uint8) (*mockConn, *mysqlConn) {
 	conn := new(mockConn)
 	cfg := NewConfig()
+	if err := cfg.normalize(); err != nil {
+		panic(err)
+	}
 	mc := &mysqlConn{
-		buf:               newBuffer(),
-		cfg:               cfg,
-		encodedAttributes: encodeConnectionAttributes(cfg),
-		netConn:           conn,
-		closech:           make(chan struct{}),
-		maxAllowedPacket:  defaultMaxAllowedPacket,
-		sequence:          sequence,
+		buf:              newBuffer(),
+		cfg:              cfg,
+		netConn:          conn,
+		closech:          make(chan struct{}),
+		maxAllowedPacket: defaultMaxAllowedPacket,
+		sequence:         sequence,
 	}
 	return conn, mc
 }

--- a/packets_test.go
+++ b/packets_test.go
@@ -96,15 +96,15 @@ var _ net.Conn = new(mockConn)
 
 func newRWMockConn(sequence uint8) (*mockConn, *mysqlConn) {
 	conn := new(mockConn)
-	connector := newConnector(NewConfig())
+	cfg := NewConfig()
 	mc := &mysqlConn{
-		buf:              newBuffer(),
-		cfg:              connector.cfg,
-		connector:        connector,
-		netConn:          conn,
-		closech:          make(chan struct{}),
-		maxAllowedPacket: defaultMaxAllowedPacket,
-		sequence:         sequence,
+		buf:               newBuffer(),
+		cfg:               cfg,
+		encodedAttributes: encodeConnectionAttributes(cfg),
+		netConn:           conn,
+		closech:           make(chan struct{}),
+		maxAllowedPacket:  defaultMaxAllowedPacket,
+		sequence:          sequence,
 	}
 	return conn, mc
 }


### PR DESCRIPTION
### Description

This pull request refactors how connection configuration and attributes are managed during MySQL connection establishment, improving flexibility and correctness when using dynamic configuration (such as via `BeforeConnect` hooks). The most significant changes include removing the `connector` reference from `mysqlConn`, ensuring all connection state is sourced from the effective `Config`, and updating tests to verify these behaviors.

**Refactoring connection configuration management:**

* Removed the `connector` field from `mysqlConn` and all related references, ensuring all state (including encoded connection attributes) is accessed from the effective `Config` at connection time. (`connection.go`, `packets.go`, `connector.go`) [[1]](diffhunk://#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7L33) [[2]](diffhunk://#diff-c1caa8de39e277339469495d65efd1a363c54065c3cc02e7422b097774e56c86L23) [[3]](diffhunk://#diff-c1caa8de39e277339469495d65efd1a363c54065c3cc02e7422b097774e56c86L58-L61) [[4]](diffhunk://#diff-c1caa8de39e277339469495d65efd1a363c54065c3cc02e7422b097774e56c86L86-R98) [[5]](diffhunk://#diff-9bed832357da35a4ab5673550fc32e42836495137555712745d617e0b84d8989L408-R410)

* Moved `encodedAttributes` from `connector` to `Config`, and ensured it is regenerated in `Config.normalize()` to reflect any changes made by `BeforeConnect` hooks. (`dsn.go`, `connector.go`) [[1]](diffhunk://#diff-1279d9b7b79b9c75c7ca5bb6288d8014c79e581620047eb81b6638df16417dc1R82-R85) [[2]](diffhunk://#diff-1279d9b7b79b9c75c7ca5bb6288d8014c79e581620047eb81b6638df16417dc1R269) [[3]](diffhunk://#diff-9bed832357da35a4ab5673550fc32e42836495137555712745d617e0b84d8989L408-R410)

* Updated connection logic to always use the latest `Config` values (for timeouts, dialers, logging, etc.) after normalization and hooks are applied. (`connector.go`) [[1]](diffhunk://#diff-c1caa8de39e277339469495d65efd1a363c54065c3cc02e7422b097774e56c86R75-R77) [[2]](diffhunk://#diff-c1caa8de39e277339469495d65efd1a363c54065c3cc02e7422b097774e56c86L86-R98) [[3]](diffhunk://#diff-c1caa8de39e277339469495d65efd1a363c54065c3cc02e7422b097774e56c86L119-R118) [[4]](diffhunk://#diff-c1caa8de39e277339469495d65efd1a363c54065c3cc02e7422b097774e56c86L148-R155)

**TLS server name derivation improvements:**

* Improved logic for deriving the TLS `ServerName` from the address, and added a `tlsServerNameDerived` flag to track when this is done, ensuring hooks can override it as needed. (`dsn.go`) [[1]](diffhunk://#diff-1279d9b7b79b9c75c7ca5bb6288d8014c79e581620047eb81b6638df16417dc1R82-R85) [[2]](diffhunk://#diff-1279d9b7b79b9c75c7ca5bb6288d8014c79e581620047eb81b6638df16417dc1L249-R255)

**Test coverage for dynamic configuration:**

* Added comprehensive tests to verify that `BeforeConnect` hooks can update timeouts, TLS settings, dialers, and connection attributes, and that these updates are correctly reflected in the established connection. (`connector_test.go`, `dsn_test.go`, `packets_test.go`) [[1]](diffhunk://#diff-fe66e46f6afc8532975550b6cc295b2c46f2038535a2f2076baeba7806165146R34-R193) [[2]](diffhunk://#diff-f9da53d30bf57579c64f8ad7ad93f6b08608ff668d418cbc2198791bbbf855d7R36) [[3]](diffhunk://#diff-f9da53d30bf57579c64f8ad7ad93f6b08608ff668d418cbc2198791bbbf855d7R245) [[4]](diffhunk://#diff-0a910c2a04b00d07b6cfa3fed6c51bcd13bd751c554d1a8afc1ab7be04f5246dL99-R105)

**Other cleanups:**

* Refactored `mysqlConn.initCapabilities` to use its own `cfg` field, simplifying the method signature. (`packets.go`) [[1]](diffhunk://#diff-9bed832357da35a4ab5673550fc32e42836495137555712745d617e0b84d8989L280-R280) [[2]](diffhunk://#diff-9bed832357da35a4ab5673550fc32e42836495137555712745d617e0b84d8989L294-R297) [[3]](diffhunk://#diff-9bed832357da35a4ab5673550fc32e42836495137555712745d617e0b84d8989L308-R308)

These changes make the connector more robust, especially in dynamic or advanced use cases where connection parameters may be modified at runtime.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
